### PR TITLE
fix(search): toggle the clear icon correctly and enable use on controlled components

### DIFF
--- a/.storybook/components/SearchStory.js
+++ b/.storybook/components/SearchStory.js
@@ -16,11 +16,11 @@ storiesOf('Search', module)
     `,
     () =>
       <Search
+        key="normal"
         {...searchProps}
         className="some-class"
         id="search-1"
         labelText="Search"
-        defaultValue={'something'}
         placeHolderText="Search Bluemix Offerings"
       />
   )
@@ -34,6 +34,7 @@ storiesOf('Search', module)
     `,
     () =>
       <Search
+        key="small"
         {...searchProps}
         className="some-class"
         small
@@ -41,4 +42,39 @@ storiesOf('Search', module)
         labelText="Search"
         placeHolderText="Search Bluemix Offerings"
       />
+  )
+  .addWithInfo(
+    'Controlled',
+    `
+      You can control the Search input like you would with a normal input as well. See the Storybook source to see the source code behind this at https://github.com/carbon-design-system/carbon-components-react/blob/master/.storybook/components/SearchStory.js
+    `,
+    () => {
+      class ControlledSearch extends React.Component {
+        state = {
+          searchValue: 'something',
+        };
+
+        handleChange = evt => {
+          this.setState({
+            searchValue: evt.target.value,
+          });
+        };
+
+        render() {
+          return (
+            <Search
+              {...searchProps}
+              className="some-class"
+              id="search-1"
+              labelText="Search"
+              value={this.state.searchValue}
+              onChange={this.handleChange}
+              placeHolderText="Search Bluemix Offerings"
+            />
+          );
+        }
+      }
+
+      return <ControlledSearch />;
+    }
   );

--- a/.storybook/components/SearchStory.js
+++ b/.storybook/components/SearchStory.js
@@ -16,7 +16,6 @@ storiesOf('Search', module)
     `,
     () =>
       <Search
-        key="normal"
         {...searchProps}
         className="some-class"
         id="search-1"
@@ -34,7 +33,6 @@ storiesOf('Search', module)
     `,
     () =>
       <Search
-        key="small"
         {...searchProps}
         className="some-class"
         small

--- a/.storybook/components/SearchStory.js
+++ b/.storybook/components/SearchStory.js
@@ -14,15 +14,16 @@ storiesOf('Search', module)
       without the use of navigation. Search can be used as the primary means of discovering content,
       or as a filter to aid the user in finding content.
     `,
-    () => (
+    () =>
       <Search
         {...searchProps}
         className="some-class"
         id="search-1"
         labelText="Search"
+        defaultValue={'something'}
         placeHolderText="Search Bluemix Offerings"
       />
-  ))
+  )
   .addWithInfo(
     'small',
     `
