### PR TITLE
fix(DetailPageHeader): identify children when minified

### DIFF
--- a/components/Breadcrumb.js
+++ b/components/Breadcrumb.js
@@ -16,6 +16,9 @@ const Breadcrumb = ({ children, className, ...other }) => {
   );
 };
 
+// needed to allow DetailPageHeader to identify this when minified
+Breadcrumb.displayName = 'Breadcrumb';
+
 Breadcrumb.propTypes = propTypes;
 
 export default Breadcrumb;

--- a/components/DetailPageHeader.js
+++ b/components/DetailPageHeader.js
@@ -110,19 +110,19 @@ class DetailPageHeader extends Component {
     let icon;
 
     Children.map(children, child => {
-      if (child.type.name === 'Breadcrumb') {
+      if (child.type.displayName === 'Breadcrumb') {
         breadcrumb = child;
       }
 
-      if (child.type.name === 'Tabs') {
+      if (child.type.displayName === 'Tabs') {
         tabs = child;
       }
 
-      if (child.type.name === 'OverflowMenu') {
+      if (child.type.displayName === 'OverflowMenu') {
         overflow = child;
       }
 
-      if (child.type.name === 'Icon') {
+      if (child.type.displayName === 'Icon') {
         icon = child;
       }
 

--- a/components/Icon.js
+++ b/components/Icon.js
@@ -129,6 +129,8 @@ const Icon = ({
 
 Icon.propTypes = propTypes;
 Icon.defaultProps = defaultProps;
+// needed to allow DetailPageHeader to identify this when minified
+Icon.displayName = 'Icon';
 
 export { icons };
 

--- a/components/OverflowMenu.js
+++ b/components/OverflowMenu.js
@@ -40,6 +40,9 @@ class OverflowMenu extends Component {
     menuOffsetFlip: { top: 0, left: -60.5 },
   };
 
+  // needed to allow DetailPageHeader to identify this when minified
+  static displayName = 'OverflowMenu';
+
   state = {
     open: this.props.open,
   };

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -24,6 +24,9 @@ class Tabs extends React.Component {
     selected: 0,
   };
 
+  // needed to allow DetailPageHeader to identify this when minified
+  static displayName = 'Tabs';
+
   state = {
     dropdownHidden: true,
     selected: this.props.selected,


### PR DESCRIPTION
This sets a `displayName` property on all of the children that `DetailPageHeader` has special cases for, and then updates the DPH to check `displayName` rather than `name`. (`name` changes during minification, but `displayName` does not.)

I'm not completely happy with this, partially because I'm not sure how to test for it, but it should at least fix the current buggy behavior. I suppose we could minify the code and then test it, but that sounds like a giant pain. 

Alternatively, there could be a [lint rule that just required all components to specify a `displayName`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md), but that would be a bigger change. It wouldn't be a bad thing to enforce though, especially if we want to allow some code to depend on component names internally.

(I dropped the `instanceof` idea because it's [not as straightforward as it sounds](https://stackoverflow.com/questions/39387405/using-instanceof-to-test-for-base-class-of-a-react-component). Given that some of the components are stateless functions that you don't directly create instances of, this kind of makes sense.)

Fixes https://github.com/carbon-design-system/carbon-components-react/issues/136
