### PR TITLE
fix(slider): onChange not being called, resolves #204

### DIFF
--- a/.storybook/components/SliderStory.js
+++ b/.storybook/components/SliderStory.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { storiesOf, action } from '@storybook/react';
 import Slider from '../../components/Slider';
+
+const mock = action('onChange');
 
 storiesOf('Slider', module)
   .addWithInfo(
@@ -10,7 +12,7 @@ storiesOf('Slider', module)
     `,
     () => (
       <div style={{ marginTop: '2rem' }}>
-        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label"/>
+        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label" onChange={mock} />
       </div>
     )
   )
@@ -21,7 +23,7 @@ storiesOf('Slider', module)
     `,
     () => (
       <div style={{ marginTop: '2rem' }}>
-        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label" hideTextInput={true}/>
+        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label" hideTextInput={true} onChange={mock}/>
       </div>
     )
   )
@@ -32,7 +34,7 @@ storiesOf('Slider', module)
     `,
     () => (
       <div style={{ marginTop: '2rem' }}>
-        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label" disabled/>
+        <Slider id="slider" value={50} min={0} max={100} step={1} labelText="Slider Label" onChange={mock} disabled/>
       </div>
     )
   );

--- a/components/Slider.js
+++ b/components/Slider.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TextInput from './TextInput';
 
-class Slider extends Component {
+class Slider extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     hideTextInput: PropTypes.bool,
@@ -37,12 +37,12 @@ class Slider extends Component {
   };
 
   componentDidMount() {
-    this.updatePosition()
+    this.updatePosition();
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps !== this.props) {
-      this.updatePosition()
+      this.updatePosition();
     }
   }
 
@@ -62,28 +62,31 @@ class Slider extends Component {
     this.setState({ dragging: true });
 
     requestAnimationFrame(() => {
-      this.setState({ dragging: false });
-      const {
-        left,
-        newValue,
-      } = this.calcValue(evt);
+      this.setState((prevState, props) => {
+        const {
+          left,
+          newValue,
+        } = this.calcValue(evt, prevState, props);
 
-      this.setState({
-        left,
-        value: newValue,
-       });
+        props.onChange({ value: newValue });
+        return {
+          dragging: false,
+          left,
+          value: newValue,
+        }
+      });
     });
   }
 
-  calcValue = (evt) => {
+  calcValue = (evt, prevState, props) => {
     const {
       min,
       max,
       step,
       stepMuliplier,
-    } = this.props;
+    } = props;
 
-    const { value } = this.state;
+    const { value } = prevState;
 
     const range = max - min;
     const valuePercentage = (((value - min) / range) * 100);
@@ -162,7 +165,7 @@ class Slider extends Component {
 
   handleChange = (evt) => {
     this.setState({ value: evt.target.value });
-    this.updatePosition();
+    this.updatePosition(evt);
   }
 
   render() {
@@ -170,7 +173,6 @@ class Slider extends Component {
       className,
       hideTextInput,
       id,
-      onChange,
       min,
       minLabel,
       max,
@@ -212,7 +214,7 @@ class Slider extends Component {
             ref={node => {
               this.element = node;
             }}
-            onClick={(evt) => this.updatePosition(evt)}
+            onClick={this.updatePosition}
             {...other}
           >
             <div
@@ -227,9 +229,9 @@ class Slider extends Component {
               className="bx--slider__thumb"
               tabIndex="0"
               style={thumbStyle}
-              onMouseDown={() => this.handleMouseStart()}
-              onTouchStart={() => this.handleTouchStart()}
-              onKeyDown={(evt) => this.updatePosition(evt)}
+              onMouseDown={this.handleMouseStart}
+              onTouchStart={this.handleTouchStart}
+              onKeyDown={this.updatePosition}
             >
             </div>
             <input
@@ -241,11 +243,7 @@ class Slider extends Component {
               min={min}
               max={max}
               step={step}
-              onChange={evt => {
-                if (!disabled) {
-                  onChange(evt);
-                }
-              }}
+              onChange={this.handleChange}
             />
           </div>
           <span className="bx--slider__range-label">{max}{maxLabel}</span>
@@ -254,7 +252,7 @@ class Slider extends Component {
               id="input-for-slider"
               className="bx-slider-text-input"
               value={value}
-              onChange={(evt) => this.handleChange(evt)}
+              onChange={this.handleChange}
             />
           : null }
         </div>

--- a/components/__tests__/Slider-test.js
+++ b/components/__tests__/Slider-test.js
@@ -6,8 +6,9 @@ import 'requestanimationframe';
 
 describe('Slider', () => {
   describe('Renders as expected', () => {
+    const mockFn = jest.fn();
     const wrapper = mount(
-      <Slider id="slider" className="extra-class" value={50} min={0} max={100} step={1}>
+      <Slider id="slider" className="extra-class" value={50} min={0} max={100} step={1} onChange={mockFn} >
         <TextInput id="input-for-slider" className="bx-slider-text-input"/>
       </Slider>
     );
@@ -35,32 +36,41 @@ describe('Slider', () => {
     });
   });
 
-  describe('calcValue method', () => {
+  describe('updatePosition method', () => {
+    const mockFn = jest.fn();
     const wrapper = mount(
-      <Slider id="slider" className="extra-class" value={50} min={0} max={100} step={1}>
+      <Slider id="slider" className="extra-class" value={50} min={0} max={100} step={1} onChange={mockFn} >
       </Slider>
     );
 
-    it('returns correct value from event with a clientX', () => {
-      const evt = {
-        type: 'click',
-        clientX: '1000',
-      }
-      expect(wrapper.instance().calcValue(evt).newValue).toEqual(100)
-    });
-    it('returns correct value from event with a right/up keydown', () => {
+    it('sets correct state from event with a right/up keydown', () => {
       const evt = {
         type: 'keydown',
         which: '38',
       }
-      expect(wrapper.instance().calcValue(evt).newValue).toEqual(51)
+      wrapper.instance().updatePosition(evt);
+      expect(mockFn).lastCalledWith({ value: 51 });
+      expect(wrapper.state().value).toEqual(51);
     });
-    it('returns correct value from event with a left/down keydown', () => {
+
+    it('sets correct state from event with a left/down keydown', () => {
       const evt = {
         type: 'keydown',
         which: '40',
       }
-      expect(wrapper.instance().calcValue(evt).newValue).toEqual(49)
+      wrapper.instance().updatePosition(evt);
+      expect(mockFn).lastCalledWith({ value: 50 });
+      expect(wrapper.state().value).toEqual(50);
+    });
+
+    it('sets correct state from event with a clientX', () => {
+      const evt = {
+        type: 'click',
+        clientX: '1000',
+      }
+      wrapper.instance().updatePosition(evt);
+      expect(mockFn).lastCalledWith({ value: 100 });
+      expect(wrapper.state().value).toEqual(100);
     });
   });
 });


### PR DESCRIPTION
Closes #204 
Fixes the following problems in the Slider component:

- Execute `this.props.onChange()` when the Slider value changes.
- Corrects `setState()` usage. [More info](https://facebook.github.io/react/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous)
- Remove use of arrow functions in JSX props. [More info](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)
- Use `PureComponent` to automatically bind class functions.