### PR TITLE
feat(Dropdown): add disabled state

### DIFF
--- a/.storybook/components/DropdownStory.js
+++ b/.storybook/components/DropdownStory.js
@@ -58,4 +58,24 @@ storiesOf('Dropdown', module)
         <DropdownItem itemText="Droplet Execution Agent" value="dea" />
         <DropdownItem itemText="Router" value="router" />
       </Dropdown>
-  ));
+  ))
+  .addWithInfo(
+    'disabled',
+    `
+      The Dropdown component is used for navigating or filtering existing content.
+      You can also have an option preselected in the dropdown.
+    `,
+    () => (
+      <Dropdown
+        {...dropdownEvents}
+        onChange={(selectedItemInfo) => console.log(selectedItemInfo)} // eslint-disable-line no-console
+        defaultText="Choose something.."
+        disabled
+      >
+        <DropdownItem itemText="All" value="all" />
+        <DropdownItem itemText="Cloud Foundry API" value="cloudFoundry" />
+        <DropdownItem itemText="Staging" value="staging" />
+        <DropdownItem itemText="Droplet Execution Agent" value="dea" />
+        <DropdownItem itemText="Router" value="router" />
+      </Dropdown>
+    ));

--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -16,11 +16,13 @@ class Dropdown extends PureComponent {
     selectedText: PropTypes.string,
     open: PropTypes.bool,
     iconDescription: PropTypes.string,
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {
     tabIndex: 0,
     open: false,
+    disabled: false,
     iconDescription: 'open list of options',
     onChange: () => {},
   };
@@ -59,6 +61,10 @@ class Dropdown extends PureComponent {
   };
 
   toggle = evt => {
+    if (this.props.disabled) {
+      return;
+    }
+
     // Open on click, enter, or space
     if (evt.which === 13 || evt.which === 32 || evt.type === 'click') {
       this.setState({ open: !this.state.open });
@@ -78,6 +84,7 @@ class Dropdown extends PureComponent {
       tabIndex,
       defaultText, // eslint-disable-line no-unused-vars
       iconDescription,
+      disabled,
       ...other
     } = this.props;
 
@@ -90,6 +97,7 @@ class Dropdown extends PureComponent {
     const dropdownClasses = classNames({
       'bx--dropdown': true,
       'bx--dropdown--open': this.state.open,
+      'bx--dropdown--disabled': disabled,
       [this.props.className]: this.props.className,
     });
 

--- a/components/__tests__/Dropdown-test.js
+++ b/components/__tests__/Dropdown-test.js
@@ -29,6 +29,14 @@ describe('Dropdown', () => {
       expect(dropdownWrapper.hasClass('bx--dropdown')).toEqual(true);
     });
 
+    it('has the expected classes when disabled', () => {
+      const wrapper = shallow(
+        <Dropdown defaultText="Choose something.." disabled/>
+      ).childAt(0);
+
+      expect(wrapper.hasClass('bx--dropdown--disabled')).toEqual(true);
+    });
+
     it('should add extra classes that are passed via className', () => {
       expect(dropdownWrapper.hasClass('extra-class')).toEqual(true);
     });
@@ -127,6 +135,23 @@ describe('Dropdown', () => {
       wrapper.setState({ open: true });
       const listener = wrapper.find(ClickListener);
       listener.props().onClickOutside();
+      expect(wrapper.state().open).toBe(false);
+    });
+
+    it('should not open when disabled', () => {
+      const wrapper = mount(
+        <Dropdown onClick={onClick} disabled>
+          <DropdownItem className="test-child" itemText="test-child" value="test-child" />
+        </Dropdown>
+      );
+      const dropdown = wrapper.find('.bx--dropdown--disabled');
+
+      dropdown.simulate('click');
+      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
+      dropdown.simulate('keypress', { which: 13 });
+      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
+      dropdown.simulate('keypress', { which: 32 });
+      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
       expect(wrapper.state().open).toBe(false);
     });
   });

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.16.0",
     "bowser": "^1.6.1",
-    "carbon-components": "^7.13.0",
+    "carbon-components": "^7.20.0",
     "carbon-icons": "^6.1.0",
     "commitizen": "^2.9.5",
     "css-loader": "^0.28.4",


### PR DESCRIPTION
closes #119 

### Overview

Allows a `disabled` prop to be added to the component.

<img width="418" alt="screen shot 2017-08-28 at 10 13 16 am" src="https://user-images.githubusercontent.com/17710824/29779902-92fef462-8bd9-11e7-8c38-09e050015641.png">

### Added

A new 'disabled' story for the dropdown component.

### Removed

N/A

### Changed

The `disabled` prop adds a class of `bx--dropdown--disabled` to trigger a visual change, and prevents the `toggle` custom method from changing the state.

### Testing / Reviewing

Added appropriate tests to existing file.