### PR TITLE
fix(number-input): control buttons

### DIFF
--- a/components/NumberInput.js
+++ b/components/NumberInput.js
@@ -22,13 +22,13 @@ class NumberInput extends Component {
     disabled: false,
     iconDescription: 'choose a number',
     label: ' ',
-    onChange: () => {},
-    onClick: () => {},
+    onChange: () => { },
+    onClick: () => { },
     step: 1,
     value: 0,
   };
-  
-  constructor (props) {
+
+  constructor(props) {
     super(props)
 
     let value = props.value;
@@ -109,20 +109,28 @@ class NumberInput extends Component {
         <div className={numberInputClasses}>
           <input type="number" pattern="[0-9]*" {...other} {...props} />
           <div className="bx--number__controls">
-            <Icon
+            <button
+              className="bx--number__control-btn"
               onClick={evt => this.handleArrowClick(evt, 'up')}
-              className="up-icon"
-              name="caret--up"
-              description={this.props.iconDescription}
-              viewBox="0 -6 10 5"
-            />
-            <Icon
+            >
+              <Icon
+                className="up-icon"
+                name="caret--up"
+                description={this.props.iconDescription}
+                viewBox="0 2 10 5"
+              />
+            </button>
+            <button
+              className="bx--number__control-btn"
               onClick={evt => this.handleArrowClick(evt, 'down')}
-              className="down-icon"
-              name="caret--down"
-              viewBox="0 6 10 5"
-              description={this.props.iconDescription}
-            />
+            >
+              <Icon
+                className="down-icon"
+                name="caret--down"
+                viewBox="0 2 10 5"
+                description={this.props.iconDescription}
+              />
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Resolves #245

Fixes the sizing of the control buttons for number input. The icons weren't being wrapped in a button component as expected by `carbon design`, so they're currently [really tiny](http://react.carbondesignsystem.com/?selectedKind=NumberInput&selectedStory=enabled&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel):
![image](https://user-images.githubusercontent.com/20052710/30933268-b1f0a302-a38f-11e7-84a0-81824334b3d7.png)
