### PR TITLE
fix(OverflowMenuItem): use PropTypes module

### DIFF
--- a/components/OverflowMenuItem.js
+++ b/components/OverflowMenuItem.js
@@ -16,7 +16,7 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   onMouseUp: PropTypes.func,
-  closeMenu: React.PropTypes.func,
+  closeMenu: PropTypes.func,
 };
 
 const defaultProps = {


### PR DESCRIPTION
A recent change used the React PropTypes property instead of the React one.

Fixes #99