### PR TITLE
fix(order-summary): open order summary links in new window by default

### DIFF
--- a/.storybook/components/LinkStory.js
+++ b/.storybook/components/LinkStory.js
@@ -15,5 +15,8 @@ storiesOf('Link', module).addWithInfo(
       Links are typically used as a means of navigation either within the application, to a place outside, or to a resource.
       For anything else, especially things that change data, you should be using a button.
     `,
-  () => <Link href="#" {...additionalProps}>A simple link</Link>
+  () =>
+    <Link href="#" {...additionalProps}>
+      A simple link
+    </Link>
 );

--- a/.storybook/components/OrderSummaryStory.js
+++ b/.storybook/components/OrderSummaryStory.js
@@ -42,12 +42,8 @@ storiesOf('OrderSummary', module)
           summaryPrice="$0.00"
           summaryDetails="estimated"
         >
-          <Button>
-            Primary Button
-          </Button>
-          <Button kind="secondary">
-            Primary Button
-          </Button>
+          <Button>Primary Button</Button>
+          <Button kind="secondary">Primary Button</Button>
         </OrderSummaryTotal>
         <OrderSummaryFooter
           footerText="Need Help?"
@@ -97,12 +93,8 @@ storiesOf('OrderSummary', module)
           summaryPrice="$0.00"
           summaryDetails="estimated"
         >
-          <Button>
-            Primary Button
-          </Button>
-          <Button kind="secondary">
-            Primary Button
-          </Button>
+          <Button>Primary Button</Button>
+          <Button kind="secondary">Primary Button</Button>
         </OrderSummaryTotal>
         <OrderSummaryFooter
           footerText="Need Help?"

--- a/components/OrderSummary.js
+++ b/components/OrderSummary.js
@@ -38,7 +38,9 @@ class OrderSummaryHeader extends Component {
 
     return (
       <section className={classes} {...other}>
-        <p className="bx--order-header-title">{title}</p>
+        <p className="bx--order-header-title">
+          {title}
+        </p>
         {children}
       </section>
     );
@@ -80,7 +82,9 @@ class OrderSummaryCategory extends Component {
 
     return (
       <li className={classes} {...other}>
-        <p className="bx--order-category-title">{categoryText}</p>
+        <p className="bx--order-category-title">
+          {categoryText}
+        </p>
         <ul>
           {children}
         </ul>
@@ -107,8 +111,12 @@ class OrderSummaryListItem extends Component {
 
     return (
       <li className={classes} {...other}>
-        <p className="bx--order-detail">{text}</p>
-        <p className="bx--order-price">{price}</p>
+        <p className="bx--order-detail">
+          {text}
+        </p>
+        <p className="bx--order-price">
+          {price}
+        </p>
       </li>
     );
   }
@@ -143,10 +151,14 @@ class OrderSummaryTotal extends Component {
     return (
       <section className={classes} {...other}>
         <div className="bx--order-total">
-          <p className="bx--order-total-text">{summaryText}</p>
+          <p className="bx--order-total-text">
+            {summaryText}
+          </p>
           <p className="bx--order-total-price">
             {summaryPrice}
-            <span>{summaryDetails}</span>
+            <span>
+              {summaryDetails}
+            </span>
           </p>
         </div>
         {children}
@@ -158,23 +170,39 @@ class OrderSummaryTotal extends Component {
 class OrderSummaryFooter extends Component {
   static propTypes = {
     className: PropTypes.string,
+    linkText: PropTypes.string,
+    href: PropTypes.string,
+    target: PropTypes.string,
+    rel: PropTypes.string,
   };
 
   static defaultProps = {
     footerText: 'Need Help?',
     linkText: 'Contact Bluemix Sales',
     href: '',
+    target: '_blank',
+    rel: 'noreferrer noopener',
   };
 
   render() {
-    const { className, footerText, linkText, href, ...other } = this.props;
+    const {
+      className,
+      footerText,
+      linkText,
+      href,
+      target,
+      rel,
+      ...other
+    } = this.props;
     const classes = classNames('bx--order-footer', className);
 
     return (
       <section className={classes} {...other}>
         <p className="bx--order-footer-text">{footerText}</p>
         &nbsp;
-        <Link href={href}>{linkText}</Link>
+        <Link href={href} target={target} rel={rel}>
+          {linkText}
+        </Link>
       </section>
     );
   }

--- a/components/__tests__/OrderSummaryFooter-test.js
+++ b/components/__tests__/OrderSummaryFooter-test.js
@@ -34,6 +34,8 @@ describe('OrderSummaryFooter', () => {
         'Contact Bluemix Sales'
       );
       expect(orderSummaryFooter.props().href).toEqual('www.google.com');
+      expect(orderSummaryFooter.props().target).toEqual('_blank');
+      expect(orderSummaryFooter.props().rel).toEqual('noreferrer noopener');
     });
 
     it('should render children as expected', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,11 +1662,7 @@ carbon-components@^7.13.0:
     flatpickr "2.6.3"
     lodash.debounce "^4.0.8"
 
-carbon-icons@^6.0.4:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/carbon-icons/-/carbon-icons-6.0.6.tgz#63e72520e7f1c0fe2c3da716dd36cd84ef90cb9c"
-
-carbon-icons@^6.1.0:
+carbon-icons@^6.0.4, carbon-icons@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/carbon-icons/-/carbon-icons-6.1.0.tgz#012951c20ee978060818a034099c163a9086d50e"
 


### PR DESCRIPTION
### Order Summary 
- Set `target="_blank"` as default for `OrderSummaryFooter`