### PR TITLE
feat(inline-select): add inline-select component

### DIFF
--- a/.storybook/components/SelectStory.js
+++ b/.storybook/components/SelectStory.js
@@ -5,13 +5,27 @@ import SelectItem from '../../components/SelectItem';
 import SelectItemGroup from '../../components/SelectItemGroup';
 
 const selectProps = {
-  onBlur: () => { action('blur'); }, // eslint-disable-line no-console
-  onClick: () => { action('click'); }, // eslint-disable-line no-console
-  onFocus: () => { action('focus'); }, // eslint-disable-line no-console
-  onMouseDown: () => { action('mouseDown'); }, // eslint-disable-line no-console
-  onMouseEnter: () => { action('mouseEnter'); }, // eslint-disable-line no-console
-  onMouseLeave: () => { action('mouseLeave'); }, // eslint-disable-line no-console
-  onMouseUp: () => { action('mouseUp'); }, // eslint-disable-line no-console
+  onBlur: () => {
+    action('blur');
+  }, // eslint-disable-line no-console
+  onClick: () => {
+    action('click');
+  }, // eslint-disable-line no-console
+  onFocus: () => {
+    action('focus');
+  }, // eslint-disable-line no-console
+  onMouseDown: () => {
+    action('mouseDown');
+  }, // eslint-disable-line no-console
+  onMouseEnter: () => {
+    action('mouseEnter');
+  }, // eslint-disable-line no-console
+  onMouseLeave: () => {
+    action('mouseLeave');
+  }, // eslint-disable-line no-console
+  onMouseUp: () => {
+    action('mouseUp');
+  }, // eslint-disable-line no-console
   className: 'some-class',
 };
 
@@ -24,7 +38,7 @@ storiesOf('Select', module)
       dissapear and the field will reflect the user's choice. Create Select Item components for each
       option in the list. The example below shows an enabled Select component with three items.
     `,
-    () => (
+    () =>
       <Select
         {...selectProps}
         onChange={action('onChange')} // eslint-disable-line no-console
@@ -40,7 +54,30 @@ storiesOf('Select', module)
           <SelectItem value="option-3" text="Option 3" />
         </SelectItemGroup>
       </Select>
-  ))
+  )
+  .addWithInfo(
+    'inline',
+    `
+      Inline select is for use when there will be multiple elements in a row
+    `,
+    () =>
+      <Select
+        {...selectProps}
+        inline
+        onChange={action('onChange')} // eslint-disable-line no-console
+        id="select-1"
+        defaultValue="placeholder-item"
+      >
+        <SelectItem disabled hidden value="placeholder-item" text="Pick an option" />
+        <SelectItemGroup label="Starter">
+          <SelectItem value="option-1" text="Option 1" />
+          <SelectItem value="option-2" text="Option 2" />
+        </SelectItemGroup>
+        <SelectItemGroup label="Advanced">
+          <SelectItem value="option-3" text="Option 3" />
+        </SelectItemGroup>
+      </Select>
+  )
   .addWithInfo(
     'disabled',
     `
@@ -49,14 +86,14 @@ storiesOf('Select', module)
       dissapear and the field will reflect the user's choice. Create SelectItem components for each
       option in the list. The example below shows an disabled Select component.
     `,
-    () => (
-      <Select disabled {...selectProps} id="select-2" >
+    () =>
+      <Select disabled {...selectProps} id="select-2">
         <SelectItem disabled hidden value="placeholder-item" text="Pick an option" />
         <SelectItem value="option-1" text="Option 1" />
         <SelectItem value="option-2" text="Option 2" />
         <SelectItem value="option-3" text="Option 3" />
       </Select>
-  ))
+  )
   .addWithInfo(
     'no label',
     `
@@ -65,7 +102,7 @@ storiesOf('Select', module)
       dissapear and the field will reflect the user's choice. Create SelectItem components for each
       option in the list. The example below shows a Select component without a label.
     `,
-    () => (
+    () =>
       <Select
         {...selectProps}
         onChange={action('onChange')} // eslint-disable-line no-console
@@ -82,4 +119,4 @@ storiesOf('Select', module)
           <SelectItem value="option-3" text="Option 3" />
         </SelectItemGroup>
       </Select>
-  ));
+  );

--- a/.storybook/components/SelectStory.js
+++ b/.storybook/components/SelectStory.js
@@ -5,27 +5,7 @@ import SelectItem from '../../components/SelectItem';
 import SelectItemGroup from '../../components/SelectItemGroup';
 
 const selectProps = {
-  onBlur: () => {
-    action('blur');
-  }, // eslint-disable-line no-console
-  onClick: () => {
-    action('click');
-  }, // eslint-disable-line no-console
-  onFocus: () => {
-    action('focus');
-  }, // eslint-disable-line no-console
-  onMouseDown: () => {
-    action('mouseDown');
-  }, // eslint-disable-line no-console
-  onMouseEnter: () => {
-    action('mouseEnter');
-  }, // eslint-disable-line no-console
-  onMouseLeave: () => {
-    action('mouseLeave');
-  }, // eslint-disable-line no-console
-  onMouseUp: () => {
-    action('mouseUp');
-  }, // eslint-disable-line no-console
+  onChange: action('onChange'),
   className: 'some-class',
 };
 
@@ -39,12 +19,7 @@ storiesOf('Select', module)
       option in the list. The example below shows an enabled Select component with three items.
     `,
     () =>
