### PR TITLE
fix(Pagination): use id as prop again

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -182,7 +182,7 @@ class Pagination extends Component {
           {pageInputDisabled
             ? <span className="bx--pagination__text">|</span>
             : <TextInput
-              id={`bx-pagination-input-${this.id}`}
+              id={`bx-pagination-input-${inputId}`}
               placeholder="0"
               value={statePage}
               onChange={this.handlePageInputChange}


### PR DESCRIPTION
Reverting an accidental change to how the id was being used.
Adding the change from 7ea8ab9 back in that was taken out in
241a15e

Fixes #200