### PR TITLE
fix(InteriorLeftNav): always pass a function

### DIFF
--- a/components/InteriorLeftNav.js
+++ b/components/InteriorLeftNav.js
@@ -120,7 +120,7 @@ class InteriorLeftNav extends Component {
         role="navigation"
         aria-label="Interior Left Navigation"
         className={classNames}
-        onClick={!this.state.open && this.toggle}
+        onClick={!this.state.open ? this.toggle : () => {}}
         {...other}
       >
         <ul key="main_list" className="left-nav-list" role="menubar">


### PR DESCRIPTION
`onClick` requires a function, but was sometimes getting `false`. This follows the same pattern, but returns a no-op instead of false to avoid a warning.

I'm sending this up because I'm _pretty sure_ it's the right move. I tested locally and the nav opens and closes as expected without any console errors. Probably worth taking a look to ensure this doesn't introduce any weird regressions.

close #252