### PR TITLE
fix(Notification): add string props to defaultProps (il8n)

### DIFF
--- a/components/Notification.js
+++ b/components/Notification.js
@@ -19,8 +19,7 @@ class Notification extends Component {
     onCloseButtonClick: () => {},
     iconDescription: 'closes notification',
     title: 'Provide a title',
-    subtitle: 'Provide a subtitle',
-    caption: 'Provide a caption'
+    subtitle: 'Provide a subtitle'
   };
 
   state = {

--- a/components/Notification.js
+++ b/components/Notification.js
@@ -12,16 +12,19 @@ class Notification extends Component {
     subtitle: PropTypes.string.isRequired,
     caption: PropTypes.string,
     onCloseButtonClick: PropTypes.func,
-    iconDescription: PropTypes.string.isRequired,
+    iconDescription: PropTypes.string.isRequired
   };
 
   static defaultProps = {
     onCloseButtonClick: () => {},
     iconDescription: 'closes notification',
+    title: 'Provide a title',
+    subtitle: 'Provide a subtitle',
+    caption: 'Provide a caption'
   };
 
   state = {
-    open: true,
+    open: true
   };
 
   handleCloseButtonClick = evt => {
@@ -60,35 +63,28 @@ class Notification extends Component {
         'bx--inline-notification',
         { [`bx--inline-notification--${this.props.kind}`]: this.props.kind },
         className
-      ),
+      )
     };
 
     const commonProps = {
       alert: {
         role: 'alert',
-        kind,
+        kind
       },
       button: {
         type: 'button',
-        onClick: this.handleCloseButtonClick,
-      },
+        onClick: this.handleCloseButtonClick
+      }
     };
 
     const toastHTML = (
-      <div
-        {...other}
-        {...commonProps.alert}
-        className={notificationClasses.toast}
-      >
+      <div {...other} {...commonProps.alert} className={notificationClasses.toast}>
         <div className="bx--toast-notification__details">
           <h3 className="bx--toast-notification__title">{title}</h3>
           <p className="bx--toast-notification__subtitle">{subtitle}</p>
           <p className="bx--toast-notification__caption">{caption}</p>
         </div>
-        <button
-          {...commonProps.button}
-          className="bx--toast-notification__close-button"
-        >
+        <button {...commonProps.button} className="bx--toast-notification__close-button">
           <Icon
             description={this.props.iconDescription}
             className="bx--toast-notification__icon"
@@ -100,11 +96,7 @@ class Notification extends Component {
     );
 
     const inlineHTML = (
-      <div
-        {...other}
-        {...commonProps.alert}
-        className={notificationClasses.inline}
-      >
+      <div {...other} {...commonProps.alert} className={notificationClasses.inline}>
         <div className="bx--inline-notification__details">
           <Icon
             description={this.props.iconDescription}
@@ -117,10 +109,7 @@ class Notification extends Component {
             <p className="bx--inline-notification__subtitle">{subtitle}</p>
           </div>
         </div>
-        <button
-          {...commonProps.button}
-          className="bx--inline-notification__close-button"
-        >
+        <button {...commonProps.button} className="bx--inline-notification__close-button">
           <Icon
             description={this.props.iconDescription}
             className="bx--inline-notification__close-icon"


### PR DESCRIPTION
related to #107 

This component will need a refactor since `Notification` relies on the `caption` prop to render either Toast or Inline notifications. This isn't possible as we need to give caption a `defaultProp` forcing the `caption` prop to always resolve as `true`....basically, this was some bad logic that I did when I originally wrote this and should be refactored in another PR. 