### PR TITLE
Feature - Close after submit ModalWrapper 

### DIFF
--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -51,6 +51,7 @@ class ModalWrapper extends React.Component {
       passiveModal,
       primaryButtonText,
       secondaryButtonText,
+      handleSubmit,
       ...other
     } = this.props;
 

--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -19,6 +19,7 @@ class ModalWrapper extends React.Component {
     primaryButtonText: PropTypes.string,
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
+    closeAfterSubmit : PropTypes.bool,
   };
 
   static defaultProps = {
@@ -42,6 +43,7 @@ class ModalWrapper extends React.Component {
     });
   };
 
+
   render() {
     const {
       id,
@@ -52,6 +54,7 @@ class ModalWrapper extends React.Component {
       primaryButtonText,
       secondaryButtonText,
       handleSubmit,
+      closeAfterSubmit,
       ...other
     } = this.props;
 
@@ -64,7 +67,7 @@ class ModalWrapper extends React.Component {
       secondaryButtonText,
       open: this.state.open,
       onRequestClose: this.handleClose,
-      onRequestSubmit: handleSubmit,
+      onRequestSubmit: closeAfterSubmit ? ()=>{ if( handleSubmit() == true ) this.handleClose() } : handleSubmit,
     };
 
     return (

--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -64,7 +64,7 @@ class ModalWrapper extends React.Component {
       secondaryButtonText,
       open: this.state.open,
       onRequestClose: this.handleClose,
-      onRequestSubmit: this.props.handleSubmit,
+      onRequestSubmit: handleSubmit,
     };
 
     return (


### PR DESCRIPTION
#218

Added an extra prop to the ModalWrapper that gives the choice of closing after submitting. This should ideally be reimplemented with async functions in the future so that the `submit` function would only close after fully resolving`.

To close after submit, the `handleSubmit` function should return the boolean  `true` and the `closeAfterSubmit` prop should be `true`