### PR TITLE
fix(structured-list): change exported files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
 export { Module, ModuleBody, ModuleHeader } from './components/Module';
-export { ProgressIndicator, ProgressStep } from './components/ProgressIndicator';
+export {
+  ProgressIndicator,
+  ProgressStep,
+} from './components/ProgressIndicator';
+export {
+  StructuredListWrapper,
+  StructuredListHead,
+  StructuredListBody,
+  StructuredListRow,
+  StructuredListInput,
+  StructuredListCell,
+} from './components/StructuredList';
 export Accordion from './components/Accordion';
 export AccordionItem from './components/AccordionItem';
 export Breadcrumb from './components/Breadcrumb';
@@ -21,7 +32,10 @@ export DatePickerInput from './components/DatePickerInput';
 export DetailPageHeader from './components/DetailPageHeader';
 export Dropdown from './components/Dropdown';
 export DropdownItem from './components/DropdownItem';
-export FileUploader, { Filename, FileUploaderButton } from './components/FileUploader';
+export FileUploader, {
+  Filename,
+  FileUploaderButton,
+} from './components/FileUploader';
 export Footer from './components/Footer';
 export Form from './components/Form';
 export FormGroup from './components/FormGroup';
@@ -48,7 +62,6 @@ export SecondaryButton from './components/SecondaryButton';
 export Select from './components/Select';
 export SelectItem from './components/SelectItem';
 export SelectItemGroup from './components/SelectItemGroup';
-export StructuredList from './components/StructuredList';
 export Switch from './components/Switch';
 export Tab from './components/Tab';
 export TabContent from './components/TabContent';


### PR DESCRIPTION
## Change to correct export

Changed the export of `StructuredList` to mimic its _structure_ 

<img width="416" alt="screen shot 2017-07-18 at 11 11 13 am" src="https://user-images.githubusercontent.com/11928039/28327735-ee4415a0-6ba9-11e7-812a-11f34ca54679.png">

Other changes in `index.js` are `prettier` formatting fixes. 
