### PR TITLE
fix(DatePicker): fix server-side-rendering (#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "check": "npm run lint && npm run test",
     "lint": "eslint {components,internal}/**",
-    "test": "jest '/(__tests__|components|lib|internal)/'",
+    "test": "jest '/(__tests__|components|lib|internal)/' && npm run test-ssr",
     "test-watch": "jest '/(__tests__|components|lib|internal)/' --watch",
+    "test-ssr": "npm run build && node server-side-rendering-tests/*.js",
     "prepublish": "npm run build",
     "build": "node scripts/build.js",
     "commitmsg": "validate-commit-msg",
@@ -87,7 +88,7 @@
   },
   "dependencies": {
     "classnames": "2.2.5",
-    "flatpickr": "^3.0.6",
+    "flatpickr": "^3.0.7",
     "lodash.debounce": "^4.0.8",
     "react-addons-css-transition-group": "^15.4.2",
     "warning": "3.0.0",

--- a/server-side-rendering-tests/loads.js
+++ b/server-side-rendering-tests/loads.js
@@ -1,0 +1,9 @@
+// Simple test to ensure the components can at least be loaded in Node.js
+// Note: this test is *not* run by Jest because Jest's pollyfills mask some errors
+
+'use strict';
+
+var assert = require('assert');
+var carbonComponentsReact = require('../cjs/index');
+assert(carbonComponentsReact);
+console.log('server-side-rendering load test passed'); // eslint-disable-line no-console


### PR DESCRIPTION
Adds a workaround for the flatpickr SSR bug and a basic SSR smoke test to ensure the lib can be at least loaded in a server-side context.

The workaround and the test are both a little barren, but I believe they're both good enough, and a solid improvement over the previous situation. The test has to live outside of jest because jest will pollyfill `window` and make things work in jest that  throw errors in Node.js.

It wouldn't be a bad idea to add an additional test that renders everything in `.storybook/components/` in Node.js to get a little more thorough coverage.

Fixes #76