### PR TITLE
fix: use propTypes from module instead of React

### DIFF
--- a/.storybook/components/CardStory.js
+++ b/.storybook/components/CardStory.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import Card from '../../components/Card';
 import OverflowMenu from '../../components/OverflowMenu';
@@ -30,8 +31,8 @@ const overflowMenuItemProps = {
 
 class ControlledCard extends Component {
   static propTypes = {
-    status: React.PropTypes.number,
-    simple: React.PropTypes.bool,
+    status: PropTypes.number,
+    simple: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/components/ToolbarSearch.js
+++ b/components/ToolbarSearch.js
@@ -1,17 +1,18 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from './Icon';
 import ClickListener from '../internal/ClickListener';
 
-class ToolbarSearch extends React.Component {
+class ToolbarSearch extends Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    type: React.PropTypes.string,
-    small: React.PropTypes.bool,
-    placeHolderText: React.PropTypes.string,
-    labelText: React.PropTypes.string,
-    id: React.PropTypes.string,
+    children: PropTypes.node,
+    className: PropTypes.string,
+    type: PropTypes.string,
+    small: PropTypes.bool,
+    placeHolderText: PropTypes.string,
+    labelText: PropTypes.string,
+    id: PropTypes.string,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Use the PropTypes modules instead of using the deprecated
React.PropTypes method