@@ -31,7 +32,7 @@ storiesOf('Search', module)
       or as a filter to aid the user in finding content. With the small property, the search field will be
       more compact.
     `,
-    () => (
+    () =>
       <Search
         {...searchProps}
         className="some-class"
@@ -40,4 +41,4 @@ storiesOf('Search', module)
         labelText="Search"
         placeHolderText="Search Bluemix Offerings"
       />
-  ));
+  );

--- a/.storybook/components/SearchStory.js
+++ b/.storybook/components/SearchStory.js
@@ -51,7 +51,7 @@ storiesOf('Search', module)
     () => {
       class ControlledSearch extends React.Component {
         state = {
-          searchValue: 'something',
+          searchValue: '',
         };
 
         handleChange = evt => {

--- a/components/Search.js
+++ b/components/Search.js
@@ -59,19 +59,16 @@ class Search extends Component {
   };
 
   handleChange = evt => {
-    if (evt.target.value !== '') {
-      this.setState({
-        hasContent: true,
-      });
-    } else {
-      this.setState({
-        hasContent: false,
-      });
-    }
-
-    if (this.props.onChange) {
-      this.props.onChange(evt);
-    }
+    this.setState(
+      {
+        hasContent: evt.target.value !== '',
+      },
+      () => {
+        if (this.props.onChange) {
+          this.props.onChange(evt);
+        }
+      }
+    );
   };
 
   // eslint-disable-next-line consistent-return

--- a/components/Search.js
+++ b/components/Search.js
@@ -28,8 +28,22 @@ class Search extends Component {
   };
 
   clearInput = () => {
-    this.input.value = '';
-    this.input.focus();
+    if (this.props.value) {
+      this.props.onChange({
+        target: {
+          value: '',
+        },
+      });
+    } else {
+      this.input.value = '';
+    }
+
+    this.setState(
+      {
+        hasContent: false,
+      },
+      () => this.input.focus()
+    );
   };
 
   toggleLayout = () => {
@@ -56,7 +70,7 @@ class Search extends Component {
     }
 
     if (this.props.onChange) {
-      this.props.onChange();
+      this.props.onChange(evt);
     }
   };
 

--- a/components/Search.js
+++ b/components/Search.js
@@ -24,10 +24,7 @@ class Search extends Component {
 
   state = {
     format: 'list',
-  };
-
-  toggleClearIcon = evt => {
-    this.input.value = evt.target.value;
+    hasContent: this.props.value || this.props.defaultValue || false,
   };
 
   clearInput = () => {
@@ -44,6 +41,22 @@ class Search extends Component {
       this.setState({
         format: 'list',
       });
+    }
+  };
+
+  handleChange = evt => {
+    if (evt.target.value !== '') {
+      this.setState({
+        hasContent: true,
+      });
+    } else {
+      this.setState({
+        hasContent: false,
+      });
+    }
+
+    if (this.props.onChange) {
+      this.props.onChange();
     }
   };
 
@@ -107,6 +120,8 @@ class Search extends Component {
       ...other
     } = this.props;
 
+    const { hasContent } = this.state;
+
     const searchClasses = classNames({
       'bx--search bx--search-with-options': true,
       'bx--search--lg': !small,
@@ -114,11 +129,9 @@ class Search extends Component {
       [className]: className,
     });
 
-    const hasContent = Boolean(this.input) && Boolean(this.input.value);
-
     const clearClasses = classNames({
       'bx--search-close': true,
-      'bx--search-close--hidden': hasContent,
+      'bx--search-close--hidden': !hasContent,
     });
 
     return (
@@ -128,14 +141,16 @@ class Search extends Component {
           description="search"
           className="bx--search-magnifier"
         />
-        <label htmlFor={id} className="bx--label">{labelText}</label>
+        <label htmlFor={id} className="bx--label">
+          {labelText}
+        </label>
         <input
           {...other}
           type={type}
           className="bx--search-input"
           id={id}
           placeholder={placeHolderText}
-          onInput={this.toggleClearIcon}
+          onChange={this.handleChange}
           ref={input => {
             this.input = input;
           }}

--- a/components/Search.js
+++ b/components/Search.js
@@ -20,6 +20,7 @@ class Search extends Component {
     type: 'text',
     small: false,
     placeHolderText: '',
+    onChange: () => {},
   };
 
   state = {
@@ -63,9 +64,7 @@ class Search extends Component {
       hasContent: evt.target.value !== '',
     });
 
-    if (this.props.onChange) {
-      this.props.onChange(evt);
-    }
+    this.props.onChange(evt);
   };
 
   // eslint-disable-next-line consistent-return

--- a/components/Search.js
+++ b/components/Search.js
@@ -59,16 +59,13 @@ class Search extends Component {
   };
 
   handleChange = evt => {
-    this.setState(
-      {
-        hasContent: evt.target.value !== '',
-      },
-      () => {
-        if (this.props.onChange) {
-          this.props.onChange(evt);
-        }
-      }
-    );
+    this.setState({
+      hasContent: evt.target.value !== '',
+    });
+
+    if (this.props.onChange) {
+      this.props.onChange(evt);
+    }
   };
 
   // eslint-disable-next-line consistent-return


### PR DESCRIPTION
Couple of bugs with the search

1) The clear icon was showing all the time, instead of only with content
2) The clear icon did not work when controlling the value of Search

This resolves both of those issues