-      <Select
-        {...selectProps}
-        onChange={action('onChange')} // eslint-disable-line no-console
-        id="select-1"
-        defaultValue="placeholder-item"
-      >
+      <Select {...selectProps} id="select-1" defaultValue="placeholder-item">
         <SelectItem disabled hidden value="placeholder-item" text="Pick an option" />
         <SelectItemGroup label="Starter">
           <SelectItem value="option-1" text="Option 1" />
@@ -61,13 +36,7 @@ storiesOf('Select', module)
       Inline select is for use when there will be multiple elements in a row
     `,
     () =>
-      <Select
-        {...selectProps}
-        inline
-        onChange={action('onChange')} // eslint-disable-line no-console
-        id="select-1"
-        defaultValue="placeholder-item"
-      >
+      <Select {...selectProps} inline id="select-1" defaultValue="placeholder-item">
         <SelectItem disabled hidden value="placeholder-item" text="Pick an option" />
         <SelectItemGroup label="Starter">
           <SelectItem value="option-1" text="Option 1" />
@@ -103,13 +72,7 @@ storiesOf('Select', module)
       option in the list. The example below shows a Select component without a label.
     `,
     () =>
-      <Select
-        {...selectProps}
-        onChange={action('onChange')} // eslint-disable-line no-console
-        id="select-3"
-        defaultValue="placeholder-item"
-        hideLabel
-      >
+      <Select {...selectProps} id="select-3" defaultValue="placeholder-item" hideLabel>
         <SelectItem disabled hidden value="placeholder-item" text="Pick an option" />
         <SelectItemGroup label="Starter">
           <SelectItem value="option-1" text="Option 1" />

--- a/components/Select.js
+++ b/components/Select.js
@@ -7,6 +7,7 @@ const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inline: PropTypes.bool,
   labelText: PropTypes.string,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
@@ -18,12 +19,14 @@ const propTypes = {
 const defaultProps = {
   disabled: false,
   labelText: 'Select',
+  inline: false,
   iconDescription: 'open list of options',
 };
 
 const Select = ({
   className,
   id,
+  inline,
   labelText,
   disabled,
   children,
@@ -33,6 +36,7 @@ const Select = ({
 }) => {
   const selectClasses = classNames({
     'bx--select': true,
+    'bx--select--inline': inline,
     [className]: className,
   });
   const labelClasses = classNames('bx--label', {
@@ -40,21 +44,13 @@ const Select = ({
   });
   return (
     <div className="bx--form-item">
-      <label htmlFor={id} className={labelClasses}>{labelText}</label>
+      {!inline ? <label htmlFor={id} className={labelClasses}>{labelText}</label> : null}
       <div className={selectClasses}>
-        <select
-          {...other}
-          id={id}
-          className="bx--select-input"
-          disabled={disabled}
-        >
+        {inline ? <label htmlFor={id} className={labelClasses}>{labelText}</label> : null}
+        <select {...other} id={id} className="bx--select-input" disabled={disabled}>
           {children}
         </select>
-        <Icon
-          name="caret--down"
-          className="bx--select__arrow"
-          description={iconDescription}
-        />
+        <Icon name="caret--down" className="bx--select__arrow" description={iconDescription} />
       </div>
     </div>
   );

--- a/components/__tests__/Select-test.js
+++ b/components/__tests__/Select-test.js
@@ -49,7 +49,8 @@ describe('Select', () => {
       });
 
       it('should have iconDescription match Icon component description prop', () => {
-        const matches = wrapper.props().iconDescription === wrapper.find(Icon).props().description;
+        const matches =
+          wrapper.props().iconDescription === wrapper.find(Icon).props().description;
         expect(matches).toEqual(true);
       });
     });
@@ -99,6 +100,20 @@ describe('Select', () => {
       it('renders children as expected', () => {
         expect(label.props().children).toEqual('Select');
       });
+    });
+  });
+  describe('Renders as expected', () => {
+    const wrapper = mount(
+      <Select id="testing" labelText="Select" className="extra-class" inline>
+        <SelectItem />
+        <SelectItem />
+      </Select>
+    );
+
+    const selectContainer = wrapper.find('.bx--form-item > div');
+
+    it('has the expected classes', () => {
+      expect(selectContainer.hasClass('bx--select--inline')).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Inline-select

### Added
- `inline-select`

### Changed
- `inline-select` has the label adjacent to the select. Normal select has it outside of the `select` container. Added a check to place the label in the correct spot
- Added tests for `inline-select`