### PR TITLE
feat(DetailPageHeader): Add Tag and Link children

### DIFF
--- a/.storybook/components/DetailPageHeaderStory.js
+++ b/.storybook/components/DetailPageHeaderStory.js
@@ -8,6 +8,8 @@ import DetailPageHeader from '../../components/DetailPageHeader';
 import Tabs from '../../components/Tabs';
 import Tab from '../../components/Tab';
 import Icon from '../../components/Icon';
+import Tag from '../../components/Tag';
+import Link from '../../components/Link';
 
 const detailPageHeaderProps = {
   title: 'Detail Page Header',
@@ -51,9 +53,14 @@ storiesOf('DetailPageHeader', module)
           {...overflowMenuItemProps}
           itemText="Delete App"
           isDelete
-          isLastItem
         />
       </OverflowMenu>
+      <Tag type="ibm">
+        Language
+      </Tag>
+      <Link href="#">
+        View demo
+      </Link>
     </DetailPageHeader>
   ))
   .addWithInfo('with tabs', () => (
@@ -85,5 +92,11 @@ storiesOf('DetailPageHeader', module)
         <Tab label="Banana" />
         <Tab label="Orange" />
       </Tabs>
+      <Tag type="ibm">
+        Language
+      </Tag>
+      <Link href="#">
+        View demo
+      </Link>
     </DetailPageHeader>
   ));

--- a/components/DetailPageHeader.js
+++ b/components/DetailPageHeader.js
@@ -7,6 +7,8 @@ import Breadcrumb from './Breadcrumb';
 import Tabs from './Tabs';
 import OverflowMenu from './OverflowMenu';
 import Icon from './Icon';
