### PR TITLE
fix(toolbar): fix import path in storybook

### DIFF
--- a/.storybook/components/ToolbarStory.js
+++ b/.storybook/components/ToolbarStory.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf, action } from '@storybook/react';
-import {
-  Toolbar,
+import Toolbar, {
   ToolbarItem,
   ToolbarTitle,
   ToolbarOption,
@@ -26,7 +25,7 @@ storiesOf('Toolbar', module).addWithInfo(
   `
     Toolbar stuff
   `,
-  () => (
+  () =>
     <Toolbar {...toolbarProps} className="some-class">
       <ToolbarItem type="search" placeHolderText="Search" />
       <ToolbarItem>
@@ -79,5 +78,4 @@ storiesOf('Toolbar', module).addWithInfo(
         </OverflowMenu>
       </ToolbarItem>
     </Toolbar>
-  )
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,7 +1410,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.6.0:
+bowser@^1.6.0, bowser@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.0.tgz#169de4018711f994242bff9a8009e77a1f35e003"
 
@@ -3542,13 +3542,9 @@ hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Toolbar was throwing an error when running storybook (due to new export syntax), this fixes that.