### PR TITLE
fix(DetailPageHeader): Correctly remove scroll event listener

### DIFF
--- a/components/DetailPageHeader.js
+++ b/components/DetailPageHeader.js
@@ -30,8 +30,8 @@ class DetailPageHeader extends Component {
   };
 
   componentDidMount() {
-    const debouncedScroll = debounce(this.handleScroll, 25);
-    window.addEventListener('scroll', debouncedScroll);
+    this._debouncedScroll = debounce(this.handleScroll, 25);
+    window.addEventListener('scroll', this._debouncedScroll);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -45,7 +45,7 @@ class DetailPageHeader extends Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', this.handleScroll);
+    window.removeEventListener('scroll', this._debouncedScroll);
   }
 
   handleScroll = () => {

--- a/components/__tests__/DetailPageHeader-test.js
+++ b/components/__tests__/DetailPageHeader-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import window from 'window-or-global';
 import DetailPageHeader from '../DetailPageHeader';
 import Icon from '../Icon';
 import Breadcrumb from '../Breadcrumb';
@@ -128,4 +129,32 @@ describe('DetailPageHeader', () => {
       expect(tabs).toEqual(true);
     });
   });
+
+  describe('scroll event listener', () => {
+    let addEvent;
+    let removeEvent;
+
+    beforeEach(() => {
+      addEvent = jest.spyOn(window, 'addEventListener').mockImplementation(() => null);
+      removeEvent = jest.spyOn(window, 'removeEventListener').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      addEvent.mockRestore();
+      removeEvent.mockRestore();
+    });
+
+    it('should pass in the same method when adding and removing the scroll event listener', () => {
+      const wrapper = mount(<DetailPageHeader title="test"/>);
+      wrapper.unmount();
+      expect(addEvent.mock.calls.length).toBe(1);
+      expect(removeEvent.mock.calls.length).toBe(1);
+      const addArgs = addEvent.mock.calls[0];
+      const removeArgs = removeEvent.mock.calls[0];
+      expect(addArgs[0]).toBe("scroll");
+      expect(removeArgs[0]).toBe("scroll");
+      expect(addArgs[1]).toBe(removeArgs[1]); // the scroll handler function
+    });
+  });
+  
 });

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-react": "^6.0.0",
     "gh-pages": "0.11.0",
     "husky": "^0.13.1",
-    "jest": "^18.1.0",
+    "jest": "^20.0.4",
     "lcov2badge": "^0.1.0",
     "lint-staged": "^3.4.0",
     "node-sass": "3.8.0",


### PR DESCRIPTION
Fixed the bug, added a test.

The test is in it's own `describe()` wrapper to localize the before/after hooks. Not absolutely required, but seemed like a good idea.

I also added [sinon](http://sinonjs.org/) as a dev dependency to make stubbing global methods a bit easier and less error-prone.

Fixes #94