### PR TITLE
ModalWrapper handleSubmit fix

### DIFF
--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -51,6 +51,7 @@ class ModalWrapper extends React.Component {
       passiveModal,
       primaryButtonText,
       secondaryButtonText,
+      handleSubmit,
       ...other
     } = this.props;
 

--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -64,7 +64,7 @@ class ModalWrapper extends React.Component {
       secondaryButtonText,
       open: this.state.open,
       onRequestClose: this.handleClose,
-      onRequestSubmit: this.props.handleSubmit,
+      onRequestSubmit: handleSubmit,
     };
 
     return (


### PR DESCRIPTION
The `handleSubmit` prop of the `ModalWrapper` made it's way through the `other` object to `Modal`, which in turn placed that prop on a plain `<div>` and caused an error.

I removed `handleSubmit` from `other` and kept the assignment to `onRequestSubmit`

Fixes #216 
