### PR TITLE
feat(pagination): supports pagination with unknown totals

### DIFF
--- a/.storybook/components/PaginationStory.js
+++ b/.storybook/components/PaginationStory.js
@@ -16,9 +16,16 @@ storiesOf('Pagination', module)
     </div>
   ))
   .addWithInfo(
-    'Default',
+    'with known total number of items',
     `
-      Description coming soon.
+      The pagination component is used to paginate through items with known total.
     `,
     () => <Pagination {...props} totalItems={103} />
+  )
+  .addWithInfo(
+    'with unknown total number of items',
+    `
+      The pagination component is used to paginate through items with unknown total.
+    `,
+    () => <Pagination {...props} pagesUnknown={true} isLastPage={false} pageInputDisabled={true} />
   );

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -14,25 +14,35 @@ class Pagination extends Component {
     itemRangeText: PropTypes.func,
     forwardText: PropTypes.string,
     itemsPerPageText: PropTypes.string,
+    itemText: PropTypes.func,
     onChange: PropTypes.func,
     pageNumberText: PropTypes.string,
     pageRangeText: PropTypes.func,
+    pageText: PropTypes.func,
     pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
-    totalItems: PropTypes.number.isRequired,
+    totalItems: PropTypes.number,
     disabled: PropTypes.bool,
     page: PropTypes.number,
     pageSize: PropTypes.number,
+    pagesUnknown: PropTypes.bool,
+    isLastPage: PropTypes.bool,
+    pageInputDisabled: PropTypes.bool,
   };
   static defaultProps = {
     backwardText: 'Backward',
     itemRangeText: (min, max, total) => `${min}-${max} of ${total} items`,
     forwardText: 'Forward',
-    itemsPerPageText: 'Items per page',
+    itemsPerPageText: 'items per page',
     onChange: () => {},
     pageNumberText: 'Page Number',
     pageRangeText: (current, total) => `${current} of ${total} pages`,
     disabled: false,
     page: 1,
+    pagesUnknown: false,
+    isLastPage: false,
+    pageInputDisabled: false,
+    itemText: (min, max) => `${min}-${max} items`,
+    pageText: (page) => `page ${page}`,
   };
   static uuid = 0;
   state = {
@@ -91,6 +101,11 @@ class Pagination extends Component {
       pageNumberText,
       pageRangeText,
       pageSizes,
+      itemText,
+      pageText,
+      pagesUnknown,
+      isLastPage,
+      pageInputDisabled,
       totalItems,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
@@ -118,16 +133,24 @@ class Pagination extends Component {
             {itemsPerPageText}&nbsp;&nbsp;|&nbsp;&nbsp;
           </span>
           <span className="bx--pagination__text">
-            {itemRangeText(
-              pageSize * (page - 1) + 1,
-              Math.min(page * pageSize, totalItems),
-              totalItems
+            {pagesUnknown ?
+              itemText(
+                pageSize * (page - 1) + 1,
+                page * pageSize,
+              ) :
+              itemRangeText(
+                pageSize * (page - 1) + 1,
+                Math.min(page * pageSize, totalItems),
+                totalItems
             )}
           </span>
         </div>
         <div className="bx--pagination__right">
           <span className="bx--pagination__text">
-            {pageRangeText(page, Math.ceil(totalItems / pageSize))}
+            {pagesUnknown ?
+              pageText(page) :
+              pageRangeText(page, Math.ceil(totalItems / pageSize))
+            }
           </span>
           <button
             className="bx--pagination__button bx--pagination__button--backward"
@@ -140,19 +163,22 @@ class Pagination extends Component {
               description={backwardText}
             />
           </button>
-          <TextInput
-            id={`bx-pagination-input-${this.id}`}
-            placeholder="0"
-            value={page}
-            onChange={this.handlePageInputChange}
-            labelText={pageNumberText}
-            hideLabel
-          />
+          {pageInputDisabled ?
+            <span className="bx--pagination__text">|</span> :
+            <TextInput
+              id={`bx-pagination-input-${this.id}`}
+              placeholder="0"
+              value={page}
+              onChange={this.handlePageInputChange}
+              labelText={pageNumberText}
+              hideLabel
+            />
+          }
           <button
             className="bx--pagination__button bx--pagination__button--forward"
             onClick={this.incrementPage}
             disabled={
-              this.props.disabled || page === Math.ceil(totalItems / pageSize)
+              this.props.disabled || page === Math.ceil(totalItems / pageSize) || isLastPage
             }
           >
             <Icon

--- a/components/__tests__/Pagination-test.js
+++ b/components/__tests__/Pagination-test.js
@@ -49,11 +49,41 @@ describe('Pagination', () => {
       });
       it('should label the dropdown', () => {
         const label = left.find('.bx--pagination__text').first();
-        expect(label.text()).toBe('Items per page\u00a0\u00a0|\u00a0\u00a0');
+        expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
       });
       it('should show the item range out of the total', () => {
         const label = left.find('.bx--pagination__text').at(1);
         expect(label.text()).toBe('1-5 of 50 items');
+      });
+
+      describe('pagination size container when total pages unknown', () => {
+        const pager = mount(
+          <Pagination
+            pageSizes={[5, 10]}
+            pagesUnknown={true}
+          />
+        );
+        const left = pager.find('.bx--pagination__left');
+
+        it('should render a left container', () => {
+          expect(left.length).toBe(1);
+        });
+        it('should have a size dropdown', () => {
+          const select = left.find(Select);
+          const items = select.find(SelectItem);
+          expect(select.length).toBe(1);
+          expect(items.length).toBe(2);
+          expect(items.at(0).props().value).toBe(5);
+          expect(items.at(1).props().value).toBe(10);
+        });
+        it('should label the dropdown', () => {
+          const label = left.find('.bx--pagination__text').first();
+          expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
+        });
+        it('should show the item range without the total', () => {
+          const label = left.find('.bx--pagination__text').at(1);
+          expect(label.text()).toBe('1-5 items');
+        });
       });
 
       describe('pagination sizing', () => {
@@ -156,6 +186,64 @@ describe('Pagination', () => {
         const buttons = smallPage.find('.bx--pagination__button');
         expect(buttons.at(0).props().disabled).toBe(true);
         expect(buttons.at(1).props().disabled).toBe(true);
+      });
+
+
+//wip2
+      describe('pagination paging container when total pages unknown', () => {
+        const pager = mount(
+          <Pagination
+            pageSizes={[5, 10]}
+            pagesUnknown={true}
+          />
+        );
+
+        const right = pager.find('.bx--pagination__right');
+        it('should render a right container', () => {
+          expect(right.length).toBe(1);
+        });
+        it('should show the current page without the total number of pages', () => {
+          const label = right.find('.bx--pagination__text').first();
+          expect(label.text()).toBe('page 1');
+        });
+        it('should have two buttons for navigation', () => {
+          const buttons = right.find('.bx--pagination__button');
+          expect(buttons.length).toBe(2);
+          expect(buttons.at(0).hasClass('bx--pagination__button--backward')).toBe(
+            true
+          );
+          expect(buttons.at(1).hasClass('bx--pagination__button--forward')).toBe(
+            true
+          );
+        });
+        it('should disable backward navigation for the first page', () => {
+          const buttons = right.find('.bx--pagination__button');
+          expect(buttons.at(0).props().disabled).toBe(true);
+          expect(buttons.at(1).props().disabled).toBe(false);
+        });
+        it('should disable forward navigation for the last page', () => {
+          const smallPage = shallow(
+            <Pagination
+              pageSizes={[100]}
+              pagesUnknown={true}
+              isLastPage={true}
+            />
+          );
+          const buttons = smallPage.find('.bx--pagination__button');
+          expect(buttons.at(0).props().disabled).toBe(true);
+          expect(buttons.at(1).props().disabled).toBe(true);
+        });
+        it('should hide text input if disabled', () => {
+          const noTextInput = shallow(
+            <Pagination
+              pageSizes={[100]}
+              pagesUnknown={true}
+              pageInputDisabled={true}
+            />
+          );
+          const right = noTextInput.find('.bx--pagination__right .bx--text__input');
+          expect(right.length).toEqual(0);
+        });
       });
 
       describe('pagination navigation', () => {


### PR DESCRIPTION
Supports pagination with unknown total number of items:
- `pagesUnknown` indicates total is unknown
- `isLastPage` indicates last page when total is unknown
- `pageInputDisabled` hides the text input for jumping to a certain page
