### PR TITLE
perf(floating-menu): reduce forced synchronous layout

### DIFF
--- a/components/OverflowMenu.js
+++ b/components/OverflowMenu.js
@@ -45,7 +45,9 @@ class OverflowMenu extends Component {
   };
 
   componentDidMount() {
-    this.getMenuPosition();
+    requestAnimationFrame(() => {
+      this.getMenuPosition();
+    });
     this.hResize = OptimizedResize.add(() => {
       this.getMenuPosition();
     });

--- a/components/Tooltip.js
+++ b/components/Tooltip.js
@@ -29,7 +29,9 @@ class Tooltip extends Component {
   };
 
   componentDidMount() {
-    this.getTriggerPosition();
+    requestAnimationFrame(() => {
+      this.getTriggerPosition();
+    });
   }
 
   getTriggerPosition = () => {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,10 @@
     "coverageDirectory": "./coverage",
     "moduleNameMapper": {
       "^.+\\.(scss)$": "<rootDir>/lib/styleMock.js"
-    }
+    },
+    "setupFiles": [
+      "<rootDir>/setup-jest.js"
+    ]
   },
   "lint-staged": {
     "*.js": [

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,0 +1,1 @@
+window.requestAnimationFrame = (callback) => { callback(); };


### PR DESCRIPTION
Several components launching floating menu have [forced synchronous layout](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing#avoid_forced_synchronous_layouts), as shown below (notice purple bar as part of JavaScript stack, which should *not* happen). This PR attempts to fix such problem, allowing browser to layout in batch.

![get-menu-position](https://user-images.githubusercontent.com/1259051/27852313-a5a1c096-6199-11e7-9de1-d89c13724d1d.png)