+import Tag from './Tag';
+import Link from './Link';
 
 class DetailPageHeader extends Component {
   static propTypes = {
@@ -111,24 +113,32 @@ class DetailPageHeader extends Component {
     let tabs;
     let overflow;
     let icon;
+    let tag;
+    let link;
 
     Children.map(children, child => {
-      if (child.type === Breadcrumb) {
-        breadcrumb = child;
+      if (child != null && child.type != null) {
+        switch (child.type) {
+          case Breadcrumb:
+            breadcrumb = child;
+            break;
+          case Tabs:
+            tabs = child;
+            break;
+          case OverflowMenu:
+            overflow = child;
+            break;
+          case Icon:
+            icon = child;
+            break;
+          case Tag:
+            tag = child;
+            break;
+          case Link:
+            link = child;
+            break;
+        }
       }
-
-      if (child.type === Tabs) {
-        tabs = child;
-      }
-
-      if (child.type === OverflowMenu) {
-        overflow = child;
-      }
-
-      if (child.type === Icon) {
-        icon = child;
-      }
-
       return null;
     });
 
@@ -152,6 +162,12 @@ class DetailPageHeader extends Component {
               {' '}
               <span className="bx--detail-page-header-status-text">
                 {statusText}{statusContent}
+                <span className="bx--detail-page-header-tag">
+                  {' '}{tag}
+                </span>
+                <span className="bx--detail-page-header-link">
+                  {' '}{link}
+                </span>
               </span>
             </div>
           </div>

--- a/components/DetailPageHeader.js
+++ b/components/DetailPageHeader.js
@@ -7,8 +7,6 @@ import Breadcrumb from './Breadcrumb';
 import Tabs from './Tabs';
 import OverflowMenu from './OverflowMenu';
 import Icon from './Icon';
-import Tag from './Tag';
-import Link from './Link';
 
 class DetailPageHeader extends Component {
   static propTypes = {
@@ -113,33 +111,24 @@ class DetailPageHeader extends Component {
     let tabs;
     let overflow;
     let icon;
-    let tag;
-    let link;
 
-    Children.map(children, child => {
-      if (child != null && child.type != null) {
-        switch (child.type) {
-          case Breadcrumb:
-            breadcrumb = child;
-            break;
-          case Tabs:
-            tabs = child;
-            break;
-          case OverflowMenu:
-            overflow = child;
-            break;
-          case Icon:
-            icon = child;
-            break;
-          case Tag:
-            tag = child;
-            break;
-          case Link:
-            link = child;
-            break;
-        }
+    let extraElements = Children.toArray(children).filter(child => {
+      switch (child.type) {
+        case Breadcrumb:
+          breadcrumb = child;
+          return false;
+        case Tabs:
+          tabs = child;
+          return false;
+        case OverflowMenu:
+          overflow = child;
+          return false;
+        case Icon:
+          icon = child;
+          return false;
+        default:
+          return true;
       }
-      return null;
     });
 
     const statusStyles = {
@@ -161,13 +150,9 @@ class DetailPageHeader extends Component {
               <div style={statusStyles} className="bx--detail-page-header-status-icon" />
               {' '}
               <span className="bx--detail-page-header-status-text">
-                {statusText}{statusContent}
-                <span className="bx--detail-page-header-tag">
-                  {' '}{tag}
-                </span>
-                <span className="bx--detail-page-header-link">
-                  {' '}{link}
-                </span>
+                {statusText}
+                {statusContent}
+                {extraElements}
               </span>
             </div>
           </div>

--- a/components/__tests__/DetailPageHeader-test.js
+++ b/components/__tests__/DetailPageHeader-test.js
@@ -9,6 +9,8 @@ import OverflowMenu from '../OverflowMenu';
 import OverflowMenuItem from '../OverflowMenuItem';
 import Tab from '../Tab';
 import Tabs from '../Tabs';
+import Tag from '../../components/Tag';
+import Link from '../../components/Link';
 
 describe('DetailPageHeader', () => {
   describe('component is rendered correctly without tabs', () => {
@@ -27,6 +29,12 @@ describe('DetailPageHeader', () => {
           <OverflowMenuItem itemText="Edit Routes and Access" />
           <OverflowMenuItem itemText="Delete App" isDelete />
         </OverflowMenu>
+        <Tag type="ibm">
+          Language
+        </Tag>
+        <Link href="www.example.com">
+          View demo
+        </Link>
       </DetailPageHeader>
     );
 
@@ -86,6 +94,16 @@ describe('DetailPageHeader', () => {
     it('should render the correct status color', () => {
       expect(wrapper.props().statusColor).toEqual('#BADA55');
     });
+
+    it('should render the Tag', () => {
+      const hasTag = wrapper.find('.bx--detail-page-header-tag').length === 1;
+      expect(hasTag).toEqual(true);
+    });
+
+    it('should render the Link', () => {
+      const hasTag = wrapper.find('.bx--detail-page-header-link').length === 1;
+      expect(hasTag).toEqual(true);
+    });
   });
 
   describe('component is rendered correctly with tabs', () => {
@@ -110,6 +128,12 @@ describe('DetailPageHeader', () => {
           <Tab label="Banana" />
           <Tab label="Orange" />
         </Tabs>
+        <Tag type="ibm">
+          Language
+        </Tag>
+        <Link href="www.example.com">
+          View demo
+        </Link>
       </DetailPageHeader>
     );
 

--- a/components/__tests__/DetailPageHeader-test.js
+++ b/components/__tests__/DetailPageHeader-test.js
@@ -96,13 +96,15 @@ describe('DetailPageHeader', () => {
     });
 
     it('should render the Tag', () => {
-      const hasTag = wrapper.find('.bx--detail-page-header-tag').length === 1;
-      expect(hasTag).toEqual(true);
+      const tag = wrapper.find(Tag).node.props.children;
+      expect(tag).toEqual('Language');
     });
 
     it('should render the Link', () => {
-      const hasTag = wrapper.find('.bx--detail-page-header-link').length === 1;
-      expect(hasTag).toEqual(true);
+      const extraLink = wrapper.find(Link).nodes.filter(node =>
+        node.props.children === 'View demo'
+      );
+      expect(extraLink.length).toEqual(1);
     });
   });
 


### PR DESCRIPTION
More context is given in issue #186.
 
This gives the option to provide 2 additional child nodes to the `DetailPageHeader`: a `Tag` and a `Link`. Below is a screenshot from the Storybook.

![screen shot 2017-08-16 at 12 02 37 pm](https://user-images.githubusercontent.com/5459406/29375526-ecd022bc-827a-11e7-96b1-6c1ab8797844.png)