### PR TITLE
test: add a basic test for index exports

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,0 +1,7 @@
+import * as Carbon from '../index';
+
+describe('Carbon Components React', () => {
+  it('can be imported using the correct path', () => {
+    expect(typeof Carbon).toBe('object')
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "check": "npm run lint && npm run test",
     "lint": "eslint {components,internal}/**",
-    "test": "jest '/(components|lib|internal)/'",
-    "test-watch": "jest '/(components|lib|internal)/' --watch",
+    "test": "jest '/(__tests__|components|lib|internal)/'",
+    "test-watch": "jest '/(__tests__|components|lib|internal)/' --watch",
     "prepublish": "npm run build",
     "build": "node scripts/build.js",
     "commitmsg": "validate-commit-msg",


### PR DESCRIPTION
An incorrect path in the index.js file would cause the library to fail
to import. This does a basic sanity check for that