### PR TITLE
fix(overflow): use React.Children.toArray to discard null values

### DIFF
--- a/components/OverflowMenu.js
+++ b/components/OverflowMenu.js
@@ -124,7 +124,7 @@ class OverflowMenu extends Component {
       iconClass
     );
 
-    const childrenWithProps = React.Children.map(children, child =>
+    const childrenWithProps = React.Children.toArray(children).map(child =>
       React.cloneElement(child, {
         closeMenu: this.closeMenu,
       })


### PR DESCRIPTION
React.Children.map errors out on conditional children - use React.Children.toArray to make sure to filter out any null values before mapping over the Array