### PR TITLE
fix(dropdown): added selectedText prop to the list to avoid warning

### DIFF
--- a/.storybook/components/OrderSummaryStory.js
+++ b/.storybook/components/OrderSummaryStory.js
@@ -25,7 +25,6 @@ storiesOf('OrderSummary', module)
           <Dropdown
             onChange={selectedItemInfo => console.log(selectedItemInfo)}
             defaultText="USD"
-            selectedText="USD"
           >
             <DropdownItem itemText="USD" value="usd" />
             <DropdownItem itemText="GBP" value="gbp" />

--- a/.storybook/components/OrderSummaryStory.js
+++ b/.storybook/components/OrderSummaryStory.js
@@ -25,6 +25,7 @@ storiesOf('OrderSummary', module)
           <Dropdown
             onChange={selectedItemInfo => console.log(selectedItemInfo)}
             defaultText="USD"
+            selectedText="USD"
           >
             <DropdownItem itemText="USD" value="usd" />
             <DropdownItem itemText="GBP" value="gbp" />
@@ -50,7 +51,7 @@ storiesOf('OrderSummary', module)
           linkText="Contact Bluemix Sales"
           href="www.google.com"
         />
-      </OrderSummary>
+      </OrderSummary>,
   )
   .addWithInfo(
     'Category',
@@ -101,5 +102,5 @@ storiesOf('OrderSummary', module)
           linkText="Contact Bluemix Sales"
           href="www.google.com"
         />
-      </OrderSummary>
+      </OrderSummary>,
   );

--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -85,13 +85,14 @@ class Dropdown extends PureComponent {
       defaultText, // eslint-disable-line no-unused-vars
       iconDescription,
       disabled,
+      selectedText, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 
     const children = React.Children.map(this.props.children, child =>
       React.cloneElement(child, {
         onClick: this.handleItemClick,
-      })
+      }),
     );
 
     const dropdownClasses = classNames({
@@ -111,7 +112,9 @@ class Dropdown extends PureComponent {
           className={dropdownClasses}
           tabIndex={tabIndex}
         >
-          <li className="bx--dropdown-text">{this.state.selectedText}</li>
+          <li className="bx--dropdown-text">
+            {this.state.selectedText}
+          </li>
           <li>
             <Icon
               name="caret--down"
@@ -120,7 +123,9 @@ class Dropdown extends PureComponent {
             />
           </li>
           <li>
-            <ul className="bx--dropdown-list">{children}</ul>
+            <ul className="bx--dropdown-list">
+              {children}
+            </ul>
           </li>
         </ul>
       </ClickListener>


### PR DESCRIPTION
Adding `selectedText` to the Dropdown gave a warning about `Unknown prop selectedText on <ul> tag`. So I added `selectedText` to the props list, so it's not added in with the `...other` object on the ul.