### PR TITLE
fix(propTypes): fix more deprecated Proptype usage

### DIFF
--- a/components/Toolbar.js
+++ b/components/Toolbar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ToolbarSearch from './ToolbarSearch';
 import classNames from 'classnames';
 

--- a/components/Tooltip.js
+++ b/components/Tooltip.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Icon from './Icon';
 import classNames from 'classnames';
 import FloatingMenu from '../internal/FloatingMenu';

--- a/components/TooltipSimple.js
+++ b/components/TooltipSimple.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from './Icon';
 import classNames from 'classnames';
 


### PR DESCRIPTION
Few more places PropTypes were being used from React instead of their
own module