### PR TITLE
fix(overflow): wrap ref usage in if statement anyways

### DIFF
--- a/components/OverflowMenu.js
+++ b/components/OverflowMenu.js
@@ -64,8 +64,10 @@ class OverflowMenu extends Component {
   }
 
   getMenuPosition = () => {
-    const menuPosition = this.menuEl.getBoundingClientRect();
-    this.setState({ menuPosition });
+    if (this.menuEl) {
+      const menuPosition = this.menuEl.getBoundingClientRect();
+      this.setState({ menuPosition });
+    }
   };
 
   handleClick = evt => {


### PR DESCRIPTION
Opening this to let people test against this, to see if this resolves the null issue. I haven't been able to isolate an appropriate test case to reproduce the bug though