### PR TITLE
fix(InteriorLeftNavItem): revert back to accepting single children

### DIFF
--- a/.storybook/components/InteriorLeftNavStory.js
+++ b/.storybook/components/InteriorLeftNavStory.js
@@ -15,37 +15,30 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
     <InteriorLeftNav>
       <InteriorLeftNavList title="Example Item 1">
         <InteriorLeftNavItem href="#example-item-1A">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1B">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1C">
-          <a href="#">Link</a>
-        </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-1D">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavList title="Example Item 2">
         <InteriorLeftNavItem href="#example-item-2A">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2B">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2C">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2D">
-          <a href="#">Link</a>
+          <a href="#">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
-      <InteriorLeftNavItem href="#example-item-3">
-        <a href="#">Link</a>
-      </InteriorLeftNavItem>
-      <InteriorLeftNavItem href="#example-item-4">
-        <a href="#">Link</a>
-      </InteriorLeftNavItem>
+      <InteriorLeftNavItem href="#example-item-3" label="Link Label" />
+      <InteriorLeftNavItem href="#example-item-4" label="Link Label" />
     </InteriorLeftNav>
 );

--- a/.storybook/components/InteriorLeftNavStory.js
+++ b/.storybook/components/InteriorLeftNavStory.js
@@ -11,22 +11,41 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
       context to support user orientation. This pattern accommodates the
       breadth of content and tasks users expect to see.
     `,
-  () => (
+  () =>
     <InteriorLeftNav>
       <InteriorLeftNavList title="Example Item 1">
-        <InteriorLeftNavItem href="#example-item-1A" label="Example Item 1A" />
-        <InteriorLeftNavItem href="#example-item-1B" label="Example Item 1B" />
-        <InteriorLeftNavItem href="#example-item-1C" label="Example Item 1C" />
-        <InteriorLeftNavItem href="#example-item-1D" label="Example Item 1D" />
+        <InteriorLeftNavItem href="#example-item-1A">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-1B">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-1C">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-1D">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavList title="Example Item 2">
-        <InteriorLeftNavItem href="#example-item-2A" label="Example Item 2A" />
-        <InteriorLeftNavItem href="#example-item-2B" label="Example Item 2B" />
-        <InteriorLeftNavItem href="#example-item-2C" label="Example Item 2C" />
-        <InteriorLeftNavItem href="#example-item-2D" label="Example Item 2D" />
+        <InteriorLeftNavItem href="#example-item-2A">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-2B">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-2C">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem href="#example-item-2D">
+          <a href="#">Link</a>
+        </InteriorLeftNavItem>
       </InteriorLeftNavList>
-      <InteriorLeftNavItem href="#example-item-3" label="Example Item 3" />
-      <InteriorLeftNavItem href="#example-item-4" label="Example Item 4" />
+      <InteriorLeftNavItem href="#example-item-3">
+        <a href="#">Link</a>
+      </InteriorLeftNavItem>
+      <InteriorLeftNavItem href="#example-item-4">
+        <a href="#">Link</a>
+      </InteriorLeftNavItem>
     </InteriorLeftNav>
-  )
 );

--- a/components/InteriorLeftNavItem.js
+++ b/components/InteriorLeftNavItem.js
@@ -10,12 +10,22 @@ const propTypes = {
   onClick: PropTypes.func,
   blankTarget: PropTypes.bool,
   children: PropTypes.node,
+  label: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   activeHref: '#',
   tabIndex: 0,
+  label: 'InteriorLeftNavItem Label',
   onClick: /* istanbul ignore next */ () => {},
+};
+
+const newChild = (children, tabIndex) => {
+  const child = React.Children.only(children);
+  return React.cloneElement(React.Children.only(child), {
+    tabIndex,
+    className: 'left-nav-list__item-link',
+  });
 };
 
 const InteriorLeftNavItem = ({
@@ -25,16 +35,11 @@ const InteriorLeftNavItem = ({
   onClick,
   tabIndex,
   children,
+  label,
   ...other
 }) => {
   const classNames = classnames('left-nav-list__item', className, {
     'left-nav-list__item--active': activeHref === href,
-  });
-
-  const child = React.Children.only(children);
-  const newChild = React.cloneElement(child, {
-    tabIndex,
-    className: 'left-nav-list__item-link',
   });
 
   return (
@@ -46,7 +51,11 @@ const InteriorLeftNavItem = ({
       onKeyPress={evt => onClick(evt, href)}
       {...other}
     >
-      {newChild}
+      {children
+        ? newChild(children, tabIndex)
+        : <a className="left-nav-list__item-link" href={href} tabIndex={tabIndex}>
+            {label}
+          </a>}
     </li>
   );
 };

--- a/components/InteriorLeftNavItem.js
+++ b/components/InteriorLeftNavItem.js
@@ -8,8 +8,8 @@ const propTypes = {
   activeHref: PropTypes.string,
   tabIndex: PropTypes.number,
   onClick: PropTypes.func,
-  label: PropTypes.string.isRequired,
   blankTarget: PropTypes.bool,
+  children: PropTypes.node,
 };
 
 const defaultProps = {
@@ -24,11 +24,17 @@ const InteriorLeftNavItem = ({
   activeHref,
   onClick,
   tabIndex,
-  label,
+  children,
   ...other
 }) => {
   const classNames = classnames('left-nav-list__item', className, {
     'left-nav-list__item--active': activeHref === href,
+  });
+
+  const child = React.Children.only(children);
+  const newChild = React.cloneElement(child, {
+    tabIndex,
+    className: 'left-nav-list__item-link',
   });
 
   return (
@@ -40,9 +46,7 @@ const InteriorLeftNavItem = ({
       onKeyPress={evt => onClick(evt, href)}
       {...other}
     >
-      <a className="left-nav-list__item-link" href={href} tabIndex={tabIndex}>
-        {label}
-      </a>
+      {newChild}
     </li>
   );
 };

--- a/components/__tests__/InteriorLeftNavItem-test.js
+++ b/components/__tests__/InteriorLeftNavItem-test.js
@@ -5,18 +5,14 @@ import { shallow, mount } from 'enzyme';
 describe('InteriorLeftNavItem', () => {
   describe('Renders as expected', () => {
     const wrapper = mount(
-      <InteriorLeftNavItem
-        className="extra-class"
-        href="test-href"
-        label="test-label"
-      />
+      <InteriorLeftNavItem className="extra-class" href="test-href">
+        <a href="test-href">link</a>
+      </InteriorLeftNavItem>
     );
     const matchingHrefs = mount(
-      <InteriorLeftNavItem
-        href="www.google.com"
-        activeHref="www.google.com"
-        label="test-label"
-      />
+      <InteriorLeftNavItem href="www.google.com" activeHref="www.google.com">
+        <a href="www.google.com">link</a>
+      </InteriorLeftNavItem>
     );
 
     it('renders a interior left nav item', () => {
@@ -28,21 +24,17 @@ describe('InteriorLeftNavItem', () => {
     it('should add extra classes that are passed via className', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
-    it('should contain a label', () => {
+    xit('should contain a label', () => {
       expect(wrapper.find('a').text()).toEqual(wrapper.props().label);
     });
     it('should contain an href', () => {
       expect(wrapper.find('a').props().href).toEqual(wrapper.props().href);
     });
     it('should add active class to item when activeHref is matched', () => {
-      expect(matchingHrefs.hasClass('left-nav-list__item--active')).toEqual(
-        true
-      );
+      expect(matchingHrefs.hasClass('left-nav-list__item--active')).toEqual(true);
     });
     it('has an anchor with the expected class', () => {
-      expect(wrapper.find('a').hasClass('left-nav-list__item-link')).toEqual(
-        true
-      );
+      expect(wrapper.find('a').hasClass('left-nav-list__item-link')).toEqual(true);
     });
   });
 

--- a/components/__tests__/InteriorLeftNavItem-test.js
+++ b/components/__tests__/InteriorLeftNavItem-test.js
@@ -5,14 +5,12 @@ import { shallow, mount } from 'enzyme';
 describe('InteriorLeftNavItem', () => {
   describe('Renders as expected', () => {
     const wrapper = mount(
-      <InteriorLeftNavItem className="extra-class" href="test-href">
+      <InteriorLeftNavItem className="extra-class" href="test-href" activeHref="test-href">
         <a href="test-href">link</a>
       </InteriorLeftNavItem>
     );
-    const matchingHrefs = mount(
-      <InteriorLeftNavItem href="www.google.com" activeHref="www.google.com">
-        <a href="www.google.com">link</a>
-      </InteriorLeftNavItem>
+    const wrapperNoChild = mount(
+      <InteriorLeftNavItem className="extra-class" href="test-href" activeHref="test-href" />
     );
 
     it('renders a interior left nav item', () => {
@@ -31,10 +29,16 @@ describe('InteriorLeftNavItem', () => {
       expect(wrapper.find('a').props().href).toEqual(wrapper.props().href);
     });
     it('should add active class to item when activeHref is matched', () => {
-      expect(matchingHrefs.hasClass('left-nav-list__item--active')).toEqual(true);
+      expect(wrapper.hasClass('left-nav-list__item--active')).toEqual(true);
     });
     it('has an anchor with the expected class', () => {
       expect(wrapper.find('a').hasClass('left-nav-list__item-link')).toEqual(true);
+    });
+    it('can render without a child ', () => {
+      expect(wrapperNoChild.length).toEqual(1);
+    });
+    it('has an anchor that matches label when no child is given', () => {
+      expect(wrapperNoChild.find('a').text()).toEqual(wrapperNoChild.props().label);
     });
   });
 

--- a/components/__tests__/InteriorLeftNavItem-test.js
+++ b/components/__tests__/InteriorLeftNavItem-test.js
@@ -24,8 +24,8 @@ describe('InteriorLeftNavItem', () => {
     it('should add extra classes that are passed via className', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
-    xit('should contain a label', () => {
-      expect(wrapper.find('a').text()).toEqual(wrapper.props().label);
+    it('should contain a default label', () => {
+      expect(wrapper.find('a').text()).toEqual('link');
     });
     it('should contain an href', () => {
       expect(wrapper.find('a').props().href).toEqual(wrapper.props().href);


### PR DESCRIPTION
Issue raised in Slack:

![image](https://user-images.githubusercontent.com/4185382/27043150-cf51674a-4f5e-11e7-81b0-827e59cb6fbc.png)
![image](https://user-images.githubusercontent.com/4185382/27043162-d5249dcc-4f5e-11e7-8dcf-e9de3d396fcc.png)

This PR goes back to [the previous way this component accepted single children nodes](https://github.com/carbon-design-system/carbon-components-react/blob/7e195d77fe79109a86ef2d61f1c4ab08bb9de5a6/components/InteriorLeftNavItem.js#L46).