### PR TITLE
fix(PropTypes): remove deprecated calls to React.PropTypes

### DIFF
--- a/.storybook/ThemeContainer.js
+++ b/.storybook/ThemeContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ThemeSwitcher from './ThemeSwitcher';
 import AppContainer from '../components/AppContainer';
 import './_theme-container.scss';

--- a/.storybook/ThemeSwitcher.js
+++ b/.storybook/ThemeSwitcher.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import './_theme-switcher.scss';
 import Icon from '../components/Icon';
 

--- a/.storybook/components/CardStory.js
+++ b/.storybook/components/CardStory.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@kadira/storybook';
 import Card from '../../components/Card';
 import OverflowMenu from '../../components/OverflowMenu';
@@ -47,8 +48,8 @@ const virtualServerCardLinks = [
 
 class ControlledCard extends Component {
   static propTypes = {
-    status: React.PropTypes.number,
-    stopApp: React.PropTypes.func,
+    status: PropTypes.number,
+    stopApp: PropTypes.func,
   }
 
   static defaultProps = {

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -25,7 +25,7 @@ class Pagination extends Component {
     pageRangeText: PropTypes.func,
     pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
     totalItems: PropTypes.number.isRequired,
-    disabled: React.PropTypes.bool,
+    disabled: PropTypes.bool,
     page: PropTypes.number,
     pageSize: PropTypes.number,
   }

--- a/components/Tag.js
+++ b/components/Tag.js
@@ -19,7 +19,7 @@ const TYPES = {
 };
 
 const propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
   className: PropTypes.string,
   type: PropTypes.oneOf(Object.keys(TYPES)).isRequired,
 };

--- a/internal/ClickListener.js
+++ b/internal/ClickListener.js
@@ -1,6 +1,7 @@
 /* global document */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class ClickListener extends React.Component {
   static propTypes = {


### PR DESCRIPTION
I found a few calls to `React.PropTypes` hanging around; this fixes ’em.