### PR TITLE
Update testing harness and upgrade prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+cjs
+es
+storybook-static

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_script:
 script:
   - npm run lint
   - npm test
+  - npm run build
+  - npm run test-ssr
 after_success:
   - npm run semantic-release
 branches:

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2,6 +2,6 @@ import * as Carbon from '../index';
 
 describe('Carbon Components React', () => {
   it('can be imported using the correct path', () => {
-    expect(typeof Carbon).toBe('object')
+    expect(typeof Carbon).toBe('object');
   });
 });

--- a/components/AccordionItem.js
+++ b/components/AccordionItem.js
@@ -72,9 +72,10 @@ class AccordionItem extends Component {
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
         {...other}
-        tabIndex="0"
-      >
-        <div className="bx--accordion__heading" onClick={this.handleHeadingClick}>
+        tabIndex="0">
+        <div
+          className="bx--accordion__heading"
+          onClick={this.handleHeadingClick}>
           <Icon
             className="bx--accordion__arrow"
             name="chevron--right"

--- a/components/Button.js
+++ b/components/Button.js
@@ -60,9 +60,9 @@ const Button = ({
     className: buttonClasses,
   };
 
-  const buttonImage = icon
-    ? <Icon name={icon} description={iconDescription} className="bx--btn__icon" />
-    : null;
+  const buttonImage = icon ? (
+    <Icon name={icon} description={iconDescription} className="bx--btn__icon" />
+  ) : null;
 
   const button = (
     <button {...other} {...commonProps} disabled={disabled} type={type}>

--- a/components/CardActionItem.js
+++ b/components/CardActionItem.js
@@ -13,8 +13,8 @@ const propTypes = {
 
 const defaultProps = {
   ariaLabel: '',
-  description: 'card action'
-}
+  description: 'card action',
+};
 
 const CardActionItem = ({
   className,
@@ -34,8 +34,7 @@ const CardActionItem = ({
       {...other}
       className={cardActionItemClasses}
       id={id}
-      aria-label={ariaLabel}
-    >
+      aria-label={ariaLabel}>
       <Icon
         className="bx--app-actions__button--icon"
         name={iconName}

--- a/components/CardContent.js
+++ b/components/CardContent.js
@@ -10,13 +10,13 @@ const propTypes = {
   cardLink: PropTypes.node,
   cardInfo: PropTypes.array,
   className: PropTypes.string,
-  iconDescription: PropTypes.string
+  iconDescription: PropTypes.string,
 };
 
 const defaultProps = {
   iconDescription: 'card icon',
   cardIcon: 'app-services',
-  cardTitle: 'card title'
+  cardTitle: 'card title',
 };
 
 const CardContent = ({
@@ -31,19 +31,23 @@ const CardContent = ({
 }) => {
   const cardContentClasses = classNames({
     'bx--card__card-overview': true,
-    [className]: className
+    [className]: className,
   });
 
   const cardLinkContent = cardLink
-    ? cardLink.map((link, key) =>
-        <a key={key} href={link} className="bx--about__title--link">{link}</a>
-      )
+    ? cardLink.map((link, key) => (
+        <a key={key} href={link} className="bx--about__title--link">
+          {link}
+        </a>
+      ))
     : '';
 
   const cardInfoContent = cardInfo
-    ? cardInfo.map((info, key) =>
-        <h4 key={key} className="bx--about__title--additional-info">{info}</h4>
-      )
+    ? cardInfo.map((info, key) => (
+        <h4 key={key} className="bx--about__title--additional-info">
+          {info}
+        </h4>
+      ))
     : '';
 
   const cardLinkContentArray = Object.keys(cardLinkContent);

--- a/components/Checkbox.js
+++ b/components/Checkbox.js
@@ -17,10 +17,17 @@ const propTypes = {
 const defaultProps = {
   onChange: () => {},
   labelText: 'Provide checkbox label text',
-  iconDescription: 'Provide icon description for a11y'
+  iconDescription: 'Provide icon description for a11y',
 };
 
-const Checkbox = ({ className, id, labelText, onChange, iconDescription, ...other }) => {
+const Checkbox = ({
+  className,
+  id,
+  labelText,
+  onChange,
+  iconDescription,
+  ...other
+}) => {
   let input;
   const wrapperClasses = classNames('bx--checkbox-label', className);
 

--- a/components/CodeSnippet.js
+++ b/components/CodeSnippet.js
@@ -15,9 +15,8 @@ const defaultProps = {
 };
 
 const CodeSnippet = ({ className, type, children, onClick, ...other }) => {
-  const snippetType = type === 'terminal'
-    ? 'bx--snippet--terminal'
-    : 'bx--snippet--code';
+  const snippetType =
+    type === 'terminal' ? 'bx--snippet--terminal' : 'bx--snippet--code';
   const wrapperClasses = classNames('bx--snippet', className, snippetType);
   return (
     <div className={wrapperClasses} {...other}>

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -54,9 +54,12 @@ export default class CopyButton extends Component {
         type="button"
         className={classNames}
         onClick={this.handleClick}
-        {...other}
-      >
-        <Icon className="bx--snippet__icon" name="copy" description={iconDescription} />
+        {...other}>
+        <Icon
+          className="bx--snippet__icon"
+          name="copy"
+          description={iconDescription}
+        />
         <div className={feedbackClassNames} data-feedback={feedback} />
       </button>
     );

--- a/components/DatePicker.js
+++ b/components/DatePicker.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import flatpickr from 'flatpickr';
-import rangePlugin from 'flatpickr/dist/plugins/rangePlugin'
+import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import DatePickerInput from './DatePickerInput';
 
 // Weekdays shorthand for english locale
@@ -38,7 +38,10 @@ class DatePicker extends Component {
         mode: this.props.datePickerType,
         allowInput: true,
         dateFormat: this.props.dateFormat,
-        plugins: this.props.datePickerType === 'range' ? [new rangePlugin({ input: this.toInputField })] : '',
+        plugins:
+          this.props.datePickerType === 'range'
+            ? [new rangePlugin({ input: this.toInputField })]
+            : '',
         clickOpens: true,
         onChange: () => {
           this.props.onChange();
@@ -47,7 +50,7 @@ class DatePicker extends Component {
           this.updateClassNames(instance);
         },
         nextArrow: this.rightArrowHTML(),
-        leftArrow: this.leftArrowHTML()
+        leftArrow: this.leftArrowHTML(),
       });
       this.addKeyboardEvents(this.cal);
     }
@@ -130,22 +133,28 @@ class DatePicker extends Component {
     });
   };
 
-  assignInputFieldRef = (node) => {
-    this.inputField = !node ? null :
-      // Child is a regular DOM node, seen in tests
-      node.nodeType === Node.ELEMENT_NODE ? node.querySelector('.bx--date-picker__input') :
-      // Child is a React component
-      node.input && node.input.nodeType === Node.ELEMENT_NODE ? node.input :
-      null;
+  assignInputFieldRef = node => {
+    this.inputField = !node
+      ? null
+      : // Child is a regular DOM node, seen in tests
+        node.nodeType === Node.ELEMENT_NODE
+        ? node.querySelector('.bx--date-picker__input')
+        : // Child is a React component
+          node.input && node.input.nodeType === Node.ELEMENT_NODE
+          ? node.input
+          : null;
   };
 
-  assignToInputFieldRef = (node) => {
-    this.toInputField = !node ? null :
-      // Child is a regular DOM node, seen in tests
-      node.nodeType === Node.ELEMENT_NODE ? node.querySelector('.bx--date-picker__input') :
-      // Child is a React component
-      node.input && node.input.nodeType === Node.ELEMENT_NODE ? node.input :
-      null;
+  assignToInputFieldRef = node => {
+    this.toInputField = !node
+      ? null
+      : // Child is a regular DOM node, seen in tests
+        node.nodeType === Node.ELEMENT_NODE
+        ? node.querySelector('.bx--date-picker__input')
+        : // Child is a React component
+          node.input && node.input.nodeType === Node.ELEMENT_NODE
+          ? node.input
+          : null;
   };
 
   render() {
@@ -165,19 +174,21 @@ class DatePicker extends Component {
       'bx--date-picker--range': datePickerType === 'range',
     });
 
-    const datePickerIcon = datePickerType === 'range'
-      ? <svg
+    const datePickerIcon =
+      datePickerType === 'range' ? (
+        <svg
           onClick={this.openCalendar}
           className="bx--date-picker__icon"
           width="17"
           height="19"
-          viewBox="0 0 17 19"
-        >
+          viewBox="0 0 17 19">
           <path d="M12 0h2v2.7h-2zM3 0h2v2.7H3z" />
           <path d="M0 2v17h17V2H0zm15 15H2V7h13v10z" />
           <path d="M9.9 15H8.6v-3.9H7.1v-.9c.9 0 1.7-.3 1.8-1.2h1v6z" />
         </svg>
-      : '';
+      ) : (
+        ''
+      );
 
     const childArray = React.Children.toArray(children);
     const childrenWithProps = childArray.map((child, index) => {

--- a/components/DatePickerInput.js
+++ b/components/DatePickerInput.js
@@ -13,7 +13,7 @@ class DatePickerInput extends Component {
     type: 'text',
     disabled: false,
     invalid: false,
-    labelText: 'Please provide label text'
+    labelText: 'Please provide label text',
   };
 
   render() {
@@ -53,49 +53,51 @@ class DatePickerInput extends Component {
       'bx--visually-hidden': hideLabel,
     });
 
-    const datePickerIcon = datePickerType === 'single'
-      ? <svg
+    const datePickerIcon =
+      datePickerType === 'single' ? (
+        <svg
           className="bx--date-picker__icon"
           width="17"
           height="19"
-          viewBox="0 0 17 19"
-        >
+          viewBox="0 0 17 19">
           <path d="M12 0h2v2.7h-2zM3 0h2v2.7H3z" />
           <path d="M0 2v17h17V2H0zm15 15H2V7h13v10z" />
           <path d="M9.9 15H8.6v-3.9H7.1v-.9c.9 0 1.7-.3 1.8-1.2h1v6z" />
         </svg>
-      : '';
+      ) : (
+        ''
+      );
 
-    const label = labelText
-      ? <label htmlFor={id} className={labelClasses}>
-          {labelText}
-        </label>
-      : null;
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
 
-    const error = invalid
-      ? <div className="bx--form-requirement">
-          {invalidText}
-        </div>
-      : null;
+    const error = invalid ? (
+      <div className="bx--form-requirement">{invalidText}</div>
+    ) : null;
 
-    const input = invalid
-      ? <input
-          {...other}
-          {...datePickerInputProps}
-          ref={input => {
-            this.input = input;
-          }}
-          data-invalid
-          className="bx--date-picker__input"
-        />
-      : <input
-          ref={input => {
-            this.input = input;
-          }}
-          {...other}
-          {...datePickerInputProps}
-          className="bx--date-picker__input"
-        />;
+    const input = invalid ? (
+      <input
+        {...other}
+        {...datePickerInputProps}
+        ref={input => {
+          this.input = input;
+        }}
+        data-invalid
+        className="bx--date-picker__input"
+      />
+    ) : (
+      <input
+        ref={input => {
+          this.input = input;
+        }}
+        {...other}
+        {...datePickerInputProps}
+        className="bx--date-picker__input"
+      />
+    );
 
     return (
       <div className="bx--date-picker-container">

--- a/components/DetailPageHeader.js
+++ b/components/DetailPageHeader.js
@@ -18,20 +18,20 @@ class DetailPageHeader extends Component {
     statusText: PropTypes.string,
     hasTabs: PropTypes.bool,
     isScrolled: PropTypes.bool,
-    isScrollingDownward: PropTypes.bool
+    isScrollingDownward: PropTypes.bool,
   };
 
   static defaultProps = {
     title: 'Provide a title',
     statusText: 'Running',
     role: 'banner', // a11y compliance
-    hasTabs: false
+    hasTabs: false,
   };
 
   state = {
     isScrolled: this.props.isScrolled || false,
     isScrollingDownward: this.props.isScrollingDownward || false,
-    lastPosition: 0
+    lastPosition: 0,
   };
 
   componentDidMount() {
@@ -63,20 +63,20 @@ class DetailPageHeader extends Component {
         this.setState({
           isScrolled: true,
           isScrollingDownward: true,
-          lastPosition: currentPosition
+          lastPosition: currentPosition,
         });
       } else {
         this.setState({
           isScrolled: true,
           isScrollingDownward: false,
-          lastPosition: currentPosition
+          lastPosition: currentPosition,
         });
       }
     } else {
       this.setState({
         isScrolled: false,
         isScrollingDownward: false,
-        lastPosition: currentPosition
+        lastPosition: currentPosition,
       });
     }
   };
@@ -103,7 +103,9 @@ class DetailPageHeader extends Component {
       ? 'bx--detail-page-header--with-tabs'
       : 'bx--detail-page-header--no-tabs';
 
-    const scrolled = isScrollingDownward ? 'bx--detail-page-header--scroll' : null;
+    const scrolled = isScrollingDownward
+      ? 'bx--detail-page-header--scroll'
+      : null;
 
     const classNames = classnames('bx--detail-page-header', withTabs, scrolled);
 
@@ -133,7 +135,7 @@ class DetailPageHeader extends Component {
     });
 
     const statusStyles = {
-      backgroundColor: statusColor
+      backgroundColor: statusColor,
     };
 
     icon = icon === undefined ? defaultIcon : icon;
@@ -143,15 +145,16 @@ class DetailPageHeader extends Component {
         <div className="bx--detail-page-header-content">
           {breadcrumb}
           <div className="bx--detail-page-header-title-container">
-            <div className="bx--detail-page-header-icon-container">
-              {icon}
-            </div>
+            <div className="bx--detail-page-header-icon-container">{icon}</div>
             <h1 className="bx--detail-page-header-title">{title}</h1>
             <div className="bx--detail-page-header-status-container">
-              <div style={statusStyles} className="bx--detail-page-header-status-icon" />
-              {' '}
+              <div
+                style={statusStyles}
+                className="bx--detail-page-header-status-icon"
+              />{' '}
               <span className="bx--detail-page-header-status-text">
-                {statusText}{statusContent}
+                {statusText}
+                {statusContent}
               </span>
             </div>
           </div>

--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -92,7 +92,7 @@ class Dropdown extends PureComponent {
     const children = React.Children.map(this.props.children, child =>
       React.cloneElement(child, {
         onClick: this.handleItemClick,
-      }),
+      })
     );
 
     const dropdownClasses = classNames({
@@ -110,11 +110,8 @@ class Dropdown extends PureComponent {
           onKeyPress={this.toggle}
           value={this.state.value}
           className={dropdownClasses}
-          tabIndex={tabIndex}
-        >
-          <li className="bx--dropdown-text">
-            {this.state.selectedText}
-          </li>
+          tabIndex={tabIndex}>
+          <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>
             <Icon
               name="caret--down"
@@ -123,9 +120,7 @@ class Dropdown extends PureComponent {
             />
           </li>
           <li>
-            <ul className="bx--dropdown-list">
-              {children}
-            </ul>
+            <ul className="bx--dropdown-list">{children}</ul>
           </li>
         </ul>
       </ClickListener>

--- a/components/DropdownItem.js
+++ b/components/DropdownItem.js
@@ -32,13 +32,11 @@ const DropdownItem = ({ className, value, itemText, onClick, ...other }) => {
       {...other}
       value={value}
       className={dropdownItemClasses}
-      onClick={handleClick}
-    >
+      onClick={handleClick}>
       <a
         href="#"
         onClick={/* istanbul ignore next */ evt => evt.preventDefault()}
-        className="bx--dropdown-link"
-      >
+        className="bx--dropdown-link">
         {itemText}
       </a>
     </li>

--- a/components/FileUploader.js
+++ b/components/FileUploader.js
@@ -17,7 +17,7 @@ class FileUploaderButton extends Component {
     onClick: PropTypes.func,
     role: PropTypes.string,
     tabIndex: PropTypes.number,
-    buttonKind: PropTypes.oneOf(['primary', 'secondary'])
+    buttonKind: PropTypes.oneOf(['primary', 'secondary']),
   };
   static defaultProps = {
     tabIndex: 0,
@@ -27,10 +27,10 @@ class FileUploaderButton extends Component {
     multiple: false,
     onChange: () => {},
     onClick: () => {},
-    role: 'button'
+    role: 'button',
   };
   state = {
-    labelText: this.props.labelText
+    labelText: this.props.labelText,
   };
   componentWillMount() {
     this.uid = this.props.id || uid();
@@ -67,7 +67,7 @@ class FileUploaderButton extends Component {
     } = this.props;
     const classes = classNames({
       'bx--file': true,
-      [className]: className
+      [className]: className,
     });
 
     return (
@@ -78,14 +78,12 @@ class FileUploaderButton extends Component {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();
           }
-        }}
-      >
+        }}>
         <label
           className={`bx--btn bx--btn--${buttonKind}`}
           htmlFor={this.uid}
           role={role}
-          {...other}
-        >
+          {...other}>
           {this.state.labelText}
         </label>
         <input
@@ -106,14 +104,14 @@ class Filename extends Component {
     style: PropTypes.object,
     status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
     tabIndex: PropTypes.number,
-    onKeyDown: PropTypes.func
+    onKeyDown: PropTypes.func,
   };
 
   static defaultProps = {
     onKeyDown: () => {},
     status: 'uploading',
     style: {},
-    tabIndex: 0
+    tabIndex: 0,
   };
 
   render() {
@@ -124,8 +122,7 @@ class Filename extends Component {
         <div
           className="bx--loading"
           style={Object.assign(style, { width: '1rem', height: '1rem' })}
-          {...other}
-        >
+          {...other}>
           <svg className="bx--loading__svg" viewBox="-42 -42 84 84">
             <circle cx="0" cy="0" r="37.5" />
           </svg>
@@ -162,13 +159,14 @@ class FileUploader extends Component {
     iconDescription: PropTypes.string,
     buttonLabel: PropTypes.string,
     buttonKind: PropTypes.oneOf(['primary', 'secondary']),
-    filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading']).isRequired,
+    filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
+      .isRequired,
     labelDescription: PropTypes.string,
     labelTitle: PropTypes.string,
     multiple: PropTypes.bool,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -178,12 +176,12 @@ class FileUploader extends Component {
     buttonKind: 'primary',
     multiple: false,
     onChange: () => {},
-    onClick: () => {}
+    onClick: () => {},
   };
 
   state = {
     filenames: [],
-    filenameStatus: ''
+    filenameStatus: '',
   };
 
   nodes = [];
@@ -221,17 +219,13 @@ class FileUploader extends Component {
 
     const classes = classNames({
       'bx--form-item': true,
-      [className]: className
+      [className]: className,
     });
 
     return (
       <div className={classes} {...other}>
-        <strong className="bx--label">
-          {labelTitle}
-        </strong>
-        <p className="bx--label-description">
-          {labelDescription}
-        </p>
+        <strong className="bx--label">{labelTitle}</strong>
+        <p className="bx--label-description">{labelDescription}</p>
         <FileUploaderButton
           labelText={buttonLabel}
           multiple={multiple}
@@ -242,16 +236,13 @@ class FileUploader extends Component {
         <div className="bx--file-container">
           {this.state.filenames.length === 0
             ? null
-            : this.state.filenames.map((name, index) =>
+            : this.state.filenames.map((name, index) => (
                 <span
                   key={index}
                   className="bx--file__selected-file"
                   ref={node => (this.nodes[index] = node)} // eslint-disable-line
-                  {...other}
-                >
-                  <p className="bx--file-filename">
-                    {name}
-                  </p>
+                  {...other}>
+                  <p className="bx--file-filename">{name}</p>
                   <span className="bx--file__state-container">
                     <Filename
                       iconDescription={iconDescription}
@@ -275,7 +266,7 @@ class FileUploader extends Component {
                     />
                   </span>
                 </span>
-              )}
+              ))}
         </div>
       </div>
     );

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -43,25 +43,27 @@ const Footer = ({
     className
   );
 
-  const footer = children
-    ? <footer {...other} className={classNames}>{children}</footer>
-    : <footer {...other} className={classNames}>
-        <div className="bx--footer-info">
-          <div className="bx--footer-info__item">
-            <p className="bx--footer-label">{labelOne}</p>
-            <Link href={linkHrefOne}>{linkTextOne}</Link>
-          </div>
-          <div className="bx--footer-info__item">
-            <p className="bx--footer-label">{labelTwo}</p>
-            <Link href={linkHrefTwo}>{linkTextTwo}</Link>
-          </div>
+  const footer = children ? (
+    <footer {...other} className={classNames}>
+      {children}
+    </footer>
+  ) : (
+    <footer {...other} className={classNames}>
+      <div className="bx--footer-info">
+        <div className="bx--footer-info__item">
+          <p className="bx--footer-label">{labelOne}</p>
+          <Link href={linkHrefOne}>{linkTextOne}</Link>
         </div>
-        <div className="bx--footer-cta">
-          <Button type="submit">
-            {buttonText}
-          </Button>
+        <div className="bx--footer-info__item">
+          <p className="bx--footer-label">{labelTwo}</p>
+          <Link href={linkHrefTwo}>{linkTextTwo}</Link>
         </div>
-      </footer>;
+      </div>
+      <div className="bx--footer-cta">
+        <Button type="submit">{buttonText}</Button>
+      </div>
+    </footer>
+  );
 
   return footer;
 };

--- a/components/Form.js
+++ b/components/Form.js
@@ -10,7 +10,12 @@ const propTypes = {
 const Form = ({ className, children, ...other }) => {
   const classNames = classnames('bx--form', className);
 
-  return <form className={classNames} {...other}> {children} </form>;
+  return (
+    <form className={classNames} {...other}>
+      {' '}
+      {children}{' '}
+    </form>
+  );
 };
 
 Form.propTypes = propTypes;

--- a/components/FormGroup.js
+++ b/components/FormGroup.js
@@ -8,13 +8,13 @@ const propTypes = {
   className: PropTypes.string,
   invalid: PropTypes.bool,
   message: PropTypes.bool,
-  messageText: PropTypes.string
+  messageText: PropTypes.string,
 };
 const defaultProps = {
   invalid: false,
   message: false,
   messageText: 'Provide message text',
-  legendText: 'Provide legend text'
+  legendText: 'Provide legend text',
 };
 
 const FormGroup = ({
@@ -33,17 +33,12 @@ const FormGroup = ({
     <fieldset
       {...invalid && { 'data-invalid': '' }}
       className={classNamesFieldset}
-      {...other}
-    >
-      <legend className={classNamesLegend}>
-        {legendText}
-      </legend>
+      {...other}>
+      <legend className={classNamesLegend}>{legendText}</legend>
       {children}
-      {message
-        ? <div className="bx--form__requirements">
-            {messageText}
-          </div>
-        : null}
+      {message ? (
+        <div className="bx--form__requirements">{messageText}</div>
+      ) : null}
     </fieldset>
   );
 };

--- a/components/Icon.js
+++ b/components/Icon.js
@@ -12,13 +12,13 @@ const propTypes = {
   role: PropTypes.string,
   style: PropTypes.object,
   viewBox: PropTypes.string,
-  width: PropTypes.string
+  width: PropTypes.string,
 };
 
 const defaultProps = {
   fillRule: 'evenodd',
   role: 'img',
-  description: 'Provide a description that will be used as the title'
+  description: 'Provide a description that will be used as the title',
 };
 
 /**
@@ -62,26 +62,30 @@ export function getSvgData(iconName) {
  * svgShapes(svgData);
  */
 export function svgShapes(svgData) {
-  const svgElements = Object.keys(svgData).filter(key => svgData[key]).map(svgProp => {
-    const data = svgData[svgProp];
+  const svgElements = Object.keys(svgData)
+    .filter(key => svgData[key])
+    .map(svgProp => {
+      const data = svgData[svgProp];
 
-    if (svgProp === 'circles') {
-      return data.map((circle, index) => {
-        const circleProps = {
-          cx: circle.cx,
-          cy: circle.cy,
-          r: circle.r,
-          key: `circle${index}`
-        };
+      if (svgProp === 'circles') {
+        return data.map((circle, index) => {
+          const circleProps = {
+            cx: circle.cx,
+            cy: circle.cy,
+            r: circle.r,
+            key: `circle${index}`,
+          };
 
-        return <circle {...circleProps} />;
-      });
-    } else if (svgProp === 'paths') {
-      return data.map((path, index) => <path d={path.d} key={`key${index}`} />);
-    }
+          return <circle {...circleProps} />;
+        });
+      } else if (svgProp === 'paths') {
+        return data.map((path, index) => (
+          <path d={path.d} key={`key${index}`} />
+        ));
+      }
 
-    return '';
-  });
+      return '';
+    });
 
   return svgElements;
 }
@@ -114,7 +118,7 @@ const Icon = ({
     style,
     viewBox: icon.viewBox,
     width: width || icon.width,
-    ...other
+    ...other,
   };
 
   const svgContent = icon ? svgShapes(icon.svgData) : '';

--- a/components/InteriorLeftNav.js
+++ b/components/InteriorLeftNav.js
@@ -20,7 +20,8 @@ class InteriorLeftNav extends Component {
   };
 
   state = {
-    activeHref: this.props.activeHref || (window.location && window.location.pathname),
+    activeHref:
+      this.props.activeHref || (window.location && window.location.pathname),
     open: true,
   };
 
@@ -121,8 +122,7 @@ class InteriorLeftNav extends Component {
         aria-label="Interior Left Navigation"
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
-        {...other}
-      >
+        {...other}>
         <ul key="main_list" className="left-nav-list" role="menubar">
           {newChildren}
         </ul>

--- a/components/InteriorLeftNavItem.js
+++ b/components/InteriorLeftNavItem.js
@@ -49,13 +49,14 @@ const InteriorLeftNavItem = ({
       className={classNames}
       onClick={evt => onClick(evt, href)}
       onKeyPress={evt => onClick(evt, href)}
-      {...other}
-    >
-      {children
-        ? newChild(children, tabIndex)
-        : <a className="left-nav-list__item-link" href={href} tabIndex={tabIndex}>
-            {label}
-          </a>}
+      {...other}>
+      {children ? (
+        newChild(children, tabIndex)
+      ) : (
+        <a className="left-nav-list__item-link" href={href} tabIndex={tabIndex}>
+          {label}
+        </a>
+      )}
     </li>
   );
 };

--- a/components/InteriorLeftNavList.js
+++ b/components/InteriorLeftNavList.js
@@ -15,7 +15,7 @@ class InteriorLeftNavList extends Component {
     onItemClick: PropTypes.func,
     activeHref: PropTypes.string,
     iconDescription: PropTypes.string,
-    id: PropTypes.string
+    id: PropTypes.string,
   };
 
   static defaultProps = {
@@ -25,11 +25,11 @@ class InteriorLeftNavList extends Component {
     activeHref: '#',
     iconDescription: 'display sub navigation items',
     onListClick: /* istanbul ignore next */ () => {},
-    onItemClick: /* istanbul ignore next */ () => {}
+    onItemClick: /* istanbul ignore next */ () => {},
   };
 
   state = {
-    open: this.props.open
+    open: this.props.open,
   };
 
   toggle = evt => {
@@ -75,7 +75,7 @@ class InteriorLeftNavList extends Component {
       'left-nav-list__item',
       'left-nav-list__item--has-children',
       {
-        'left-nav-list__item--expanded': this.state.open
+        'left-nav-list__item--expanded': this.state.open,
       },
       className
     );
@@ -91,8 +91,7 @@ class InteriorLeftNavList extends Component {
         onClick={this.toggle}
         onKeyPress={this.toggle}
         role="menuitem"
-        {...other}
-      >
+        {...other}>
         <a className="left-nav-list__item-link">
           {title}
           <div className="left-nav-list__item-icon">
@@ -103,7 +102,10 @@ class InteriorLeftNavList extends Component {
             />
           </div>
         </a>
-        <ul role="menu" className="left-nav-list left-nav-list--nested" aria-hidden>
+        <ul
+          role="menu"
+          className="left-nav-list left-nav-list--nested"
+          aria-hidden>
           {newChildren}
         </ul>
       </li>

--- a/components/Link.js
+++ b/components/Link.js
@@ -10,7 +10,11 @@ const propTypes = {
 
 const Link = ({ children, className, href, ...other }) => {
   const classNames = classnames('bx--link', className);
-  return <a href={href} className={classNames} {...other}>{children}</a>;
+  return (
+    <a href={href} className={classNames} {...other}>
+      {children}
+    </a>
+  );
 };
 
 Link.propTypes = propTypes;

--- a/components/ListItem.js
+++ b/components/ListItem.js
@@ -9,7 +9,11 @@ const propTypes = {
 
 const ListItem = ({ children, className, ...other }) => {
   const classNames = classnames('bx--list__item', className);
-  return <li className={classNames} {...other}>{children}</li>;
+  return (
+    <li className={classNames} {...other}>
+      {children}
+    </li>
+  );
 };
 
 ListItem.propTypes = propTypes;

--- a/components/Loading.js
+++ b/components/Loading.js
@@ -32,11 +32,11 @@ class Loading extends React.Component {
       </div>
     );
 
-    return withOverlay
-      ? <div className="bx--loading-overlay">
-          {loading}
-        </div>
-      : loading;
+    return withOverlay ? (
+      <div className="bx--loading-overlay">{loading}</div>
+    ) : (
+      loading
+    );
   }
 }
 

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -20,7 +20,7 @@ class Modal extends Component {
     onKeyDown: PropTypes.func,
     iconDescription: PropTypes.string,
     primaryButtonDisabled: PropTypes.bool,
-    onSecondarySubmit: PropTypes.func
+    onSecondarySubmit: PropTypes.func,
   };
 
   static defaultProps = {
@@ -31,7 +31,7 @@ class Modal extends Component {
     passiveModal: false,
     iconDescription: 'close the modal',
     modalHeading: 'Provide a heading',
-    modalLabel: 'Provide a label'
+    modalLabel: 'Provide a label',
   };
 
   handleKeyDown = evt => {
@@ -64,70 +64,73 @@ class Modal extends Component {
       ...other
     } = this.props;
 
-    const onSecondaryButtonClick = onSecondarySubmit ? onSecondarySubmit : onRequestClose;
+    const onSecondaryButtonClick = onSecondarySubmit
+      ? onSecondarySubmit
+      : onRequestClose;
 
     const modalClasses = classNames({
       'bx--modal': true,
       'bx--modal-tall': !passiveModal,
       'is-visible': open,
-      [this.props.className]: this.props.className
+      [this.props.className]: this.props.className,
     });
 
-    const modalLabelContent = modalLabel
-      ? <h4 className="bx--modal-header__label">{modalLabel}</h4>
-      : '';
+    const modalLabelContent = modalLabel ? (
+      <h4 className="bx--modal-header__label">{modalLabel}</h4>
+    ) : (
+      ''
+    );
 
-    const modalBody = passiveModal
-      ? <div ref="modalInner" className="bx--modal-container">
-          <div className="bx--modal-header">
-            <button className="bx--modal-close" type="button" onClick={onRequestClose}>
-              <Icon
-                name="close"
-                className="bx--modal-close__icon"
-                description={iconDescription}
-              />
-            </button>
-            {modalLabelContent}
-            <h2 className="bx--modal-header__heading">
-              {modalHeading}
-            </h2>
-          </div>
-          <div className="bx--modal-content">
-            {this.props.children}
+    const modalBody = passiveModal ? (
+      <div ref="modalInner" className="bx--modal-container">
+        <div className="bx--modal-header">
+          <button
+            className="bx--modal-close"
+            type="button"
+            onClick={onRequestClose}>
+            <Icon
+              name="close"
+              className="bx--modal-close__icon"
+              description={iconDescription}
+            />
+          </button>
+          {modalLabelContent}
+          <h2 className="bx--modal-header__heading">{modalHeading}</h2>
+        </div>
+        <div className="bx--modal-content">{this.props.children}</div>
+      </div>
+    ) : (
+      <div ref="modalInner" className="bx--modal-container">
+        <div className="bx--modal-header">
+          {modalLabelContent}
+          <h2 className="bx--modal-header__heading">{modalHeading}</h2>
+          <button
+            className="bx--modal-close"
+            type="button"
+            onClick={onRequestClose}>
+            <Icon
+              name="close"
+              className="bx--modal-close__icon"
+              description={iconDescription}
+            />
+          </button>
+        </div>
+        <div className="bx--modal-content">{this.props.children}</div>
+        <div className="bx--modal-footer">
+          <div className="bx--modal__buttons-container">
+            <Button kind="secondary" onClick={onSecondaryButtonClick}>
+              {secondaryButtonText}
+            </Button>
+            <Button
+              kind="primary"
+              disabled={primaryButtonDisabled}
+              onClick={onRequestSubmit}>
+              {primaryButtonText}
+            </Button>
           </div>
         </div>
-      : <div ref="modalInner" className="bx--modal-container">
-          <div className="bx--modal-header">
-            {modalLabelContent}
-            <h2 className="bx--modal-header__heading">
-              {modalHeading}
-            </h2>
-            <button className="bx--modal-close" type="button" onClick={onRequestClose}>
-              <Icon
-                name="close"
-                className="bx--modal-close__icon"
-                description={iconDescription}
-              />
-            </button>
-          </div>
-          <div className="bx--modal-content">
-            {this.props.children}
-          </div>
-          <div className="bx--modal-footer">
-            <div className="bx--modal__buttons-container">
-              <Button kind="secondary" onClick={onSecondaryButtonClick}>
-                {secondaryButtonText}
-              </Button>
-              <Button
-                kind="primary"
-                disabled={primaryButtonDisabled}
-                onClick={onRequestSubmit}
-              >
-                {primaryButtonText}
-              </Button>
-            </div>
-          </div>
-        </div>;
+      </div>
+    );
 
     const modal = (
       <div
@@ -135,8 +138,7 @@ class Modal extends Component {
         onKeyDown={this.handleKeyDown}
         onClick={this.handleClick}
         className={modalClasses}
-        tabIndex={-1}
-      >
+        tabIndex={-1}>
         {modalBody}
       </div>
     );

--- a/components/ModalWrapper.js
+++ b/components/ModalWrapper.js
@@ -74,8 +74,7 @@ class ModalWrapper extends React.Component {
             this.handleClose();
             this.props.onKeyDown(evt);
           }
-        }}
-      >
+        }}>
         <Button onClick={this.handleOpen}>{buttonTriggerText}</Button>
         <Modal {...props} {...other}>
           {this.props.children}

--- a/components/Module.js
+++ b/components/Module.js
@@ -35,9 +35,7 @@ const Module = ({ children, className, size, ...other }) => {
 
   return (
     <div className={wrapperClasses} {...other}>
-      <div className="bx--module__inner">
-        {children}
-      </div>
+      <div className="bx--module__inner">{children}</div>
     </div>
   );
 };

--- a/components/Notification.js
+++ b/components/Notification.js
@@ -10,14 +10,14 @@ class NotificationButton extends Component {
     type: PropTypes.string,
     iconDescription: PropTypes.string,
     name: PropTypes.string,
-    notificationType: PropTypes.oneOf(['toast', 'inline'])
+    notificationType: PropTypes.oneOf(['toast', 'inline']),
   };
   static defaultProps = {
     ariaLabel: 'close notificaion',
     notificationType: 'toast',
     type: 'button',
     iconDescription: 'close icon',
-    name: 'close'
+    name: 'close',
   };
   render() {
     const {
@@ -33,14 +33,14 @@ class NotificationButton extends Component {
     const buttonClasses = classNames(
       {
         'bx--toast-notification__close-button': notificationType === 'toast',
-        'bx--inline-notification__close-button': notificationType === 'inline'
+        'bx--inline-notification__close-button': notificationType === 'inline',
       },
       className
     );
 
     const iconClasses = classNames({
       'bx--toast-notification__icon': notificationType === 'toast',
-      'bx--inline-notification__close-icon': notificationType === 'inline'
+      'bx--inline-notification__close-icon': notificationType === 'inline',
     });
 
     return (
@@ -61,14 +61,14 @@ class NotificationTextDetails extends Component {
     title: PropTypes.string,
     subtitle: PropTypes.string,
     caption: PropTypes.string,
-    notificationType: PropTypes.oneOf(['toast', 'inline'])
+    notificationType: PropTypes.oneOf(['toast', 'inline']),
   };
 
   static defaultProps = {
     title: 'title',
     subtitle: 'subtitle',
     caption: 'caption',
-    notificationType: 'toast'
+    notificationType: 'toast',
   };
 
   render() {
@@ -106,7 +106,7 @@ class ToastNotification extends Component {
     caption: PropTypes.string,
     onCloseButtonClick: PropTypes.func,
     iconDescription: PropTypes.string.isRequired,
-    notificationType: PropTypes.string
+    notificationType: PropTypes.string,
   };
 
   static defaultProps = {
@@ -117,11 +117,11 @@ class ToastNotification extends Component {
     role: 'alert',
     notificationType: 'toast',
     iconDescription: 'closes notification',
-    onCloseButtonClick: () => {}
+    onCloseButtonClick: () => {},
   };
 
   state = {
-    open: true
+    open: true,
   };
 
   handleCloseButtonClick = evt => {
@@ -186,18 +186,18 @@ class InlineNotification extends Component {
     role: PropTypes.string.isRequired,
     onCloseButtonClick: PropTypes.func,
     iconDescription: PropTypes.string.isRequired,
-    notificationType: PropTypes.string
+    notificationType: PropTypes.string,
   };
 
   static defaultProps = {
     role: 'alert',
     notificationType: 'inline',
     iconDescription: 'closes notification',
-    onCloseButtonClick: () => {}
+    onCloseButtonClick: () => {},
   };
 
   state = {
-    open: true
+    open: true,
   };
 
   handleCloseButtonClick = evt => {
@@ -268,18 +268,18 @@ class Notification extends Component {
     subtitle: PropTypes.string.isRequired,
     caption: PropTypes.string,
     onCloseButtonClick: PropTypes.func,
-    iconDescription: PropTypes.string.isRequired
+    iconDescription: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
     onCloseButtonClick: () => {},
     iconDescription: 'closes notification',
     title: 'Provide a title',
-    subtitle: 'Provide a subtitle'
+    subtitle: 'Provide a subtitle',
   };
 
   state = {
-    open: true
+    open: true,
   };
 
   handleCloseButtonClick = evt => {
@@ -318,11 +318,15 @@ class Notification extends Component {
         'bx--inline-notification',
         { [`bx--inline-notification--${this.props.kind}`]: this.props.kind },
         className
-      )
+      ),
     };
 
     const toastHTML = (
-      <div {...other} role="alert" kind={kind} className={notificationClasses.toast}>
+      <div
+        {...other}
+        role="alert"
+        kind={kind}
+        className={notificationClasses.toast}>
         <NotificationTextDetails
           title={title}
           subtitle={subtitle}
@@ -337,7 +341,11 @@ class Notification extends Component {
     );
 
     const inlineHTML = (
-      <div {...other} role="alert" kind={kind} className={notificationClasses.inline}>
+      <div
+        {...other}
+        role="alert"
+        kind={kind}
+        className={notificationClasses.inline}>
         <div className="bx--inline-notification__details">
           <Icon
             description={this.props.iconDescription}
@@ -367,5 +375,5 @@ export {
   ToastNotification,
   InlineNotification,
   NotificationButton,
-  NotificationTextDetails
+  NotificationTextDetails,
 };

--- a/components/NumberInput.js
+++ b/components/NumberInput.js
@@ -22,14 +22,14 @@ class NumberInput extends Component {
     disabled: false,
     iconDescription: 'choose a number',
     label: ' ',
-    onChange: () => { },
-    onClick: () => { },
+    onChange: () => {},
+    onClick: () => {},
     step: 1,
     value: 0,
   };
 
   constructor(props) {
-    super(props)
+    super(props);
 
     let value = props.value;
     if (props.min || props.min === 0) {
@@ -37,7 +37,7 @@ class NumberInput extends Component {
     }
 
     this.state = {
-      value
+      value,
     };
   }
 
@@ -58,13 +58,15 @@ class NumberInput extends Component {
   };
 
   handleArrowClick = (evt, direction) => {
-    let value = typeof this.state.value === 'string'
-      ? Number(this.state.value)
-      : this.state.value;
+    let value =
+      typeof this.state.value === 'string'
+        ? Number(this.state.value)
+        : this.state.value;
     const { disabled, min, max, step } = this.props;
-    const conditional = direction === 'down'
-      ? (min !== undefined && value > min) || min === undefined
-      : (max !== undefined && value < max) || max === undefined;
+    const conditional =
+      direction === 'down'
+        ? (min !== undefined && value > min) || min === undefined
+        : (max !== undefined && value < max) || max === undefined;
 
     if (!disabled && conditional) {
       value = direction === 'down' ? value - step : value + step;
@@ -105,14 +107,15 @@ class NumberInput extends Component {
 
     return (
       <div className="bx--form-item">
-        <label htmlFor={id} className="bx--label">{label}</label>
+        <label htmlFor={id} className="bx--label">
+          {label}
+        </label>
         <div className={numberInputClasses}>
           <input type="number" pattern="[0-9]*" {...other} {...props} />
           <div className="bx--number__controls">
             <button
               className="bx--number__control-btn"
-              onClick={evt => this.handleArrowClick(evt, 'up')}
-            >
+              onClick={evt => this.handleArrowClick(evt, 'up')}>
               <Icon
                 className="up-icon"
                 name="caret--up"
@@ -122,8 +125,7 @@ class NumberInput extends Component {
             </button>
             <button
               className="bx--number__control-btn"
-              onClick={evt => this.handleArrowClick(evt, 'down')}
-            >
+              onClick={evt => this.handleArrowClick(evt, 'down')}>
               <Icon
                 className="down-icon"
                 name="caret--down"

--- a/components/OrderSummary.js
+++ b/components/OrderSummary.js
@@ -38,9 +38,7 @@ class OrderSummaryHeader extends Component {
 
     return (
       <section className={classes} {...other}>
-        <p className="bx--order-header-title">
-          {title}
-        </p>
+        <p className="bx--order-header-title">{title}</p>
         {children}
       </section>
     );
@@ -82,12 +80,8 @@ class OrderSummaryCategory extends Component {
 
     return (
       <li className={classes} {...other}>
-        <p className="bx--order-category-title">
-          {categoryText}
-        </p>
-        <ul>
-          {children}
-        </ul>
+        <p className="bx--order-category-title">{categoryText}</p>
+        <ul>{children}</ul>
       </li>
     );
   }
@@ -111,12 +105,8 @@ class OrderSummaryListItem extends Component {
 
     return (
       <li className={classes} {...other}>
-        <p className="bx--order-detail">
-          {text}
-        </p>
-        <p className="bx--order-price">
-          {price}
-        </p>
+        <p className="bx--order-detail">{text}</p>
+        <p className="bx--order-price">{price}</p>
       </li>
     );
   }
@@ -151,14 +141,10 @@ class OrderSummaryTotal extends Component {
     return (
       <section className={classes} {...other}>
         <div className="bx--order-total">
-          <p className="bx--order-total-text">
-            {summaryText}
-          </p>
+          <p className="bx--order-total-text">{summaryText}</p>
           <p className="bx--order-total-price">
             {summaryPrice}
-            <span>
-              {summaryDetails}
-            </span>
+            <span>{summaryDetails}</span>
           </p>
         </div>
         {children}

--- a/components/OrderedList.js
+++ b/components/OrderedList.js
@@ -16,7 +16,11 @@ const OrderedList = ({ children, className, nested, ...other }) => {
   const classNames = classnames('bx--list--ordered', className, {
     'bx--list--nested': nested,
   });
-  return <ol className={classNames} {...other}>{children}</ol>;
+  return (
+    <ol className={classNames} {...other}>
+      {children}
+    </ol>
+  );
 };
 
 OrderedList.propTypes = propTypes;

--- a/components/OverflowMenu.js
+++ b/components/OverflowMenu.js
@@ -145,8 +145,7 @@ class OverflowMenu extends Component {
           aria-label={ariaLabel}
           id={id}
           tabIndex={tabIndex}
-          ref={this.bindMenuEl}
-        >
+          ref={this.bindMenuEl}>
           <Icon
             onClick={this.handleClick}
             className={overflowMenuIconClasses}
@@ -154,19 +153,18 @@ class OverflowMenu extends Component {
             description={iconDescription}
             style={{ width: '100%' }}
           />
-          {floatingMenu
-            ? <FloatingMenu
-                menuPosition={this.state.menuPosition}
-                menuDirection="bottom"
-                menuOffset={flipped ? menuOffsetFlip : menuOffset}
-              >
-                <ul className={overflowMenuOptionsClasses}>
-                  {childrenWithProps}
-                </ul>
-              </FloatingMenu>
-            : <ul className={overflowMenuOptionsClasses}>
+          {floatingMenu ? (
+            <FloatingMenu
+              menuPosition={this.state.menuPosition}
+              menuDirection="bottom"
+              menuOffset={flipped ? menuOffsetFlip : menuOffset}>
+              <ul className={overflowMenuOptionsClasses}>
                 {childrenWithProps}
-              </ul>}
+              </ul>
+            </FloatingMenu>
+          ) : (
+            <ul className={overflowMenuOptionsClasses}>{childrenWithProps}</ul>
+          )}
         </div>
       </ClickListener>
     );

--- a/components/OverflowMenuItem.js
+++ b/components/OverflowMenuItem.js
@@ -16,14 +16,14 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   onMouseUp: PropTypes.func,
-  closeMenu: PropTypes.func
+  closeMenu: PropTypes.func,
 };
 
 const defaultProps = {
   hasDivider: false,
   isDelete: false,
   itemText: 'Provide itemText',
-  onClick: () => {}
+  onClick: () => {},
 };
 
 const OverflowMenuItem = ({
@@ -40,10 +40,13 @@ const OverflowMenuItem = ({
     'bx--overflow-menu-options__btn'
   );
 
-  const overflowMenuItemClasses = classNames('bx--overflow-menu-options__option', {
-    'bx--overflow-menu--divider': hasDivider,
-    'bx--overflow-menu-options__option--danger': isDelete
-  });
+  const overflowMenuItemClasses = classNames(
+    'bx--overflow-menu-options__option',
+    {
+      'bx--overflow-menu--divider': hasDivider,
+      'bx--overflow-menu-options__option--danger': isDelete,
+    }
+  );
 
   const handleClick = evt => {
     onClick(evt);
@@ -56,8 +59,7 @@ const OverflowMenuItem = ({
         {...other}
         type="button"
         className={overflowMenuBtnClasses}
-        onClick={handleClick}
-      >
+        onClick={handleClick}>
         {itemText}
       </button>
     </li>

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -49,10 +49,10 @@ class Pagination extends Component {
 
   state = {
     page: this.props.page,
-    pageSize: this.props.pageSize &&
-      this.props.pageSizes.includes(this.props.pageSize)
-      ? this.props.pageSize
-      : this.props.pageSizes[0],
+    pageSize:
+      this.props.pageSize && this.props.pageSizes.includes(this.props.pageSize)
+        ? this.props.pageSize
+        : this.props.pageSizes[0],
   };
 
   componentWillMount() {
@@ -138,11 +138,10 @@ class Pagination extends Component {
             labelText={itemsPerPageText}
             hideLabel
             onChange={this.handleSizeChange}
-            value={statePageSize}
-          >
-            {pageSizes.map(size =>
+            value={statePageSize}>
+            {pageSizes.map(size => (
               <SelectItem key={size} value={size} text={String(size)} />
-            )}
+            ))}
           </Select>
           <span className="bx--pagination__text">
             {itemsPerPageText}&nbsp;&nbsp;|&nbsp;&nbsp;
@@ -150,38 +149,36 @@ class Pagination extends Component {
           <span className="bx--pagination__text">
             {pagesUnknown
               ? itemText(
-                statePageSize * (statePage - 1) + 1,
-                statePage * statePageSize,
-              )
+                  statePageSize * (statePage - 1) + 1,
+                  statePage * statePageSize
+                )
               : itemRangeText(
-                statePageSize * (statePage - 1) + 1,
-                Math.min(statePage * statePageSize, totalItems),
-                totalItems
-              )
-            }
+                  statePageSize * (statePage - 1) + 1,
+                  Math.min(statePage * statePageSize, totalItems),
+                  totalItems
+                )}
           </span>
         </div>
         <div className="bx--pagination__right">
           <span className="bx--pagination__text">
             {pagesUnknown
               ? pageText(statePage)
-              : pageRangeText(statePage, Math.ceil(totalItems / statePageSize))
-            }
+              : pageRangeText(statePage, Math.ceil(totalItems / statePageSize))}
           </span>
           <button
             className="bx--pagination__button bx--pagination__button--backward"
             onClick={this.decrementPage}
-            disabled={this.props.disabled || statePage === 1}
-          >
+            disabled={this.props.disabled || statePage === 1}>
             <Icon
               className="bx--pagination__button-icon"
               name="chevron--left"
               description={backwardText}
             />
           </button>
-          {pageInputDisabled
-            ? <span className="bx--pagination__text">|</span>
-            : <TextInput
+          {pageInputDisabled ? (
+            <span className="bx--pagination__text">|</span>
+          ) : (
+            <TextInput
               id={`bx-pagination-input-${inputId}`}
               placeholder="0"
               value={statePage}
@@ -189,7 +186,7 @@ class Pagination extends Component {
               labelText={pageNumberText}
               hideLabel
             />
-          }
+          )}
           <button
             className="bx--pagination__button bx--pagination__button--forward"
             onClick={this.incrementPage}
@@ -197,8 +194,7 @@ class Pagination extends Component {
               this.props.disabled ||
               statePage === Math.ceil(totalItems / statePageSize) ||
               isLastPage
-            }
-          >
+            }>
             <Icon
               className="bx--pagination__button-icon"
               name="chevron--right"

--- a/components/ProgressIndicator.js
+++ b/components/ProgressIndicator.js
@@ -8,54 +8,57 @@ const propTypes = {
   current: PropTypes.bool,
   complete: PropTypes.bool,
   incomplete: PropTypes.bool,
-  description: PropTypes.string
+  description: PropTypes.string,
 };
 
 const defaultProps = {
-  label: 'Provide label'
+  label: 'Provide label',
 };
 
 const ProgressStep = ({ ...props }) => {
-  const { label, description, className, current, complete, incomplete } = props;
+  const {
+    label,
+    description,
+    className,
+    current,
+    complete,
+    incomplete,
+  } = props;
 
   const classes = classnames({
     'bx--progress-step': true,
     'bx--progress-step--current': current,
     'bx--progress-step--complete': complete,
     'bx--progress-step--incomplete': incomplete,
-    [className]: className
+    [className]: className,
   });
 
   return (
     <li className={classes}>
       <svg>
-        <title>
-          {description}
-        </title>
-        {current
-          ? <g>
-              <circle
-                stroke="#3d70b2"
-                strokeWidth="5"
-                fill="transparent"
-                cx="12"
-                cy="12"
-                r="12"
-              />
-              <circle fill="#3d70b2" cx="12" cy="12" r="6" />
-            </g>
-          : null}
-        {complete
-          ? <g>
-              <circle cx="12" cy="12" r="12" />
-              <polygon points="10.3 13.6 7.7 11 6.3 12.4 10.3 16.4 17.8 9 16.4 7.6" />
-            </g>
-          : null}
+        <title>{description}</title>
+        {current ? (
+          <g>
+            <circle
+              stroke="#3d70b2"
+              strokeWidth="5"
+              fill="transparent"
+              cx="12"
+              cy="12"
+              r="12"
+            />
+            <circle fill="#3d70b2" cx="12" cy="12" r="6" />
+          </g>
+        ) : null}
+        {complete ? (
+          <g>
+            <circle cx="12" cy="12" r="12" />
+            <polygon points="10.3 13.6 7.7 11 6.3 12.4 10.3 16.4 17.8 9 16.4 7.6" />
+          </g>
+        ) : null}
         {incomplete ? <circle cx="12" cy="12" r="12" /> : null}
       </svg>
-      <p className="bx--progress-label">
-        {label}
-      </p>
+      <p className="bx--progress-label">{label}</p>
       <span className="bx--progress-line" />
     </li>
   );
@@ -68,15 +71,15 @@ class ProgressIndicator extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    currentIndex: PropTypes.number
+    currentIndex: PropTypes.number,
   };
 
   static defaultProps = {
-    currentIndex: 0
+    currentIndex: 0,
   };
 
   state = {
-    currentIndex: this.props.currentIndex
+    currentIndex: this.props.currentIndex,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -89,15 +92,15 @@ class ProgressIndicator extends Component {
     React.Children.map(this.props.children, (child, index) => {
       if (index === this.state.currentIndex) {
         return React.cloneElement(child, {
-          current: true
+          current: true,
         });
       } else if (index < this.state.currentIndex) {
         return React.cloneElement(child, {
-          complete: true
+          complete: true,
         });
       } else if (index > this.state.currentIndex) {
         return React.cloneElement(child, {
-          incomplete: true
+          incomplete: true,
         });
       }
       return null;
@@ -107,7 +110,7 @@ class ProgressIndicator extends Component {
     const { className, currentIndex, ...other } = this.props; // eslint-disable-line no-unused-vars
     const classes = classnames({
       'bx--progress': true,
-      [className]: className
+      [className]: className,
     });
     return (
       <ul className={classes} {...other}>

--- a/components/RadioButton.js
+++ b/components/RadioButton.js
@@ -13,12 +13,12 @@ class RadioButton extends React.Component {
     labelText: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   };
 
   static defaultProps = {
     labelText: 'Provide labelText',
-    onChange: () => {}
+    onChange: () => {},
   };
 
   componentWillMount() {
@@ -30,7 +30,10 @@ class RadioButton extends React.Component {
   };
 
   render() {
-    const wrapperClasses = classNames('radioButtonWrapper', this.props.className);
+    const wrapperClasses = classNames(
+      'radioButtonWrapper',
+      this.props.className
+    );
 
     const { labelText, ...other } = this.props;
 

--- a/components/Search.js
+++ b/components/Search.js
@@ -13,7 +13,7 @@ class Search extends Component {
     labelText: PropTypes.string,
     id: PropTypes.string,
     searchButtonLabelText: PropTypes.string,
-    layoutButtonLabelText: PropTypes.string
+    layoutButtonLabelText: PropTypes.string,
   };
 
   static defaultProps = {
@@ -21,12 +21,12 @@ class Search extends Component {
     small: false,
     placeHolderText: '',
     onChange: () => {},
-    labelText: 'Provide labelText'
+    labelText: 'Provide labelText',
   };
 
   state = {
     format: 'list',
-    hasContent: this.props.value || this.props.defaultValue || false
+    hasContent: this.props.value || this.props.defaultValue || false,
   };
 
   clearInput = evt => {
@@ -36,8 +36,8 @@ class Search extends Component {
     } else {
       const clearedEvt = Object.assign({}, evt.target, {
         target: {
-          value: ''
-        }
+          value: '',
+        },
       });
       this.props.onChange(clearedEvt);
     }
@@ -48,18 +48,18 @@ class Search extends Component {
   toggleLayout = () => {
     if (this.state.format === 'list') {
       this.setState({
-        format: 'grid'
+        format: 'grid',
       });
     } else {
       this.setState({
-        format: 'list'
+        format: 'list',
       });
     }
   };
 
   handleChange = evt => {
     this.setState({
-      hasContent: evt.target.value !== ''
+      hasContent: evt.target.value !== '',
     });
 
     this.props.onChange(evt);
@@ -72,9 +72,12 @@ class Search extends Component {
         <button
           className="bx--search-button"
           type="button"
-          aria-label={this.props.searchButtonLabelText}
-        >
-          <Icon name="filter--glyph" description="filter" className="bx--search-filter" />
+          aria-label={this.props.searchButtonLabelText}>
+          <Icon
+            name="filter--glyph"
+            description="filter"
+            className="bx--search-filter"
+          />
         </button>
       );
     }
@@ -88,19 +91,24 @@ class Search extends Component {
           className="bx--search-button"
           type="button"
           onClick={this.toggleLayout}
-          aria-label={this.props.layoutButtonLabelText}
-        >
-          {this.state.format === 'list'
-            ? <div className="bx--search__toggle-layout__container">
-                <Icon name="list" description="list" className="bx--search-view" />
-              </div>
-            : <div className="bx--search__toggle-layout__container">
-                <Icon
-                  name="grid"
-                  description="toggle-layout"
-                  className="bx--search-view"
-                />
-              </div>}
+          aria-label={this.props.layoutButtonLabelText}>
+          {this.state.format === 'list' ? (
+            <div className="bx--search__toggle-layout__container">
+              <Icon
+                name="list"
+                description="list"
+                className="bx--search-view"
+              />
+            </div>
+          ) : (
+            <div className="bx--search__toggle-layout__container">
+              <Icon
+                name="grid"
+                description="toggle-layout"
+                className="bx--search-view"
+              />
+            </div>
+          )}
         </button>
       );
     }
@@ -123,12 +131,12 @@ class Search extends Component {
       'bx--search bx--search-with-options': true,
       'bx--search--lg': !small,
       'bx--search--sm': small,
-      [className]: className
+      [className]: className,
     });
 
     const clearClasses = classNames({
       'bx--search-close': true,
-      'bx--search-close--hidden': !hasContent
+      'bx--search-close--hidden': !hasContent,
     });
 
     return (

--- a/components/Select.js
+++ b/components/Select.js
@@ -44,13 +44,29 @@ const Select = ({
   });
   return (
     <div className="bx--form-item">
-      {!inline ? <label htmlFor={id} className={labelClasses}>{labelText}</label> : null}
+      {!inline ? (
+        <label htmlFor={id} className={labelClasses}>
+          {labelText}
+        </label>
+      ) : null}
       <div className={selectClasses}>
-        {inline ? <label htmlFor={id} className={labelClasses}>{labelText}</label> : null}
-        <select {...other} id={id} className="bx--select-input" disabled={disabled}>
+        {inline ? (
+          <label htmlFor={id} className={labelClasses}>
+            {labelText}
+          </label>
+        ) : null}
+        <select
+          {...other}
+          id={id}
+          className="bx--select-input"
+          disabled={disabled}>
           {children}
         </select>
-        <Icon name="caret--down" className="bx--select__arrow" description={iconDescription} />
+        <Icon
+          name="caret--down"
+          className="bx--select__arrow"
+          description={iconDescription}
+        />
       </div>
     </div>
   );

--- a/components/SelectItem.js
+++ b/components/SelectItem.js
@@ -29,8 +29,7 @@ const SelectItem = ({ className, value, disabled, hidden, text, ...other }) => {
       className={selectItemClasses}
       value={value}
       disabled={disabled}
-      hidden={hidden}
-    >
+      hidden={hidden}>
       {text}
     </option>
   );

--- a/components/SelectItemGroup.js
+++ b/components/SelectItemGroup.js
@@ -6,18 +6,28 @@ const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired
+  label: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   disabled: false,
-  label: 'Provide label'
+  label: 'Provide label',
 };
 
-const SelectItemGroup = ({ children, className, disabled, label, ...other }) => {
+const SelectItemGroup = ({
+  children,
+  className,
+  disabled,
+  label,
+  ...other
+}) => {
   const classNames = classnames('bx--select-optgroup', className);
   return (
-    <optgroup className={classNames} label={label} disabled={disabled} {...other}>
+    <optgroup
+      className={classNames}
+      label={label}
+      disabled={disabled}
+      {...other}>
       {children}
     </optgroup>
   );

--- a/components/Slider.js
+++ b/components/Slider.js
@@ -28,7 +28,7 @@ class Slider extends PureComponent {
     disabled: false,
     minLabel: '',
     maxLabel: '',
-  }
+  };
 
   state = {
     dragging: false,
@@ -46,7 +46,7 @@ class Slider extends PureComponent {
     }
   }
 
-  updatePosition = (evt) => {
+  updatePosition = evt => {
     if (evt && this.props.disabled) {
       return;
     }
@@ -63,33 +63,25 @@ class Slider extends PureComponent {
 
     requestAnimationFrame(() => {
       this.setState((prevState, props) => {
-        const {
-          left,
-          newValue,
-        } = this.calcValue(evt, prevState, props);
+        const { left, newValue } = this.calcValue(evt, prevState, props);
 
         props.onChange({ value: newValue });
         return {
           dragging: false,
           left,
           value: newValue,
-        }
+        };
       });
     });
-  }
+  };
 
   calcValue = (evt, prevState, props) => {
-    const {
-      min,
-      max,
-      step,
-      stepMuliplier,
-    } = props;
+    const { min, max, step, stepMuliplier } = props;
 
     const { value } = prevState;
 
     const range = max - min;
-    const valuePercentage = (((value - min) / range) * 100);
+    const valuePercentage = (value - min) / range * 100;
 
     let left;
     let newValue;
@@ -108,21 +100,20 @@ class Slider extends PureComponent {
         }[evt.which];
 
         if (direction !== undefined) {
-          const multiplier = evt.shiftKey === true
-            ? (range / step) / stepMuliplier
-            : 1;
+          const multiplier =
+            evt.shiftKey === true ? range / step / stepMuliplier : 1;
           const stepMultiplied = step * multiplier;
-          const stepSize = (stepMultiplied / range) * 100;
-          left = valuePercentage + (stepSize * direction);
-          newValue = Number(value) + (stepMultiplied * direction);
+          const stepSize = stepMultiplied / range * 100;
+          left = valuePercentage + stepSize * direction;
+          newValue = Number(value) + stepMultiplied * direction;
         }
       }
       if (type === 'mousemove' || type === 'click' || type === 'touchmove') {
         const clientX = evt.touches ? evt.touches[0].clientX : evt.clientX;
         const track = this.track.getBoundingClientRect();
-        const ratio = ((clientX - track.left) / track.width);
-        const rounded = min + (Math.round(((range * ratio) / step)) * step);
-        left = (((rounded - min) / range) * 100);
+        const ratio = (clientX - track.left) / track.width;
+        const rounded = min + Math.round(range * ratio / step) * step;
+        left = (rounded - min) / range * 100;
         newValue = rounded;
       }
     }
@@ -137,36 +128,66 @@ class Slider extends PureComponent {
     }
 
     return { left, newValue };
-  }
+  };
 
   handleMouseStart = () => {
-    this.element.ownerDocument.addEventListener('mousemove', this.updatePosition)
-    this.element.ownerDocument.addEventListener('mouseup', this.handleMouseEnd)
-  }
+    this.element.ownerDocument.addEventListener(
+      'mousemove',
+      this.updatePosition
+    );
+    this.element.ownerDocument.addEventListener('mouseup', this.handleMouseEnd);
+  };
 
   handleMouseEnd = () => {
-    this.element.ownerDocument.removeEventListener('mousemove', this.updatePosition)
-    this.element.ownerDocument.removeEventListener('mouseup', this.handleMouseEnd)
-  }
+    this.element.ownerDocument.removeEventListener(
+      'mousemove',
+      this.updatePosition
+    );
+    this.element.ownerDocument.removeEventListener(
+      'mouseup',
+      this.handleMouseEnd
+    );
+  };
 
   handleTouchStart = () => {
-    this.element.ownerDocument.addEventListener('touchmove', this.updatePosition);
+    this.element.ownerDocument.addEventListener(
+      'touchmove',
+      this.updatePosition
+    );
     this.element.ownerDocument.addEventListener('touchup', this.handleTouchEnd);
-    this.element.ownerDocument.addEventListener('touchend', this.handleTouchEnd);
-    this.element.ownerDocument.addEventListener('touchcancel', this.handleTouchEnd);
-  }
+    this.element.ownerDocument.addEventListener(
+      'touchend',
+      this.handleTouchEnd
+    );
+    this.element.ownerDocument.addEventListener(
+      'touchcancel',
+      this.handleTouchEnd
+    );
+  };
 
   handleTouchEnd = () => {
-    this.element.ownerDocument.removeEventListener('touchmove', this.updatePosition);
-    this.element.ownerDocument.removeEventListener('touchup', this.handleTouchEnd);
-    this.element.ownerDocument.removeEventListener('touchend', this.handleTouchEnd);
-    this.element.ownerDocument.removeEventListener('touchcancel', this.handleTouchEnd);
-  }
+    this.element.ownerDocument.removeEventListener(
+      'touchmove',
+      this.updatePosition
+    );
+    this.element.ownerDocument.removeEventListener(
+      'touchup',
+      this.handleTouchEnd
+    );
+    this.element.ownerDocument.removeEventListener(
+      'touchend',
+      this.handleTouchEnd
+    );
+    this.element.ownerDocument.removeEventListener(
+      'touchcancel',
+      this.handleTouchEnd
+    );
+  };
 
-  handleChange = (evt) => {
+  handleChange = evt => {
     this.setState({ value: evt.target.value });
     this.updatePosition(evt);
-  }
+  };
 
   render() {
     const {
@@ -186,45 +207,48 @@ class Slider extends PureComponent {
       ...other
     } = this.props;
 
-    const {
-      value,
-      left,
-    } = this.state;
+    const { value, left } = this.state;
 
     const sliderClasses = classNames(
       'bx--slider',
       { 'bx--slider--disabled': disabled },
-      className,
+      className
     );
 
     const filledTrackStyle = {
       transform: `translate(0%, -50%) scaleX(${left / 100})`,
-    }
+    };
     const thumbStyle = {
       left: `${left}%`,
-    }
+    };
 
     return (
       <div className="bx--form-item">
-        <label htmlFor={id} className="bx--label">{labelText}</label>
+        <label htmlFor={id} className="bx--label">
+          {labelText}
+        </label>
         <div className="bx--slider-container">
-          <span className="bx--slider__range-label">{min}{minLabel}</span>
+          <span className="bx--slider__range-label">
+            {min}
+            {minLabel}
+          </span>
           <div
             className={sliderClasses}
             ref={node => {
               this.element = node;
             }}
             onClick={this.updatePosition}
-            {...other}
-          >
+            {...other}>
             <div
               className="bx--slider__track"
               ref={node => {
                 this.track = node;
               }}
-            >
-            </div>
-            <div className="bx--slider__filled-track" style={filledTrackStyle}></div>
+            />
+            <div
+              className="bx--slider__filled-track"
+              style={filledTrackStyle}
+            />
             <div
               className="bx--slider__thumb"
               tabIndex="0"
@@ -232,8 +256,7 @@ class Slider extends PureComponent {
               onMouseDown={this.handleMouseStart}
               onTouchStart={this.handleTouchStart}
               onKeyDown={this.updatePosition}
-            >
-            </div>
+            />
             <input
               id={id}
               type="hidden"
@@ -246,15 +269,18 @@ class Slider extends PureComponent {
               onChange={this.handleChange}
             />
           </div>
-          <span className="bx--slider__range-label">{max}{maxLabel}</span>
-          {!hideTextInput ?
+          <span className="bx--slider__range-label">
+            {max}
+            {maxLabel}
+          </span>
+          {!hideTextInput ? (
             <TextInput
               id="input-for-slider"
               className="bx-slider-text-input"
               value={value}
               onChange={this.handleChange}
             />
-          : null }
+          ) : null}
         </div>
       </div>
     );

--- a/components/Slider.js
+++ b/components/Slider.js
@@ -51,7 +51,7 @@ class Slider extends PureComponent {
       return;
     }
 
-    if(evt && evt.dispatchConfig) {
+    if (evt && evt.dispatchConfig) {
       evt.persist();
     }
 

--- a/components/StructuredList.js
+++ b/components/StructuredList.js
@@ -8,12 +8,12 @@ class StructuredListWrapper extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     border: PropTypes.bool,
-    selection: PropTypes.bool
+    selection: PropTypes.bool,
   };
 
   static defaultProps = {
     border: false,
-    selection: false
+    selection: false,
   };
 
   render() {
@@ -21,7 +21,7 @@ class StructuredListWrapper extends Component {
 
     const classes = classNames('bx--structured-list', className, {
       'bx--structured-list--border': border,
-      'bx--structured-list--selection': selection
+      'bx--structured-list--selection': selection,
     });
 
     return (
@@ -35,14 +35,18 @@ class StructuredListWrapper extends Component {
 class StructuredListHead extends Component {
   static propTypes = {
     children: PropTypes.node,
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {
     const { children, className, ...other } = this.props;
 
     const classes = classNames('bx--structured-list-thead', className);
-    return <div className={classes} {...other}>{children}</div>;
+    return (
+      <div className={classes} {...other}>
+        {children}
+      </div>
+    );
   }
 }
 
@@ -54,13 +58,13 @@ class StructuredListInput extends Component {
     name: PropTypes.string,
     title: PropTypes.string,
     defaultChecked: PropTypes.bool,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
   };
 
   static defaultProps = {
     onChange: () => {},
     value: 'value',
-    title: 'title'
+    title: 'title',
   };
 
   componentWillMount() {
@@ -93,7 +97,7 @@ class StructuredListRow extends Component {
     label: PropTypes.bool,
     htmlFor: PropTypes.string,
     tabIndex: PropTypes.number,
-    onKeyDown: PropTypes.func
+    onKeyDown: PropTypes.func,
   };
 
   static defaultProps = {
@@ -101,7 +105,7 @@ class StructuredListRow extends Component {
     head: false,
     label: false,
     tabIndex: 0,
-    onKeyDown: () => {}
+    onKeyDown: () => {},
   };
 
   render() {
@@ -117,22 +121,23 @@ class StructuredListRow extends Component {
     } = this.props;
 
     const classes = classNames('bx--structured-list-row', className, {
-      'bx--structured-list-row--header-row': head
+      'bx--structured-list-row--header-row': head,
     });
 
-    return label
-      ? <label
-          {...other}
-          tabIndex={tabIndex}
-          className={classes}
-          htmlFor={htmlFor}
-          onKeyDown={onKeyDown}
-        >
-          {children}
-        </label>
-      : <div {...other} className={classes}>
-          {children}
-        </div>;
+    return label ? (
+      <label
+        {...other}
+        tabIndex={tabIndex}
+        className={classes}
+        htmlFor={htmlFor}
+        onKeyDown={onKeyDown}>
+        {children}
+      </label>
+    ) : (
+      <div {...other} className={classes}>
+        {children}
+      </div>
+    );
   }
 }
 
@@ -141,22 +146,26 @@ class StructuredListBody extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     head: PropTypes.bool,
-    onKeyDown: PropTypes.func
+    onKeyDown: PropTypes.func,
   };
 
   static defaultProps = {
-    onKeyDown: () => {}
+    onKeyDown: () => {},
   };
 
   state = {
     labelRows: null,
-    rowSelected: 0
+    rowSelected: 0,
   };
 
   render() {
     const { children, className, ...other } = this.props;
     const classes = classNames('bx--structured-list-tbody', className);
-    return <div className={classes} {...other}>{children}</div>;
+    return (
+      <div className={classes} {...other}>
+        {children}
+      </div>
+    );
   }
 }
 
@@ -165,12 +174,12 @@ class StructuredListCell extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     head: PropTypes.bool,
-    noWrap: PropTypes.bool
+    noWrap: PropTypes.bool,
   };
 
   static defaultProps = {
     head: false,
-    noWrap: false
+    noWrap: false,
   };
 
   render() {
@@ -179,10 +188,14 @@ class StructuredListCell extends Component {
     const classes = classNames(className, {
       'bx--structured-list-th': head,
       'bx--structured-list-td': !head,
-      'bx--structured-list-content--nowrap': noWrap
+      'bx--structured-list-content--nowrap': noWrap,
     });
 
-    return <div className={classes} {...other}>{children}</div>;
+    return (
+      <div className={classes} {...other}>
+        {children}
+      </div>
+    );
   }
 }
 
@@ -192,5 +205,5 @@ export {
   StructuredListBody,
   StructuredListRow,
   StructuredListInput,
-  StructuredListCell
+  StructuredListCell,
 };

--- a/components/Tab.js
+++ b/components/Tab.js
@@ -15,7 +15,7 @@ class Tab extends React.Component {
     onClick: PropTypes.func.isRequired,
     onKeyDown: PropTypes.func.isRequired,
     selected: PropTypes.bool.isRequired,
-    tabIndex: PropTypes.number.isRequired
+    tabIndex: PropTypes.number.isRequired,
   };
 
   static defaultProps = {
@@ -25,7 +25,7 @@ class Tab extends React.Component {
     href: '#',
     selected: false,
     onClick: () => {},
-    onKeyDown: () => {}
+    onKeyDown: () => {},
   };
 
   setTabFocus(evt) {
@@ -77,15 +77,13 @@ class Tab extends React.Component {
           onKeyDown(evt);
         }}
         role={role}
-        selected={selected}
-      >
+        selected={selected}>
         <a
           className="bx--tabs__nav-link"
           href={href}
           role="tab"
           tabIndex={tabIndex}
-          ref="tabAnchor"
-        >
+          ref="tabAnchor">
           {label}
         </a>
       </li>

--- a/components/Table.js
+++ b/components/Table.js
@@ -26,8 +26,7 @@ const Table = props => {
         style={{
           borderCollapse: 'collapse',
           borderSpacing: 0,
-        }}
-      >
+        }}>
         {children}
       </table>
     </div>

--- a/components/TableData.js
+++ b/components/TableData.js
@@ -25,14 +25,16 @@ const TableData = props => {
 
   return (
     <td {...other} className={tableDataClasses}>
-      {expanded === undefined
-        ? children
-        : <Icon
-            className={iconClasses}
-            name="chevron--right"
-            description="expand row"
-            style={style}
-          />}
+      {expanded === undefined ? (
+        children
+      ) : (
+        <Icon
+          className={iconClasses}
+          name="chevron--right"
+          description="expand row"
+          style={style}
+        />
+      )}
     </td>
   );
 };

--- a/components/TableHeader.js
+++ b/components/TableHeader.js
@@ -19,17 +19,20 @@ const TableHeader = props => {
 
   let sortContent;
   if (sortDir) {
-    sortContent = sortDir === 'DESC'
-      ? <Icon
+    sortContent =
+      sortDir === 'DESC' ? (
+        <Icon
           name="caret--down"
           description="descending sort"
           className={iconClasses}
         />
-      : <Icon
+      ) : (
+        <Icon
           name="caret--up"
           description="ascending sort"
           className={iconClasses}
-        />;
+        />
+      );
   } else {
     sortContent = '';
   }

--- a/components/TableRowExpanded.js
+++ b/components/TableRowExpanded.js
@@ -30,9 +30,7 @@ const TableRowExpanded = props => {
 
   return (
     <tr {...other} className={tableRowClasses}>
-      <td colSpan={colSpan}>
-        {children}
-      </td>
+      <td colSpan={colSpan}>{children}</td>
     </tr>
   );
 };

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -16,7 +16,7 @@ class Tabs extends React.Component {
     onKeyDown: PropTypes.func,
     triggerHref: PropTypes.string.isRequired,
     selected: PropTypes.number,
-    iconDescription: PropTypes.string.isRequired
+    iconDescription: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
@@ -24,13 +24,13 @@ class Tabs extends React.Component {
     role: 'navigation',
     href: '#',
     triggerHref: '#',
-    selected: 0
+    selected: 0,
   };
 
   state = {
     dropdownHidden: true,
     selected: this.props.selected,
-    selectedLabel: React.Children.toArray(this.props.children)[0].props.label
+    selectedLabel: React.Children.toArray(this.props.children)[0].props.label,
   };
 
   componentWillReceiveProps({ selected }) {
@@ -49,7 +49,7 @@ class Tabs extends React.Component {
     this.setState({
       selected: index,
       selectedLabel: label,
-      dropdownHidden: !this.state.dropdownHidden
+      dropdownHidden: !this.state.dropdownHidden,
     });
   };
 
@@ -60,7 +60,7 @@ class Tabs extends React.Component {
       this.setState({
         selected: index,
         selectedLabel: label,
-        dropdownHidden: !this.state.dropdownHidden
+        dropdownHidden: !this.state.dropdownHidden,
       });
     }
   };
@@ -85,12 +85,18 @@ class Tabs extends React.Component {
 
   handleDropdownClick = () => {
     this.setState({
-      dropdownHidden: !this.state.dropdownHidden
+      dropdownHidden: !this.state.dropdownHidden,
     });
   };
 
   render() {
-    const { iconDescription, className, triggerHref, role, ...other } = this.props;
+    const {
+      iconDescription,
+      className,
+      triggerHref,
+      role,
+      ...other
+    } = this.props;
 
     const tabsWithProps = this.getTabs().map((tab, index) => {
       const newTab = React.cloneElement(tab, {
@@ -99,7 +105,7 @@ class Tabs extends React.Component {
         handleTabClick: this.handleTabClick,
         handleTabAnchorFocus: this.handleTabAnchorFocus,
         ref: `tab${index}`,
-        handleTabKeyDown: this.handleTabKeyDown
+        handleTabKeyDown: this.handleTabKeyDown,
       });
 
       return newTab;
@@ -109,7 +115,10 @@ class Tabs extends React.Component {
       const { children, selected } = tab.props;
 
       return (
-        <TabContent className="tab-content" hidden={!selected} selected={selected}>
+        <TabContent
+          className="tab-content"
+          hidden={!selected}
+          selected={selected}>
           {children}
         </TabContent>
       );
@@ -118,8 +127,8 @@ class Tabs extends React.Component {
     const classes = {
       tabs: classNames('bx--tabs', className),
       tablist: classNames('bx--tabs__nav', {
-        'bx--tabs__nav--hidden': this.state.dropdownHidden
-      })
+        'bx--tabs__nav--hidden': this.state.dropdownHidden,
+      }),
     };
 
     return (
@@ -129,8 +138,7 @@ class Tabs extends React.Component {
             <a
               className="bx--tabs-trigger-text"
               href={triggerHref}
-              onClick={this.handleDropdownClick}
-            >
+              onClick={this.handleDropdownClick}>
               {this.state.selectedLabel}
             </a>
             <Icon description={iconDescription} name="caret--down" />

--- a/components/Tag.js
+++ b/components/Tag.js
@@ -24,7 +24,9 @@ const Tag = ({ children, className, type, ...other }) => {
   const tagClass = `bx--tag--${type}`;
   const tagClasses = classNames('bx--tag', tagClass, className);
   return (
-    <span className={tagClasses} {...other}>{children || TYPES[type]}</span>
+    <span className={tagClasses} {...other}>
+      {children || TYPES[type]}
+    </span>
   );
 };
 

--- a/components/TextArea.js
+++ b/components/TextArea.js
@@ -15,7 +15,7 @@ const propTypes = {
   rows: PropTypes.number,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   invalid: PropTypes.bool,
-  invalidText: PropTypes.string
+  invalidText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -27,7 +27,7 @@ const defaultProps = {
   cols: 50,
   invalid: false,
   labelText: 'Provide labelText',
-  invalidText: 'Provide invalidText'
+  invalidText: 'Provide invalidText',
 };
 
 const Textarea = ({
@@ -51,25 +51,30 @@ const Textarea = ({
       if (!other.disabled) {
         onClick(evt);
       }
-    }
+    },
   };
 
   const textareaClasses = classNames('bx--text-area', className);
-  const label = labelText
-    ? <label htmlFor={id} className="bx--label">
-        {labelText}
-      </label>
-    : null;
+  const label = labelText ? (
+    <label htmlFor={id} className="bx--label">
+      {labelText}
+    </label>
+  ) : null;
 
-  const error = invalid
-    ? <div className="bx--form-requirement">
-        {invalidText}
-      </div>
-    : null;
+  const error = invalid ? (
+    <div className="bx--form-requirement">{invalidText}</div>
+  ) : null;
 
-  const input = invalid
-    ? <textarea {...other} {...textareaProps} className={textareaClasses} data-invalid />
-    : <textarea {...other} {...textareaProps} className={textareaClasses} />;
+  const input = invalid ? (
+    <textarea
+      {...other}
+      {...textareaProps}
+      className={textareaClasses}
+      data-invalid
+    />
+  ) : (
+    <textarea {...other} {...textareaProps} className={textareaClasses} />
+  );
 
   return (
     <div className="bx--form-item">

--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -15,7 +15,7 @@ const propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hideLabel: PropTypes.bool,
   invalid: PropTypes.bool,
-  invalidText: PropTypes.string
+  invalidText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -26,7 +26,7 @@ const defaultProps = {
   onClick: () => {},
   invalid: false,
   labelText: '',
-  invalidText: 'Provide invalidText'
+  invalidText: 'Provide invalidText',
 };
 
 const TextInput = ({
@@ -55,29 +55,34 @@ const TextInput = ({
       }
     },
     placeholder,
-    type
+    type,
   };
 
   const textInputClasses = classNames('bx--text-input', className);
   const labelClasses = classNames('bx--label', {
-    'bx--visually-hidden': hideLabel
+    'bx--visually-hidden': hideLabel,
   });
 
-  const label = labelText
-    ? <label htmlFor={id} className={labelClasses}>
-        {labelText}
-      </label>
-    : null;
+  const label = labelText ? (
+    <label htmlFor={id} className={labelClasses}>
+      {labelText}
+    </label>
+  ) : null;
 
-  const error = invalid
-    ? <div className="bx--form-requirement">
-        {invalidText}
-      </div>
-    : null;
+  const error = invalid ? (
+    <div className="bx--form-requirement">{invalidText}</div>
+  ) : null;
 
-  const input = invalid
-    ? <input {...other} {...textInputProps} data-invalid className={textInputClasses} />
-    : <input {...other} {...textInputProps} className={textInputClasses} />;
+  const input = invalid ? (
+    <input
+      {...other}
+      {...textInputProps}
+      data-invalid
+      className={textInputClasses}
+    />
+  ) : (
+    <input {...other} {...textInputProps} className={textInputClasses} />
+  );
 
   return (
     <div className="bx--form-item">

--- a/components/Tile.js
+++ b/components/Tile.js
@@ -72,7 +72,7 @@ class ClickableTile extends Component {
       {
         'bx--tile--is-clicked': this.state.clicked,
       },
-      className,
+      className
     );
 
     return (
@@ -81,8 +81,7 @@ class ClickableTile extends Component {
         className={classes}
         {...other}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
-      >
+        onKeyDown={this.handleKeyDown}>
         {children}
       </a>
     );
@@ -151,7 +150,7 @@ class SelectableTile extends Component {
       {
         'bx--tile--is-selected': this.state.selected,
       },
-      className,
+      className
     );
 
     return (
@@ -161,8 +160,7 @@ class SelectableTile extends Component {
         tabIndex={tabIndex}
         {...other}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
-      >
+        onKeyDown={this.handleKeyDown}>
         <input
           ref={input => {
             this.input = input;
@@ -179,9 +177,7 @@ class SelectableTile extends Component {
         <div className="bx--tile__checkmark">
           <Icon name="checkmark--glyph" description="Tile checkmark" />
         </div>
-        <div className="bx--tile-content">
-          {children}
-        </div>
+        <div className="bx--tile-content">{children}</div>
       </label>
     );
   }
@@ -235,7 +231,7 @@ class ExpandableTile extends Component {
       },
       () => {
         this.setMaxHeight();
-      },
+      }
     );
     this.props.handleClick();
   };
@@ -260,7 +256,7 @@ class ExpandableTile extends Component {
       {
         'bx--tile--is-expanded': this.state.expanded,
       },
-      className,
+      className
     );
     const tileStyle = {
       maxHeight: this.state.tileMaxHeight,
@@ -278,8 +274,7 @@ class ExpandableTile extends Component {
         {...other}
         role="button"
         onClick={this.handleClick}
-        tabIndex={tabIndex}
-      >
+        tabIndex={tabIndex}>
         <button className="bx--tile__chevron">
           <Icon name="chevron--down" description="Tile chevron" />
         </button>
@@ -287,8 +282,7 @@ class ExpandableTile extends Component {
           ref={tileContent => {
             this.tileContent = tileContent;
           }}
-          className="bx--tile-content"
-        >
+          className="bx--tile-content">
           {content}
         </div>
       </div>
@@ -305,11 +299,7 @@ class TileAboveTheFoldContent extends Component {
   render() {
     const { children } = this.props;
 
-    return (
-      <span className="bx--tile-content__above-the-fold">
-        {children}
-      </span>
-    );
+    return <span className="bx--tile-content__above-the-fold">{children}</span>;
   }
 }
 
@@ -322,11 +312,7 @@ class TileBelowTheFoldContent extends Component {
   render() {
     const { children } = this.props;
 
-    return (
-      <span className="bx--tile-content__below-the-fold">
-        {children}
-      </span>
-    );
+    return <span className="bx--tile-content__below-the-fold">{children}</span>;
   }
 }
 

--- a/components/TimePicker.js
+++ b/components/TimePicker.js
@@ -76,17 +76,15 @@ export default class TimePicker extends Component {
       'bx--visually-hidden': hideLabel,
     });
 
-    const label = labelText
-      ? <label htmlFor={id} className={labelClasses}>
-          {labelText}
-        </label>
-      : null;
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
 
-    const error = invalid
-      ? <div className="bx--form-requirement">
-          {invalidText}
-        </div>
-      : null;
+    const error = invalid ? (
+      <div className="bx--form-requirement">{invalidText}</div>
+    ) : null;
 
     return (
       <div className="bx--form-item">

--- a/components/TimePickerSelect.js
+++ b/components/TimePickerSelect.js
@@ -21,7 +21,7 @@ export default class TimePickerSelect extends Component {
     inline: true,
     iconDescription: 'open list of options',
     hideLabel: true,
-    labelText: 'Provide label text'
+    labelText: 'Provide label text',
   };
 
   render() {
@@ -48,11 +48,11 @@ export default class TimePickerSelect extends Component {
       'bx--visually-hidden': hideLabel,
     });
 
-    const label = labelText
-      ? <label htmlFor={id} className={labelClasses}>
-          {labelText}
-        </label>
-      : null;
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
 
     return (
       <div className={selectClasses}>
@@ -61,8 +61,7 @@ export default class TimePickerSelect extends Component {
           {...other}
           id={id}
           className="bx--select-input"
-          disabled={disabled}
-        >
+          disabled={disabled}>
           {children}
         </select>
         <Icon

--- a/components/Toolbar.js
+++ b/components/Toolbar.js
@@ -5,29 +5,29 @@ import classNames from 'classnames';
 
 const propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 const toolbarItemPropTypes = {
   children: PropTypes.node,
   type: PropTypes.string,
-  placeHolderText: PropTypes.string
+  placeHolderText: PropTypes.string,
 };
 
 const toolbarTitlePropTypes = {
-  title: PropTypes.string
+  title: PropTypes.string,
 };
 
 const toolbarTitleDefaultProps = {
-  title: PropTypes.string
+  title: PropTypes.string,
 };
 
 const toolbarItemDefaultProps = {
-  placeHolderText: 'Provide placeHolderText'
+  placeHolderText: 'Provide placeHolderText',
 };
 
 const toolbarOptionPropTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 const Toolbar = ({ children, className, ...other }) => {
@@ -41,19 +41,22 @@ const Toolbar = ({ children, className, ...other }) => {
 };
 
 const ToolbarItem = ({ children, type, placeHolderText }) => {
-  const toolbarItem = type === 'search'
-    ? <ToolbarSearch placeHolderText={placeHolderText} />
-    : children;
+  const toolbarItem =
+    type === 'search' ? (
+      <ToolbarSearch placeHolderText={placeHolderText} />
+    ) : (
+      children
+    );
   return toolbarItem;
 };
 
-const ToolbarTitle = ({ title }) =>
-  <li className="bx--toolbar-menu__title">
-    {title}
-  </li>;
+const ToolbarTitle = ({ title }) => (
+  <li className="bx--toolbar-menu__title">{title}</li>
+);
 
-const ToolbarOption = ({ children }) =>
-  <li className="bx--toolbar-menu__option">{children}</li>;
+const ToolbarOption = ({ children }) => (
+  <li className="bx--toolbar-menu__option">{children}</li>
+);
 
 const ToolbarDivider = () => <hr className="bx--toolbar-menu__divider" />;
 

--- a/components/ToolbarSearch.js
+++ b/components/ToolbarSearch.js
@@ -12,7 +12,7 @@ class ToolbarSearch extends Component {
     small: PropTypes.bool,
     placeHolderText: PropTypes.string,
     labelText: PropTypes.string,
-    id: PropTypes.string
+    id: PropTypes.string,
   };
 
   static defaultProps = {
@@ -20,23 +20,23 @@ class ToolbarSearch extends Component {
     id: 'search__input',
     labelText: 'Provide labelText',
     placeHolderText: 'Provide placeHolderText',
-    role: 'search'
+    role: 'search',
   };
 
   state = {
-    expanded: false
+    expanded: false,
   };
 
   expandSearch = () => {
     this.setState({
-      expanded: !this.state.expanded
+      expanded: !this.state.expanded,
     });
     this.input.focus();
   };
 
   handleClickOutside = () => {
     this.setState({
-      expanded: false
+      expanded: false,
     });
   };
 
@@ -54,13 +54,15 @@ class ToolbarSearch extends Component {
     const searchClasses = classNames({
       'bx--search bx--search--sm bx--toolbar-search': true,
       'bx--toolbar-search--active': this.state.expanded,
-      [className]: className
+      [className]: className,
     });
 
     return (
       <ClickListener onClickOutside={this.handleClickOutside}>
         <div className={searchClasses} role={role}>
-          <label htmlFor={id} className="bx--label">{labelText}</label>
+          <label htmlFor={id} className="bx--label">
+            {labelText}
+          </label>
           <input
             {...other}
             type={type}
@@ -71,7 +73,9 @@ class ToolbarSearch extends Component {
               this.input = input;
             }}
           />
-          <button className="bx--toolbar-search__btn" onClick={this.expandSearch}>
+          <button
+            className="bx--toolbar-search__btn"
+            onClick={this.expandSearch}>
             <Icon
               name="search--glyph"
               description="search"

--- a/components/Tooltip.js
+++ b/components/Tooltip.js
@@ -13,7 +13,7 @@ class Tooltip extends Component {
     triggerText: PropTypes.string,
     showIcon: PropTypes.bool,
     iconName: PropTypes.string,
-    iconDescription: PropTypes.string
+    iconDescription: PropTypes.string,
   };
 
   static defaultProps = {
@@ -22,11 +22,11 @@ class Tooltip extends Component {
     showIcon: true,
     iconName: 'info--glyph',
     iconDescription: 'tooltip',
-    triggerText: 'Provide triggerText'
+    triggerText: 'Provide triggerText',
   };
 
   state = {
-    open: this.props.open
+    open: this.props.open,
   };
 
   componentDidMount() {
@@ -71,43 +71,45 @@ class Tooltip extends Component {
 
     return (
       <div>
-        {showIcon
-          ? <div className="bx--tooltip__trigger">
-              {triggerText}
-              <div
-                ref={node => {
-                  this.triggerEl = node;
-                }}
-                onMouseOver={() => this.handleMouse('over')}
-                onMouseOut={() => this.handleMouse('out')}
-                onFocus={() => this.handleMouse('over')}
-                onBlur={() => this.handleMouse('out')}
-              >
-                <Icon name={iconName} description={iconDescription} tabIndex="0" />
-              </div>
-            </div>
-          : <div
-              className="bx--tooltip__trigger"
+        {showIcon ? (
+          <div className="bx--tooltip__trigger">
+            {triggerText}
+            <div
               ref={node => {
                 this.triggerEl = node;
               }}
               onMouseOver={() => this.handleMouse('over')}
               onMouseOut={() => this.handleMouse('out')}
               onFocus={() => this.handleMouse('over')}
-              onBlur={() => this.handleMouse('out')}
-            >
-              {triggerText}
-            </div>}
+              onBlur={() => this.handleMouse('out')}>
+              <Icon
+                name={iconName}
+                description={iconDescription}
+                tabIndex="0"
+              />
+            </div>
+          </div>
+        ) : (
+          <div
+            className="bx--tooltip__trigger"
+            ref={node => {
+              this.triggerEl = node;
+            }}
+            onMouseOver={() => this.handleMouse('over')}
+            onMouseOut={() => this.handleMouse('out')}
+            onFocus={() => this.handleMouse('over')}
+            onBlur={() => this.handleMouse('out')}>
+            {triggerText}
+          </div>
+        )}
         <FloatingMenu
           menuPosition={this.state.triggerPosition}
           menuDirection={direction}
-          menuOffset={menuOffset}
-        >
+          menuOffset={menuOffset}>
           <div
             className={tooltipClasses}
             {...other}
-            data-floating-menu-direction={direction}
-          >
+            data-floating-menu-direction={direction}>
             {children}
           </div>
         </FloatingMenu>

--- a/components/TooltipSimple.js
+++ b/components/TooltipSimple.js
@@ -10,7 +10,7 @@ const propTypes = {
   text: PropTypes.string.isRequired,
   showIcon: PropTypes.bool,
   iconName: PropTypes.string,
-  iconDescription: PropTypes.string
+  iconDescription: PropTypes.string,
 };
 
 const defaultProps = {
@@ -18,7 +18,7 @@ const defaultProps = {
   showIcon: true,
   iconName: 'info--glyph',
   iconDescription: 'tooltip',
-  text: 'Provide text'
+  text: 'Provide text',
 };
 
 const TooltipSimple = ({
@@ -37,7 +37,11 @@ const TooltipSimple = ({
   return (
     <div className={tooltipWrapperClasses}>
       {children}
-      <div tabIndex="0" className={tooltipClasses} data-tooltip-text={text} {...other}>
+      <div
+        tabIndex="0"
+        className={tooltipClasses}
+        data-tooltip-text={text}
+        {...other}>
         {showIcon && <Icon name={iconName} description={iconDescription} />}
       </div>
     </div>

--- a/components/UnorderedList.js
+++ b/components/UnorderedList.js
@@ -16,7 +16,11 @@ const UnorderedList = ({ children, className, nested, ...other }) => {
   const classNames = classnames('bx--list--unordered', className, {
     'bx--list--nested': nested,
   });
-  return <ul className={classNames} {...other}>{children}</ul>;
+  return (
+    <ul className={classNames} {...other}>
+      {children}
+    </ul>
+  );
 };
 
 UnorderedList.propTypes = propTypes;

--- a/components/__tests__/AccordionItem-test.js
+++ b/components/__tests__/AccordionItem-test.js
@@ -51,7 +51,7 @@ describe('AccordionItem', () => {
       const item = toggler.find('li');
       expect(item.hasClass('bx--accordion__item--active')).toEqual(false);
       toggler.setState({ open: true });
-      expect(item.hasClass('bx--accordion__item--active')).toEqual(true);
+      expect(toggler.find('li').hasClass('bx--accordion__item--active')).toEqual(true);
     });
   });
 

--- a/components/__tests__/Breadcrumb-test.js
+++ b/components/__tests__/Breadcrumb-test.js
@@ -6,26 +6,29 @@ import { mount } from 'enzyme';
 describe('Breadcrumb', () => {
   describe('Renders as expected', () => {
     const breadcrumb = mount(
-        <Breadcrumb className="parent-class">
-          <BreadcrumbItem className="some-class" href="www.google.com">Breadcrumb 1</BreadcrumbItem>
-        </Breadcrumb>
-      );
-    const breadcrumbItem = breadcrumb.find('.some-class');
+      <Breadcrumb className="parent-class">
+        <BreadcrumbItem className="some-class" href="www.google.com">Breadcrumb 1</BreadcrumbItem>
+      </Breadcrumb>
+    );
+
+    const breadcrumbItem = breadcrumb.find(BreadcrumbItem);
+
     it('renders a breadcrumb', () => {
       expect(breadcrumb.length).toEqual(1);
     });
+
     it('should use the appropriate breadcrumb class', () => {
-      expect(breadcrumb.hasClass('bx--breadcrumb')).toEqual(true);
+      expect(breadcrumb.children().hasClass('bx--breadcrumb')).toEqual(true);
     });
+
     it('should add extra classes that are passed via className', () => {
       expect(breadcrumb.hasClass('parent-class')).toEqual(true);
     });
+
     it('should render children as expected', () => {
-      expect(breadcrumb.find('.some-class').length).toEqual(1);
+      expect(breadcrumb.find(BreadcrumbItem).length).toEqual(1);
     });
-    it('should render children as expected', () => {
-      expect(breadcrumb.find('.some-class').length).toEqual(1);
-    });
+
     it('should render children content as expected', () => {
       expect(breadcrumbItem.text()).toEqual('Breadcrumb 1');
     });

--- a/components/__tests__/CardContent-test.js
+++ b/components/__tests__/CardContent-test.js
@@ -64,7 +64,7 @@ describe('CardContent', () => {
         it('has expected links', () => {
           const links = title.childAt(1);
           expect(links.length).toBe(1);
-          expect(links.node.type).toBe('a');
+          expect(links.getElement().type).toBe('a');
           expect(links.hasClass('bx--about__title--link')).toBe(true);
           expect(links.props().href).toBe('http://test-card-link.mybluemix.net');
           expect(links.props().children).toBe('http://test-card-link.mybluemix.net');
@@ -73,13 +73,13 @@ describe('CardContent', () => {
         it('has expected info paragraphs', () => {
           const info1 = title.childAt(2);
           expect(info1.length).toBe(1);
-          expect(info1.node.type).toBe('h4');
+          expect(info1.getElement().type).toBe('h4');
           expect(info1.hasClass('bx--about__title--additional-info')).toBe(true);
           expect(info1.props().children).toBe('testInfo1');
 
           const info2 = title.childAt(3);
           expect(info2.length).toBe(1);
-          expect(info2.node.type).toBe('h4');
+          expect(info2.getElement().type).toBe('h4');
           expect(info2.hasClass('bx--about__title--additional-info')).toBe(true);
           expect(info2.props().children).toBe('testInfo2');
         });

--- a/components/__tests__/Checkbox-test.js
+++ b/components/__tests__/Checkbox-test.js
@@ -50,16 +50,16 @@ describe('Checkbox', () => {
       });
 
       describe('input', () => {
-        const input = wrapper.find('input');
+        const input = () => wrapper.find('input');
 
         it('has id set as expected', () => {
-          expect(input.props().id).toEqual('testing');
+          expect(input().props().id).toEqual('testing');
         });
 
         it('defaultChecked prop sets defaultChecked on input', () => {
-          expect(input.props().defaultChecked).toBeUndefined();
+          expect(input().props().defaultChecked).toBeUndefined();
           wrapper.setProps({ defaultChecked: true });
-          expect(input.props().defaultChecked).toEqual(true);
+          expect(input().props().defaultChecked).toEqual(true);
         });
       });
     });
@@ -70,11 +70,11 @@ describe('Checkbox', () => {
       <Checkbox id="test" disabled />
     );
 
-    const input = wrapper.find('input');
-    expect(input.props().disabled).toEqual(true);
+    const input = () => wrapper.find('input');
+    expect(input().props().disabled).toEqual(true);
 
     wrapper.setProps({ disabled: false });
-    expect(input.props().disabled).toEqual(false);
+    expect(input().props().disabled).toEqual(false);
   });
 
   it('checked prop on component sets checked prop on input', () => {
@@ -82,11 +82,11 @@ describe('Checkbox', () => {
       <Checkbox id="test" checked />
     );
 
-    const input = wrapper.find('input');
-    expect(input.props().checked).toEqual(true);
+    const input = () => wrapper.find('input');
+    expect(input().props().checked).toEqual(true);
 
     wrapper.setProps({ checked: false });
-    expect(input.props().checked).toEqual(false);
+    expect(input().props().checked).toEqual(false);
   });
 
   describe('events', () => {
@@ -98,7 +98,7 @@ describe('Checkbox', () => {
       );
 
       const input = wrapper.find('input');
-      const inputElement = input.get(0);
+      const inputElement = input.instance();
 
       inputElement.checked = true;
       wrapper.find('input').simulate('change');

--- a/components/__tests__/ContentSwitcher-test.js
+++ b/components/__tests__/ContentSwitcher-test.js
@@ -62,10 +62,8 @@ describe('ContentSwitcher', () => {
     );
 
     const children = wrapper.find(Switch);
-    const firstChild = children.first();
-    const secondChild = children.last();
 
-    firstChild.props().onClick(mockData);
+    children.first().props().onClick(mockData);
 
     it('should invoke onChange', () => {
       expect(onChange).toBeCalledWith(mockData);
@@ -76,6 +74,9 @@ describe('ContentSwitcher', () => {
     });
 
     it('should set selected to true on the correct child', () => {
+      wrapper.update();
+      const firstChild = wrapper.find(Switch).first();
+      const secondChild = wrapper.find(Switch).last();
       expect(firstChild.props().selected).toEqual(false);
       expect(secondChild.props().selected).toEqual(true);
     });
@@ -95,10 +96,8 @@ describe('ContentSwitcher', () => {
     );
 
     const children = wrapper.find(Switch);
-    const firstChild = children.first();
-    const secondChild = children.last();
 
-    firstChild.props().onKeyDown(mockData);
+    children.first().props().onKeyDown(mockData);
 
     it('should invoke onChange', () => {
       expect(onChange).toBeCalledWith(mockData);
@@ -109,6 +108,9 @@ describe('ContentSwitcher', () => {
     });
 
     it('should set selected to true on the correct child', () => {
+      wrapper.update();
+      const firstChild = wrapper.find(Switch).first();
+      const secondChild = wrapper.find(Switch).last();
       expect(firstChild.props().selected).toEqual(false);
       expect(secondChild.props().selected).toEqual(true);
     });

--- a/components/__tests__/CopyButton-test.js
+++ b/components/__tests__/CopyButton-test.js
@@ -60,12 +60,12 @@ describe('CopyButton', () => {
   describe('Renders feedback as expected', () => {
     it('Should make the feedback visible', () => {
       const feedbackWrapper = mount(<CopyButton feedback="Copied!" />);
-      const feedback = feedbackWrapper.find('.bx--btn--copy__feedback');
-      expect(feedback.hasClass('bx--btn--copy__feedback--displayed')).toBe(
+      const feedback = () => feedbackWrapper.find('.bx--btn--copy__feedback');
+      expect(feedback().hasClass('bx--btn--copy__feedback--displayed')).toBe(
         false,
       );
       feedbackWrapper.setState({ showFeedback: true });
-      expect(feedback.hasClass('bx--btn--copy__feedback--displayed')).toBe(
+      expect(feedback().hasClass('bx--btn--copy__feedback--displayed')).toBe(
         true,
       );
     });

--- a/components/__tests__/DatePicker-test.js
+++ b/components/__tests__/DatePicker-test.js
@@ -13,11 +13,11 @@ describe('DatePicker', () => {
     const datepicker = wrapper.childAt(0);
 
     it('has the expected classes', () => {
-      expect(datepicker.hasClass('bx--date-picker')).toBe(true);
+      expect(datepicker.children().hasClass('bx--date-picker')).toBe(true);
     });
 
     it('should add extra classes that are passed via className', () => {
-      expect(datepicker.hasClass('extra-class')).toBe(true);
+      expect(datepicker.children().hasClass('extra-class')).toBe(true);
     });
 
     it('should add the date picker type as expected', () => {
@@ -52,7 +52,7 @@ describe('DatePicker', () => {
     const datepicker = wrapper.childAt(0);
 
     it('has the simple date picker class', () => {
-      expect(datepicker.hasClass('bx--date-picker--simple')).toBe(true);
+      expect(datepicker.children().hasClass('bx--date-picker--simple')).toBe(true);
     });
 
     it('should not initalize a calendar', () => {
@@ -73,15 +73,15 @@ describe('DatePicker', () => {
     const icon = wrapper.find('svg');
 
     it('has the single date picker class', () => {
-      expect(datepicker.hasClass('bx--date-picker--single')).toBe(true);
+      expect(datepicker.children().hasClass('bx--date-picker--single')).toBe(true);
     });
 
     it('should initalize a calendar', () => {
-      expect(wrapper.node.cal).toBeDefined();
+      expect(wrapper.instance().cal).toBeDefined();
     });
 
     it('should update the classnames', () => {
-      expect(wrapper.node.cal.calendarContainer.classList.contains('bx--date-picker__calendar')).toBe(true);
+      expect(wrapper.instance().cal.calendarContainer.classList.contains('bx--date-picker__calendar')).toBe(true);
     });
 
     it('should not render an icon', () => {
@@ -104,15 +104,15 @@ describe('DatePicker', () => {
     const icon = wrapper.find('svg');
 
     it('has the range date picker class', () => {
-      expect(datepicker.hasClass('bx--date-picker--range')).toBe(true);
+      expect(datepicker.children().hasClass('bx--date-picker--range')).toBe(true);
     });
 
     it('should initalize a calendar', () => {
-      expect(wrapper.node.cal).toBeDefined();
+      expect(wrapper.instance().cal).toBeDefined();
     });
 
     it('should update the classnames', () => {
-      expect(wrapper.node.cal.calendarContainer.classList.contains('bx--date-picker__calendar')).toBe(true);
+      expect(wrapper.instance().cal.calendarContainer.classList.contains('bx--date-picker__calendar')).toBe(true);
     });
 
     it('should render an icon', () => {

--- a/components/__tests__/DetailPageHeader-test.js
+++ b/components/__tests__/DetailPageHeader-test.js
@@ -31,8 +31,8 @@ describe('DetailPageHeader', () => {
     );
 
     it('should render wrapper with the correct class', () => {
-      expect(wrapper.hasClass('bx--detail-page-header')).toEqual(true);
-      expect(wrapper.hasClass('bx--detail-page-header--no-tabs')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--detail-page-header')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--detail-page-header--no-tabs')).toEqual(true);
     });
 
     it('should render an icon', () => {
@@ -156,5 +156,5 @@ describe('DetailPageHeader', () => {
       expect(addArgs[1]).toBe(removeArgs[1]); // the scroll handler function
     });
   });
-  
+
 });

--- a/components/__tests__/Dropdown-test.js
+++ b/components/__tests__/Dropdown-test.js
@@ -103,34 +103,35 @@ describe('Dropdown', () => {
 
     it('should add the open dropdown class on click', () => {
       dropdown.simulate('click');
-      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(true);
+      expect(wrapper.find('.bx--dropdown').hasClass('bx--dropdown--open')).toEqual(true);
     });
 
     it('should toggle the open dropdown class on Enter', () => {
       wrapper.setState({ open: false });
       dropdown.simulate('keypress', { which: 13 });
-      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(true);
+      expect(wrapper.find('.bx--dropdown').hasClass('bx--dropdown--open')).toEqual(true);
       dropdown.simulate('keypress', { which: 13 });
-      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
+      expect(wrapper.find('.bx--dropdown').hasClass('bx--dropdown--open')).toEqual(false);
     });
 
     it('should toggle the open dropdown class on Space', () => {
       wrapper.setState({ open: false });
       dropdown.simulate('keypress', { which: 32 });
-      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(true);
+      expect(wrapper.find('.bx--dropdown').hasClass('bx--dropdown--open')).toEqual(true);
       dropdown.simulate('keypress', { which: 32 });
-      expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
+      expect(wrapper.find('.bx--dropdown').hasClass('bx--dropdown--open')).toEqual(false);
     });
 
     it('should update data value state when child item is clicked', () => {
-      child.simulate('click');
-      expect(dropdown.props().value).toEqual('test-child');
+      child.last().simulate('click');
+      expect(wrapper.find('.bx--dropdown').props().value).toEqual('test-child');
     });
 
     it('should update selected text when child item is clicked', () => {
-      child.simulate('click');
+      child.last().simulate('click');
       expect(wrapper.state().selectedText).toEqual('test-child');
     });
+
     it('should close dropdown on click outside', () => {
       wrapper.setState({ open: true });
       const listener = wrapper.find(ClickListener);

--- a/components/__tests__/FileUploader-test.js
+++ b/components/__tests__/FileUploader-test.js
@@ -21,7 +21,7 @@ describe('FileUploaderButton', () => {
 
   describe('Renders as expected with default props', () => {
     it('renders with expected className', () => {
-      expect(mountWrapper.hasClass('bx--file')).toBe(true);
+      expect(mountWrapper.children().hasClass('bx--file')).toBe(true);
     });
 
     it('renders with given className', () => {
@@ -86,7 +86,7 @@ describe('FileUploader', () => {
 
   describe('Renders as expected with defaults', () => {
     it('should render with default className', () => {
-      expect(mountWrapper.hasClass('bx--form-item')).toEqual(true);
+      expect(mountWrapper.children().hasClass('bx--form-item')).toEqual(true);
     });
 
     it('should render with given className', () => {

--- a/components/__tests__/Footer-test.js
+++ b/components/__tests__/Footer-test.js
@@ -16,34 +16,44 @@ describe('Footer', () => {
         buttonText="Create"
       />,
     );
+
     it('should use the appropriate footer class', () => {
-      expect(footer.hasClass('bx--footer')).toEqual(true);
+      expect(footer.children().hasClass('bx--footer')).toEqual(true);
     });
+
     it('should send the first link the correct label', () => {
       expect(footer.props().labelOne).toEqual('Need Help?');
     });
+
     it('should send the first link the correct title', () => {
       expect(footer.props().linkTextOne).toEqual('Contact Bluemix Sales');
     });
+
     it('should send the first link the href property', () => {
       expect(footer.props().linkHrefOne).toEqual('www.google.com');
     });
+
     it('should send the second link the correct label', () => {
       expect(footer.props().labelTwo).toEqual('Estimate Monthly Cost');
     });
+
     it('should send the second link the correct title', () => {
       expect(footer.props().linkTextTwo).toEqual('Cost Calculator');
     });
+
     it('should send the second link the href property', () => {
       expect(footer.props().linkHrefTwo).toEqual('www.bing.com');
     });
+
     it('should send the button the correct text', () => {
       expect(footer.props().buttonText).toEqual('Create');
     });
+
     it('should all for custom classes to be applied', () => {
       expect(footer.hasClass('some-class')).toEqual(true);
     });
   });
+
   describe('Renders children as expected', () => {
     const footer = mount(
       <Footer>
@@ -51,6 +61,7 @@ describe('Footer', () => {
         <div className="test">This is a test.</div>
       </Footer>,
     );
+
     it('should render children as expected', () => {
       expect(footer.find('.test').length).toBe(2);
     });

--- a/components/__tests__/InteriorLeftNav-test.js
+++ b/components/__tests__/InteriorLeftNav-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import InteriorLeftNav from '../InteriorLeftNav';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 describe('InteriorLeftNav', () => {
   describe('Renders as expected', () => {

--- a/components/__tests__/InteriorLeftNav-test.js
+++ b/components/__tests__/InteriorLeftNav-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import InteriorLeftNav from '../InteriorLeftNav';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 describe('InteriorLeftNav', () => {
   describe('Renders as expected', () => {
@@ -11,12 +11,15 @@ describe('InteriorLeftNav', () => {
     it('renders a interior left nav', () => {
       expect(wrapper.length).toEqual(1);
     });
+
     it('has the expected classes', () => {
-      expect(wrapper.hasClass('bx--interior-left-nav')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--interior-left-nav')).toEqual(true);
     });
+
     it('should add extra classes that are passed via className', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
+
     it('should render children as expected', () => {
       const interiorLeftNav = mount(
         <InteriorLeftNav>
@@ -31,7 +34,7 @@ describe('InteriorLeftNav', () => {
         </InteriorLeftNav>,
       );
       expect(interiorLeftNav.find('.left-nav-list').length).toEqual(2);
-      expect(interiorLeftNav.find('.test-child').length).toEqual(2);
+      expect(interiorLeftNav.find('.test-child').length).toEqual(4);
       expect(
         interiorLeftNav.find('.bx--interior-left-nav-collapse').length,
       ).toEqual(1);
@@ -45,13 +48,13 @@ describe('InteriorLeftNav', () => {
         <InteriorLeftNavList className="second" open />
       </InteriorLeftNav>,
     );
-    const first = twoLists.find('.first');
-    const second = twoLists.find('.second');
+    const first = () => twoLists.find('li.first');
+    const second = () => twoLists.find('li.second');
 
     it('should close the second list when the first is clicked', () => {
-      expect(second.hasClass('left-nav-list__item--expanded')).toBe(true);
-      first.simulate('click');
-      expect(second.hasClass('left-nav-list__item--expanded')).toBe(false);
+      expect(second().hasClass('left-nav-list__item--expanded')).toBe(true);
+      first().simulate('click');
+      expect(second().hasClass('left-nav-list__item--expanded')).toBe(false);
     });
   });
 
@@ -90,7 +93,7 @@ describe('InteriorLeftNav', () => {
 
     it('should close the nav when the toggler is clicked', () => {
       toggler.simulate('click');
-      expect(interiorLeftNav.hasClass('bx--interior-left-nav--collapsed')).toBe(
+      expect(interiorLeftNav.children().hasClass('bx--interior-left-nav--collapsed')).toBe(
         true,
       );
       expect(interiorLeftNav.state().open).toBe(false);

--- a/components/__tests__/InteriorLeftNavItem-test.js
+++ b/components/__tests__/InteriorLeftNavItem-test.js
@@ -16,27 +16,35 @@ describe('InteriorLeftNavItem', () => {
     it('renders a interior left nav item', () => {
       expect(wrapper.length).toEqual(1);
     });
+
     it('has the expected classes', () => {
-      expect(wrapper.hasClass('left-nav-list__item')).toEqual(true);
+      expect(wrapper.children().hasClass('left-nav-list__item')).toEqual(true);
     });
+
     it('should add extra classes that are passed via className', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
+
     it('should contain a default label', () => {
       expect(wrapper.find('a').text()).toEqual('link');
     });
+
     it('should contain an href', () => {
       expect(wrapper.find('a').props().href).toEqual(wrapper.props().href);
     });
+
     it('should add active class to item when activeHref is matched', () => {
-      expect(wrapper.hasClass('left-nav-list__item--active')).toEqual(true);
+      expect(wrapper.children().hasClass('left-nav-list__item--active')).toEqual(true);
     });
+
     it('has an anchor with the expected class', () => {
       expect(wrapper.find('a').hasClass('left-nav-list__item-link')).toEqual(true);
     });
+
     it('can render without a child ', () => {
       expect(wrapperNoChild.length).toEqual(1);
     });
+
     it('has an anchor that matches label when no child is given', () => {
       expect(wrapperNoChild.find('a').text()).toEqual(wrapperNoChild.props().label);
     });

--- a/components/__tests__/Loading-test.js
+++ b/components/__tests__/Loading-test.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import Loading from '../Loading';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 describe('Loading', () => {
   describe('Renders as expected', () => {

--- a/components/__tests__/Loading-test.js
+++ b/components/__tests__/Loading-test.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import Loading from '../Loading';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 describe('Loading', () => {
   describe('Renders as expected', () => {
@@ -43,11 +43,10 @@ describe('Loading', () => {
     const wrapper = mount(<Loading className="extra-class" />);
 
     it('should remove and add bx--loading--stop class', () => {
-      const loader = wrapper.find('.bx--loading');
       wrapper.setProps({ active: false });
-      expect(loader.hasClass('bx--loading--stop')).toEqual(true);
+      expect(wrapper.find('.bx--loading').hasClass('bx--loading--stop')).toEqual(true);
       wrapper.setProps({ active: true });
-      expect(loader.hasClass('bx--loading--stop')).toEqual(false);
+      expect(wrapper.find('.bx--loading').hasClass('bx--loading--stop')).toEqual(false);
     });
 
     it('should not render overlay when withOverlay is set to false', () => {

--- a/components/__tests__/Modal-test.js
+++ b/components/__tests__/Modal-test.js
@@ -90,17 +90,18 @@ describe('Modal', () => {
   describe('events', () => {
     it('should set expected class when state is open', () => {
       const wrapper = mount(<ModalWrapper />);
-      const modal = wrapper.childAt(1);
+      const modal = wrapper.find(Modal);
       const modalContainer = modal.find('.bx--modal');
       const openClass = 'is-visible';
+
       expect(modalContainer.hasClass(openClass)).not.toEqual(true);
       wrapper.setState({ open: true });
-      expect(modalContainer.hasClass(openClass)).toEqual(true);
+      expect(wrapper.find('.bx--modal').hasClass(openClass)).toEqual(true);
     });
 
     it('should set state to open when trigger button is clicked', () => {
       const wrapper = mount(<ModalWrapper />);
-      const triggerBtn = wrapper.childAt(0);
+      const triggerBtn = wrapper.children().childAt(0);
       expect(wrapper.state().open).not.toEqual(true);
       triggerBtn.simulate('click');
       expect(wrapper.state().open).toEqual(true);
@@ -108,7 +109,7 @@ describe('Modal', () => {
 
     it('should set open state to false when close button is clicked', () => {
       const wrapper = mount(<ModalWrapper />);
-      const modal = wrapper.childAt(1);
+      const modal = wrapper.find(Modal);
       const closeBtn = modal.find('.bx--modal-close');
       wrapper.setState({ open: true });
       expect(wrapper.state().open).toEqual(true);
@@ -118,7 +119,7 @@ describe('Modal', () => {
 
     it('should stay open when "inner modal" is clicked', () => {
       const wrapper = mount(<ModalWrapper />);
-      const modal = wrapper.childAt(1);
+      const modal = wrapper.find(Modal);
       const div = modal.find('.bx--modal-container');
       wrapper.setState({ open: true });
       div.simulate('click');
@@ -127,7 +128,7 @@ describe('Modal', () => {
 
     it('should close when "outer modal" is clicked...not "inner modal"', () => {
       const wrapper = mount(<ModalWrapper />);
-      const modal = wrapper.childAt(1);
+      const modal = wrapper.find(Modal);
       const div = modal.find('.bx--modal');
       wrapper.setState({ open: true });
       div.simulate('click');

--- a/components/__tests__/NumberInput-test.js
+++ b/components/__tests__/NumberInput-test.js
@@ -3,7 +3,7 @@ import { mount, shallow } from 'enzyme';
 import Icon from '../Icon';
 import NumberInput from '../NumberInput';
 
-describe('numberInput', () => {
+describe('NumberInput', () => {
   describe('should render as expected', () => {
     const wrapper = mount(
       <NumberInput min={0} max={100} id="test" label="Number Input" className="extra-class" />
@@ -34,27 +34,27 @@ describe('numberInput', () => {
       it('should set a min as expected', () => {
         expect(numberInput.props().min).toEqual(0);
         wrapper.setProps({ min: 10 });
-        expect(numberInput.props().min).toEqual(10);
+        expect(wrapper.find('input').props().min).toEqual(10);
       });
 
       it('should set a max as expected', () => {
         expect(numberInput.props().max).toEqual(100);
         wrapper.setProps({ max: 10 });
-        expect(numberInput.props().min).toEqual(10);
+        expect(wrapper.find('input').props().min).toEqual(10);
       });
 
       it('should set step as expected', () => {
         expect(numberInput.props().step).toEqual(1);
         wrapper.setProps({ step: 10 });
-        expect(numberInput.props().step).toEqual(10);
+        expect(wrapper.find('input').props().step).toEqual(10);
       });
 
       it('should set disabled as expected', () => {
         expect(numberInput.props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(numberInput.props().disabled).toEqual(true);
+        expect(wrapper.find('input').props().disabled).toEqual(true);
       });
-  
+
       describe('initial rendering', () => {
 
         const getWrapper = (min, max, value) => mount(<NumberInput min={min} max={max} value={value} id="test" label="Number Input" className="extra-class" />);
@@ -176,8 +176,8 @@ describe('numberInput', () => {
       );
 
       const input = wrapper.find('input');
-      const upArrow = wrapper.find('.up-icon');
-      const downArrow = wrapper.find('.down-icon');
+      const upArrow = wrapper.find('.up-icon').last();
+      const downArrow = wrapper.find('.down-icon').last();
 
       it('should invoke onClick when numberInput is clicked', () => {
         input.simulate('click');

--- a/components/__tests__/OrderSummaryFooter-test.js
+++ b/components/__tests__/OrderSummaryFooter-test.js
@@ -19,8 +19,8 @@ describe('OrderSummaryFooter', () => {
     });
 
     it('should render with the appropriate classes', () => {
-      expect(orderSummaryFooter.hasClass('bx--order-footer')).toEqual(true);
-      expect(orderSummaryFooter.hasClass('some-class')).toEqual(true);
+      expect(orderSummaryFooter.children().hasClass('bx--order-footer')).toEqual(true);
+      expect(orderSummaryFooter.children().hasClass('some-class')).toEqual(true);
     });
 
     it('should render with the correct footer text', () => {

--- a/components/__tests__/OrderSummaryHeader-test.js
+++ b/components/__tests__/OrderSummaryHeader-test.js
@@ -22,8 +22,8 @@ describe('OrderSummaryHeader', () => {
     });
 
     it('should render with the appropriate classes', () => {
-      expect(orderSummaryHeader.hasClass('bx--order-header')).toEqual(true);
-      expect(orderSummaryHeader.hasClass('some-class')).toEqual(true);
+      expect(orderSummaryHeader.children().hasClass('bx--order-header')).toEqual(true);
+      expect(orderSummaryHeader.children().hasClass('some-class')).toEqual(true);
     });
 
     it('should render with the correct title', () => {

--- a/components/__tests__/OverflowMenu-test.js
+++ b/components/__tests__/OverflowMenu-test.js
@@ -83,7 +83,7 @@ describe('OverflowMenu', () => {
 
       expect(menuOptions.hasClass(openClass)).not.toEqual(true);
       rootWrapper.setState({ open: true });
-      expect(menuOptions.hasClass(openClass)).not.toEqual(false);
+      expect(rootWrapper.find('ul').hasClass(openClass)).not.toEqual(false);
     });
 
     it('should be in an open state after icon is clicked', () => {

--- a/components/__tests__/Pagination-test.js
+++ b/components/__tests__/Pagination-test.js
@@ -36,9 +36,11 @@ describe('Pagination', () => {
 
     describe('pagination size container', () => {
       const left = pagination.find('.bx--pagination__left');
+
       it('should render a left container', () => {
         expect(left.length).toBe(1);
       });
+
       it('should have a size dropdown', () => {
         const select = left.find(Select);
         const items = select.find(SelectItem);
@@ -47,10 +49,12 @@ describe('Pagination', () => {
         expect(items.at(0).props().value).toBe(5);
         expect(items.at(1).props().value).toBe(10);
       });
+
       it('should label the dropdown', () => {
         const label = left.find('.bx--pagination__text').first();
         expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
       });
+
       it('should show the item range out of the total', () => {
         const label = left.find('.bx--pagination__text').at(1);
         expect(label.text()).toBe('1-5 of 50 items');
@@ -68,6 +72,7 @@ describe('Pagination', () => {
         it('should render a left container', () => {
           expect(left.length).toBe(1);
         });
+
         it('should have a size dropdown', () => {
           const select = left.find(Select);
           const items = select.find(SelectItem);
@@ -76,10 +81,12 @@ describe('Pagination', () => {
           expect(items.at(0).props().value).toBe(5);
           expect(items.at(1).props().value).toBe(10);
         });
+
         it('should label the dropdown', () => {
           const label = left.find('.bx--pagination__text').first();
           expect(label.text()).toBe('items per page\u00a0\u00a0|\u00a0\u00a0');
         });
+
         it('should show the item range without the total', () => {
           const label = left.find('.bx--pagination__text').at(1);
           expect(label.text()).toBe('1-5 items');
@@ -109,6 +116,7 @@ describe('Pagination', () => {
           expect(labels.at(1).text()).toBe('1-10 of 50 items');
           expect(labels.at(2).text()).toBe('1 of 5 pages');
         });
+
         it('should reset the page when page size changes', () => {
           let actualPage;
           const handler = ({ page }) => {
@@ -127,6 +135,7 @@ describe('Pagination', () => {
           expect(actualPage).toBe(1);
           expect(pager.state().page).toBe(1);
         });
+
         it('should return to first page on changes to pageSizes', () => {
           const pager = mount(
             <Pagination pageSizes={[5, 10]} totalItems={50} />
@@ -135,12 +144,14 @@ describe('Pagination', () => {
           pager.setProps({ pageSizes: [3, 6] });
           expect(pager.state().page).toEqual(1);
         });
+
         it('should default to pageSize if pageSize is provided', () => {
           const pager = mount(
             <Pagination pageSizes={[5, 10]} pageSize={10} totalItems={50} />
           );
           expect(pager.state().pageSize).toEqual(10);
         });
+
         it('should default to pageSize if on change to pageSize', () => {
           const pager = mount(
             <Pagination pageSizes={[5, 10]} totalItems={50} />
@@ -153,13 +164,16 @@ describe('Pagination', () => {
 
     describe('pagination paging container', () => {
       const right = pagination.find('.bx--pagination__right');
+
       it('should render a right container', () => {
         expect(right.length).toBe(1);
       });
+
       it('should show the current page out of the total number of pages', () => {
         const label = right.find('.bx--pagination__text').first();
         expect(label.text()).toBe('1 of 10 pages');
       });
+
       it('should have two buttons for navigation', () => {
         const buttons = right.find('.bx--pagination__button');
         expect(buttons.length).toBe(2);
@@ -170,11 +184,13 @@ describe('Pagination', () => {
           true
         );
       });
+
       it('should disable backward navigation for the first page', () => {
         const buttons = right.find('.bx--pagination__button');
         expect(buttons.at(0).props().disabled).toBe(true);
         expect(buttons.at(1).props().disabled).toBe(false);
       });
+
       it('should disable forward navigation for the last page', () => {
         const smallPage = shallow(
           <Pagination
@@ -199,13 +215,16 @@ describe('Pagination', () => {
         );
 
         const right = pager.find('.bx--pagination__right');
+
         it('should render a right container', () => {
           expect(right.length).toBe(1);
         });
+
         it('should show the current page without the total number of pages', () => {
           const label = right.find('.bx--pagination__text').first();
           expect(label.text()).toBe('page 1');
         });
+
         it('should have two buttons for navigation', () => {
           const buttons = right.find('.bx--pagination__button');
           expect(buttons.length).toBe(2);
@@ -216,11 +235,13 @@ describe('Pagination', () => {
             true
           );
         });
+
         it('should disable backward navigation for the first page', () => {
           const buttons = right.find('.bx--pagination__button');
           expect(buttons.at(0).props().disabled).toBe(true);
           expect(buttons.at(1).props().disabled).toBe(false);
         });
+
         it('should disable forward navigation for the last page', () => {
           const smallPage = shallow(
             <Pagination
@@ -233,6 +254,7 @@ describe('Pagination', () => {
           expect(buttons.at(0).props().disabled).toBe(true);
           expect(buttons.at(1).props().disabled).toBe(true);
         });
+
         it('should hide text input if disabled', () => {
           const noTextInput = shallow(
             <Pagination
@@ -264,6 +286,7 @@ describe('Pagination', () => {
           expect(actualPage).toBe(2);
           expect(pager.state().page).toBe(2);
         });
+
         it('should go to the previous page when clicking backward', () => {
           let actualPage;
           const handler = ({ page }) => {
@@ -282,6 +305,7 @@ describe('Pagination', () => {
           expect(actualPage).toBe(1);
           expect(pager.state().page).toBe(1);
         });
+
         it('should jump to the page entered in the input field', () => {
           let actualPage;
           const handler = ({ page }) => {
@@ -297,10 +321,12 @@ describe('Pagination', () => {
           expect(pager.state().page).toBe(1);
           pager
             .find('.bx--text__input')
+            .last()
             .simulate('change', { target: { value: 2 } });
           expect(actualPage).toBe(2);
           expect(pager.state().page).toBe(2);
         });
+
         it('should jump to page number if prop page is provided', () => {
           const pager = mount(
             <Pagination pageSizes={[5, 10]} totalItems={50} page={3} />

--- a/components/__tests__/ProgressIndicator-test.js
+++ b/components/__tests__/ProgressIndicator-test.js
@@ -59,7 +59,7 @@ describe('ProgressIndicator', () => {
     describe('ProgressStep', () => {
       it('should render with correct base className', () => {
         expect(
-          mountedList.find(ProgressStep).at(0).hasClass('bx--progress-step')
+          mountedList.find(ProgressStep).at(0).children().hasClass('bx--progress-step')
         ).toEqual(true);
       });
 
@@ -87,6 +87,7 @@ describe('ProgressIndicator', () => {
             mountedList
               .find(ProgressStep)
               .at(3)
+              .children()
               .hasClass('bx--progress-step--current')
           ).toEqual(true);
         });
@@ -102,6 +103,7 @@ describe('ProgressIndicator', () => {
             mountedList
               .find(ProgressStep)
               .at(0)
+              .children()
               .hasClass('bx--progress-step--complete')
           ).toEqual(true);
         });
@@ -116,6 +118,7 @@ describe('ProgressIndicator', () => {
             mountedList
               .find(ProgressStep)
               .at(5)
+              .children()
               .hasClass('bx--progress-step--incomplete')
           ).toEqual(true);
         });

--- a/components/__tests__/RadioButton-test.js
+++ b/components/__tests__/RadioButton-test.js
@@ -81,10 +81,10 @@ describe('RadioButton', () => {
       defaultChecked: true,
     });
 
-    const input = wrapper.find('input');
-    expect(input.props().defaultChecked).toEqual(true);
+    const input = () => wrapper.find('input');
+    expect(input().props().defaultChecked).toEqual(true);
     wrapper.setProps({ defaultChecked: false });
-    expect(input.props().defaultChecked).toEqual(false);
+    expect(input().props().defaultChecked).toEqual(false);
   });
 
   it('should set id if one is passed in', () => {
@@ -101,7 +101,7 @@ describe('RadioButton', () => {
       const onChange = jest.fn();
       const wrapper = render({ onChange });
       const input = wrapper.find('input');
-      const inputElement = input.get(0);
+      const inputElement = input.instance();
 
       inputElement.checked = true;
       wrapper.find('input').simulate('change');

--- a/components/__tests__/RadioButtonGroup-test.js
+++ b/components/__tests__/RadioButtonGroup-test.js
@@ -26,30 +26,30 @@ describe('RadioButtonGroup', () => {
 
       it('sets disabled attribute if disabled prop is set', () => {
         wrapper.setProps({ disabled: true });
-        expect(div.props().disabled).toEqual(true);
+        expect(wrapper.first('dev').props().disabled).toEqual(true);
       });
     });
 
     describe('children', () => {
-      const radioButton = wrapper.find(RadioButton);
+      const radioButton = () => wrapper.find(RadioButton);
 
       it('renders expected number of children', () => {
-        expect(radioButton.length).toEqual(2);
+        expect(radioButton().length).toEqual(2);
       });
 
       it('should set checked property based on defaultSelected prop', () => {
-        expect(radioButton.last().props().checked).toEqual(true);
+        expect(radioButton().last().props().checked).toEqual(true);
       });
 
       it('should set checked property based on valueSelected prop', () => {
         wrapper.setProps({ valueSelected: 'male' });
-        expect(radioButton.first().props().checked).toEqual(true);
+        expect(radioButton().first().props().checked).toEqual(true);
         wrapper.setProps({ valueSelected: 'female' });
-        expect(radioButton.last().props().checked).toEqual(true);
+        expect(radioButton().last().props().checked).toEqual(true);
       });
 
       it('should set expected props on children', () => {
-        const firstChild = radioButton.first();
+        const firstChild = radioButton().first();
         expect(firstChild.props().name).toEqual('gender');
         expect(firstChild.props().value).toEqual('male');
       });
@@ -74,7 +74,8 @@ describe('RadioButtonGroup', () => {
 
     it('invoking onChange sets checked on correct child', () => {
       firstRadio.props().onChange(...args);
-      expect(firstRadio.props().checked).toEqual(true);
+      wrapper.update();
+      expect(wrapper.find(RadioButton).first().props().checked).toEqual(true);
     });
 
     it('should invoke onChange with correct arguments', () => {

--- a/components/__tests__/Search-test.js
+++ b/components/__tests__/Search-test.js
@@ -34,20 +34,20 @@ describe('Search', () => {
       it('should set type as expected', () => {
         expect(textInput.props().type).toEqual('text');
         wrapper.setProps({ type: 'email' });
-        expect(textInput.props().type).toEqual('email');
+        expect(wrapper.find('input').props().type).toEqual('email');
       });
 
       it('should set value as expected', () => {
         expect(textInput.props().defaultValue).toEqual(undefined);
         wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput.props().defaultValue).toEqual('test');
-        expect(textInput.props().value).toEqual(undefined);
+        expect(wrapper.find('input').props().defaultValue).toEqual('test');
+        expect(wrapper.find('input').props().value).toEqual(undefined);
       });
 
       it('should set placeholder as expected', () => {
         expect(textInput.props().placeholder).toEqual('');
         wrapper.setProps({ placeHolderText: 'Enter text' });
-        expect(textInput.props().placeholder).toEqual('Enter text');
+        expect(wrapper.find('input').props().placeholder).toEqual('Enter text');
       });
     });
 
@@ -77,8 +77,8 @@ describe('Search', () => {
         });
 
         it('should have type="button"', () => {
-          const type1 = btns.get(0).getAttribute('type');
-          const type2 = btns.get(1).getAttribute('type');
+          const type1 = btns.first().instance().getAttribute('type');
+          const type2 = btns.last().instance().getAttribute('type');
           expect(type1).toEqual('button');
           expect(type2).toEqual('button');
         });

--- a/components/__tests__/Select-test.js
+++ b/components/__tests__/Select-test.js
@@ -70,13 +70,13 @@ describe('Select', () => {
 
       it('should set defaultValue as expected', () => {
         wrapper.setProps({ defaultValue: 'select-1' });
-        expect(select.props().defaultValue).toEqual('select-1');
+        expect(wrapper.find('select').props().defaultValue).toEqual('select-1');
       });
 
       it('should set disabled as expected', () => {
         expect(select.props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(select.props().disabled).toEqual(true);
+        expect(wrapper.find('select').props().disabled).toEqual(true);
       });
 
       it('renders children as expected', () => {

--- a/components/__tests__/Slider-test.js
+++ b/components/__tests__/Slider-test.js
@@ -39,8 +39,15 @@ describe('Slider', () => {
   describe('updatePosition method', () => {
     const mockFn = jest.fn();
     const wrapper = mount(
-      <Slider id="slider" className="extra-class" value={50} min={0} max={100} step={1} onChange={mockFn} >
-      </Slider>
+      <Slider
+        id="slider"
+        className="extra-class"
+        value={50}
+        min={0}
+        max={100}
+        step={1}
+        onChange={mockFn}
+      />
     );
 
     it('sets correct state from event with a right/up keydown', () => {

--- a/components/__tests__/StructuredList-test.js
+++ b/components/__tests__/StructuredList-test.js
@@ -111,12 +111,12 @@ describe('StructuredListRow', () => {
 
     it('should use <div> HTML by default (or when label prop is false)', () => {
       const wrapperLabel = shallow(<StructuredListRow />);
-      expect(wrapperLabel.node.type).toEqual('div');
+      expect(wrapperLabel.getElement().type).toEqual('div');
     });
 
     it('should use <label> HTML when label prop is true', () => {
       const wrapperLabel = shallow(<StructuredListRow label />);
-      expect(wrapperLabel.node.type).toEqual('label');
+      expect(wrapperLabel.getElement().type).toEqual('label');
     });
 
     it('Should accept other props from ...other', () => {

--- a/components/__tests__/Tabs-test.js
+++ b/components/__tests__/Tabs-test.js
@@ -147,7 +147,7 @@ describe('Tabs', () => {
 
       describe('state: selectedLabel', () => {
         it('sets a new value for selectedLabel state when Tab is clicked', () => {
-          const lastTab = wrapper.find('.lastTab');
+          const lastTab = wrapper.find('.lastTab').last();
           lastTab.simulate('click');
           expect(wrapper.state().selectedLabel).toEqual('lastTab');
         });
@@ -162,8 +162,8 @@ describe('Tabs', () => {
         </Tabs>,
       );
 
-      const firstTab = wrapper.find('.firstTab');
-      const lastTab = wrapper.find('.lastTab');
+      const firstTab = wrapper.find('.firstTab').last();
+      const lastTab = wrapper.find('.lastTab').last();
       const leftKey = 37;
       const rightKey = 39;
       const spaceKey = 32;

--- a/components/__tests__/TextArea-test.js
+++ b/components/__tests__/TextArea-test.js
@@ -2,57 +2,57 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import Textarea from '../TextArea';
 
-describe('Textarea', () => {
+describe('TextArea', () => {
   describe('should render as expected', () => {
     const wrapper = mount(<Textarea id="testing" className="extra-class" />);
 
-    const textarea = wrapper.find('textarea');
+    const textarea = () => wrapper.find('textarea');
 
     describe('textarea', () => {
       it('renders a textarea', () => {
-        expect(textarea.length).toEqual(1);
+        expect(textarea().length).toEqual(1);
       });
 
       it('has the expected classes', () => {
-        expect(textarea.hasClass('bx--text-area')).toEqual(true);
+        expect(textarea().hasClass('bx--text-area')).toEqual(true);
       });
 
       it('applies extra classes specified via className', () => {
-        expect(textarea.hasClass('extra-class')).toEqual(true);
+        expect(textarea().hasClass('extra-class')).toEqual(true);
       });
 
       it('should set rows as expected', () => {
-        expect(textarea.props().rows).toEqual(4);
+        expect(textarea().props().rows).toEqual(4);
         wrapper.setProps({ rows: 10 });
-        expect(textarea.props().rows).toEqual(10);
+        expect(textarea().props().rows).toEqual(10);
       });
 
       it('should set cols as expected', () => {
-        expect(textarea.props().cols).toEqual(50);
+        expect(textarea().props().cols).toEqual(50);
         wrapper.setProps({ cols: 200 });
-        expect(textarea.props().cols).toEqual(200);
+        expect(textarea().props().cols).toEqual(200);
       });
 
       it('should set disabled as expected', () => {
-        expect(textarea.props().disabled).toEqual(false);
+        expect(textarea().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(textarea.props().disabled).toEqual(true);
+        expect(textarea().props().disabled).toEqual(true);
       });
 
       it('should set placeholder as expected', () => {
-        expect(textarea.props().placeholder).toEqual('Hint text here');
+        expect(textarea().props().placeholder).toEqual('Hint text here');
         wrapper.setProps({ placeholder: 'Type here' });
-        expect(textarea.props().placeholder).toEqual('Type here');
+        expect(textarea().props().placeholder).toEqual('Type here');
       });
 
       it('should set value as expected', () => {
         wrapper.setProps({ value: 'value set' });
-        expect(textarea.props().value).toEqual('value set');
+        expect(textarea().props().value).toEqual('value set');
       });
 
       it('should set defaultValue as expected', () => {
         wrapper.setProps({ defaultValue: 'default value' });
-        expect(textarea.props().defaultValue).toEqual('default value');
+        expect(textarea().props().defaultValue).toEqual('default value');
       });
     });
 

--- a/components/__tests__/TextInput-test.js
+++ b/components/__tests__/TextInput-test.js
@@ -6,43 +6,43 @@ describe('TextInput', () => {
   describe('renders as expected', () => {
     const wrapper = mount(<TextInput id="test" className="extra-class" />);
 
-    const textInput = wrapper.find('input');
+    const textInput = () => wrapper.find('input');
 
     describe('input', () => {
       it('renders as expected', () => {
-        expect(textInput.length).toBe(1);
+        expect(textInput().length).toBe(1);
       });
 
       it('has the expected classes', () => {
-        expect(textInput.hasClass('bx--text-input')).toEqual(true);
+        expect(textInput().hasClass('bx--text-input')).toEqual(true);
       });
 
       it('should add extra classes that are passed via className', () => {
-        expect(textInput.hasClass('extra-class')).toEqual(true);
+        expect(textInput().hasClass('extra-class')).toEqual(true);
       });
 
       it('should set type as expected', () => {
-        expect(textInput.props().type).toEqual('text');
+        expect(textInput().props().type).toEqual('text');
         wrapper.setProps({ type: 'email' });
-        expect(textInput.props().type).toEqual('email');
+        expect(textInput().props().type).toEqual('email');
       });
 
       it('should set value as expected', () => {
-        expect(textInput.props().defaultValue).toEqual(undefined);
+        expect(textInput().props().defaultValue).toEqual(undefined);
         wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput.props().defaultValue).toEqual('test');
+        expect(textInput().props().defaultValue).toEqual('test');
       });
 
       it('should set disabled as expected', () => {
-        expect(textInput.props().disabled).toEqual(false);
+        expect(textInput().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(textInput.props().disabled).toEqual(true);
+        expect(textInput().props().disabled).toEqual(true);
       });
 
       it('should set placeholder as expected', () => {
-        expect(textInput.props().placeholder).not.toBeDefined();
+        expect(textInput().props().placeholder).not.toBeDefined();
         wrapper.setProps({ placeholder: 'Enter text' });
-        expect(textInput.props().placeholder).toEqual('Enter text');
+        expect(textInput().props().placeholder).toEqual('Enter text');
       });
     });
 

--- a/components/__tests__/Tile-test.js
+++ b/components/__tests__/Tile-test.js
@@ -83,7 +83,7 @@ describe('Tile', () => {
     });
 
     it('has the expected classes', () => {
-      expect(wrapper.hasClass('bx--tile--selectable')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--tile--selectable')).toEqual(true);
     });
 
     it('renders extra classes passed in via className', () => {
@@ -91,9 +91,9 @@ describe('Tile', () => {
     });
 
     it('toggles the selectable class on click', () => {
-      expect(wrapper.hasClass('bx--tile--is-selected')).toEqual(false);
+      expect(wrapper.children().hasClass('bx--tile--is-selected')).toEqual(false);
       wrapper.simulate('click');
-      expect(wrapper.hasClass('bx--tile--is-selected')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--tile--is-selected')).toEqual(true);
     });
 
     it('toggles the selectable state on click', () => {
@@ -111,9 +111,8 @@ describe('Tile', () => {
     });
 
     it('the input should be checked when state is selected', () => {
-      const input = wrapper.find('input');
       wrapper.setState({ selected: true });
-      expect(input.props().checked).toEqual(true);
+      expect(wrapper.find('input').props().checked).toEqual(true);
     });
   });
 
@@ -134,7 +133,7 @@ describe('Tile', () => {
     });
 
     it('has the expected classes', () => {
-      expect(wrapper.hasClass('bx--tile--expandable')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--tile--expandable')).toEqual(true);
     });
 
     it('renders extra classes passed in via className', () => {
@@ -142,9 +141,9 @@ describe('Tile', () => {
     });
 
     it('toggles the expandable class on click', () => {
-      expect(wrapper.hasClass('bx--tile--is-expanded')).toEqual(false);
+      expect(wrapper.children().hasClass('bx--tile--is-expanded')).toEqual(false);
       wrapper.simulate('click');
-      expect(wrapper.hasClass('bx--tile--is-expanded')).toEqual(true);
+      expect(wrapper.children().hasClass('bx--tile--is-expanded')).toEqual(true);
     });
 
     it('toggles the expandable state on click', () => {

--- a/components/__tests__/TimePicker-test.js
+++ b/components/__tests__/TimePicker-test.js
@@ -7,14 +7,12 @@ describe('TimePicker', () => {
     describe('input', () => {
       let wrapper;
       let timePicker;
-      let label;
       let textInput;
 
       beforeEach(() => {
         wrapper = mount(<TimePicker id="test" className="extra-class" />);
 
         timePicker = () => wrapper.find('.bx--time-picker');
-        label = () => wrapper.find('label');
         textInput = () => wrapper.find('input');
       });
 
@@ -50,16 +48,12 @@ describe('TimePicker', () => {
 
     describe('label', () => {
       let wrapper;
-      let timePicker;
       let label;
-      let textInput;
 
       beforeEach(() => {
         wrapper = mount(<TimePicker id="test" className="extra-class" />);
 
-        timePicker = () => wrapper.find('.bx--time-picker');
         label = () => wrapper.find('label');
-        textInput = () => wrapper.find('input');
       });
 
       it('does not render a label by default', () => {

--- a/components/__tests__/TimePicker-test.js
+++ b/components/__tests__/TimePicker-test.js
@@ -4,65 +4,84 @@ import { mount, shallow } from 'enzyme';
 
 describe('TimePicker', () => {
   describe('renders as expected', () => {
-    const wrapper = mount(<TimePicker id="test" className="extra-class" />);
-
-    const timePicker = wrapper.childAt(0);
-    const label = wrapper.find('label');
-    const textInput = wrapper.find('input');
-
     describe('input', () => {
-      it('renders as expected', () => {
-        expect(textInput.length).toBe(1);
+      let wrapper;
+      let timePicker;
+      let label;
+      let textInput;
+
+      beforeEach(() => {
+        wrapper = mount(<TimePicker id="test" className="extra-class" />);
+
+        timePicker = () => wrapper.find('.bx--time-picker');
+        label = () => wrapper.find('label');
+        textInput = () => wrapper.find('input');
       });
 
-      it('has the expected classes', () => {
-        expect(timePicker.hasClass('bx--time-picker')).toEqual(true);
+      it('renders as expected', () => {
+        expect(textInput().length).toBe(1);
       });
 
       it('should add extra classes that are passed via className', () => {
-        expect(timePicker.hasClass('extra-class')).toEqual(true);
+        expect(timePicker().hasClass('extra-class')).toEqual(true);
       });
 
       it('should set type as expected', () => {
-        expect(textInput.props().type).toEqual('text');
+        expect(textInput().props().type).toEqual('text');
       });
 
       it('should set value as expected', () => {
-        expect(textInput.props().defaultValue).toEqual(undefined);
+        expect(textInput().props().defaultValue).toEqual(undefined);
         wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput.props().defaultValue).toEqual('test');
+        expect(textInput().props().defaultValue).toEqual('test');
       });
 
       it('should set disabled as expected', () => {
-        expect(textInput.props().disabled).toEqual(false);
+        expect(textInput().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(textInput.props().disabled).toEqual(true);
+        expect(textInput().props().disabled).toEqual(true);
       });
 
       it('should set placeholder as expected', () => {
         wrapper.setProps({ placeholder: 'ss:mm' });
-        expect(textInput.props().placeholder).toEqual('ss:mm');
+        expect(textInput().props().placeholder).toEqual('ss:mm');
       });
     });
 
     describe('label', () => {
-      it('does not render a label by default', () => {
-        expect(label.length).toBe(0);
+      let wrapper;
+      let timePicker;
+      let label;
+      let textInput;
+
+      beforeEach(() => {
+        wrapper = mount(<TimePicker id="test" className="extra-class" />);
+
+        timePicker = () => wrapper.find('.bx--time-picker');
+        label = () => wrapper.find('label');
+        textInput = () => wrapper.find('input');
       });
 
-      wrapper.setProps({ labelText: 'Enter a time' });
-      const renderedLabel = wrapper.find('label');
+      it('does not render a label by default', () => {
+        expect(label().length).toBe(0);
+      });
 
       it('renders a label', () => {
-        expect(renderedLabel.length).toBe(1);
+        wrapper.setProps({ labelText: 'Enter a time' });
+        const renderedlabel = wrapper.find('label');
+        expect(renderedlabel.length).toBe(1);
       });
 
       it('has the expected classes', () => {
-        expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+        wrapper.setProps({ labelText: 'Enter a time' });
+        const renderedlabel = wrapper.find('label');
+        expect(renderedlabel.hasClass('bx--label')).toEqual(true);
       });
 
       it('should set label as expected', () => {
-        expect(renderedLabel.text()).toEqual('Enter a time');
+        wrapper.setProps({ labelText: 'Enter a time' });
+        const renderedlabel = wrapper.find('label');
+        expect(renderedlabel.text()).toEqual('Enter a time');
       });
     });
   });

--- a/components/__tests__/Toggle-test.js
+++ b/components/__tests__/Toggle-test.js
@@ -18,7 +18,7 @@ describe('Toggle', () => {
     it('should set defaultChecked as expected', () => {
       expect(input.props().defaultChecked).toEqual(false);
       wrapper.setProps({ defaultToggled: true });
-      expect(input.props().defaultChecked).toEqual(true);
+      expect(wrapper.find('input').props().defaultChecked).toEqual(true);
     });
 
     it('Can set defaultToggled state', () => {
@@ -52,11 +52,11 @@ describe('Toggle', () => {
       <Toggle id="test" toggled />
     );
 
-    const input = wrapper.find('input');
-    expect(input.props().checked).toEqual(true);
+    const input = () => wrapper.find('input');
+    expect(input().props().checked).toEqual(true);
 
     wrapper.setProps({ toggled: false });
-    expect(input.props().checked).toEqual(false);
+    expect(input().props().checked).toEqual(false);
   });
 
   describe('events', () => {
@@ -68,7 +68,7 @@ describe('Toggle', () => {
       );
 
       const input = wrapper.find('input');
-      const inputElement = input.get(0);
+      const inputElement = input.instance();
 
       inputElement.checked = true;
       wrapper.find('input').simulate('change');

--- a/components/__tests__/Toolbar-test.js
+++ b/components/__tests__/Toolbar-test.js
@@ -15,8 +15,8 @@ describe('Toolbar', () => {
 
     describe('toolbar container', () => {
       it('should render the expected classes', () => {
-        expect(toolbar.hasClass('bx--toolbar')).toEqual(true);
-        expect(toolbar.hasClass('extra-class')).toEqual(true);
+        expect(toolbar.children().hasClass('bx--toolbar')).toEqual(true);
+        expect(toolbar.children().hasClass('extra-class')).toEqual(true);
       });
     });
   });
@@ -86,7 +86,7 @@ describe('Toolbar', () => {
       const toolbarTitle = withToolbarTitle.find(ToolbarTitle);
 
       it('should render a toolbar title with the expected className', () => {
-        expect(toolbarTitle.hasClass('bx--toolbar-menu__title')).toEqual(true);
+        expect(toolbarTitle.children().hasClass('bx--toolbar-menu__title')).toEqual(true);
       });
 
       it('should render a toolbar title with the expected title', () => {
@@ -108,7 +108,7 @@ describe('Toolbar', () => {
       const toolbarOption = withToolbarOption.find(ToolbarOption);
 
       it('should render a toolbar option with the expected className', () => {
-        expect(toolbarOption.hasClass('bx--toolbar-menu__option')).toEqual(
+        expect(toolbarOption.children().hasClass('bx--toolbar-menu__option')).toEqual(
           true
         );
       });
@@ -130,7 +130,7 @@ describe('Toolbar', () => {
       const toolbarDivider = withToolbarDivider.find(ToolbarDivider);
 
       it('should render a toolbar divider with the expected className', () => {
-        expect(toolbarDivider.hasClass('bx--toolbar-menu__divider')).toEqual(
+        expect(toolbarDivider.children().hasClass('bx--toolbar-menu__divider')).toEqual(
           true
         );
       });

--- a/config/jest/cssTransform.js
+++ b/config/jest/cssTransform.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// This is a custom Jest transformer turning style imports into empty objects.
+// http://facebook.github.io/jest/docs/tutorial-webpack.html
+module.exports = {
+  process() {
+    return 'module.exports = {};';
+  },
+  getCacheKey() {
+    // The output is always the same.
+    return 'cssTransform';
+  },
+};

--- a/config/jest/fileTransform.js
+++ b/config/jest/fileTransform.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const path = require('path');
+
+// This is a custom Jest transformer turning file imports into filenames.
+// http://facebook.github.io/jest/docs/tutorial-webpack.html
+module.exports = {
+  process(src, filename) {
+    return `module.exports = ${JSON.stringify(path.basename(filename))};`;
+  },
+};

--- a/config/jest/jsTransform.js
+++ b/config/jest/jsTransform.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { createTransformer } = require('babel-jest');
+
+// This is a custom Jest transformer that process *.js files
+// http://facebook.github.io/jest/docs/tutorial-webpack.html
+const babelOptions = {
+  presets: [
+    [
+      'env',
+      {
+        targets: {
+          browsers: ['last 1 versions', 'Firefox ESR'],
+        },
+      },
+    ],
+    'react',
+    'stage-1',
+  ],
+  plugins: [
+    'transform-object-assign',
+  ],
+};
+
+module.exports = createTransformer(babelOptions);

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -1,0 +1,16 @@
+
+/**
+ * (C) Copyright IBM Corp. 2017 All Rights Reserved
+ *
+ * The source code for this program is not published or otherwise
+ * divested of its trade secrets, irrespective of what has
+ * been deposited with the U.S. Copyright Office.
+ */
+
+'use strict';
+
+const enzyme = require.requireActual('enzyme');
+const Adapter = require.requireActual('enzyme-adapter-react-15');
+
+// Configure enzyme to work with React 15 for now
+enzyme.configure({ adapter: new Adapter() });

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,0 +1,25 @@
+'use strict';
+
+jest.unmock('promise');
+jest.unmock('whatwg-fetch');
+jest.unmock('object-assign');
+
+if (typeof Promise === 'undefined') {
+  // Rejection tracking prevents a common issue where React gets into an
+  // inconsistent state due to an error, but it gets swallowed by a Promise,
+  // and the user has no idea what causes React's erratic future behavior.
+  require('promise/lib/rejection-tracking').enable();
+  window.Promise = require('promise/lib/es6-extensions.js');
+}
+
+// fetch() polyfill for making API calls.
+require('whatwg-fetch');
+
+// Object.assign() is commonly used with React.
+// It will use the native implementation if it's present and isn't buggy.
+Object.assign = require('object-assign');
+
+// Starting with React 16, we'll have to polyfill this in test environments.
+global.requestAnimationFrame = function (callback) {
+  callback();
+};

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -20,6 +20,6 @@ require('whatwg-fetch');
 Object.assign = require('object-assign');
 
 // Starting with React 16, we'll have to polyfill this in test environments.
-global.requestAnimationFrame = function (callback) {
+global.requestAnimationFrame = function(callback) {
   callback();
 };

--- a/internal/ClickListener.js
+++ b/internal/ClickListener.js
@@ -28,8 +28,7 @@ class ClickListener extends React.Component {
       <div
         ref={el => {
           this.element = el;
-        }}
-      >
+        }}>
         {this.props.children}
       </div>
     );

--- a/internal/FloatingMenu.js
+++ b/internal/FloatingMenu.js
@@ -112,7 +112,14 @@ class FloatingMenu extends React.Component {
   };
 
   render() {
-    return <div ref={(node) => { this.doc = node && node.ownerDocument; }} hidden />;
+    return (
+      <div
+        ref={node => {
+          this.doc = node && node.ownerDocument;
+        }}
+        hidden
+      />
+    );
   }
 }
 

--- a/internal/OptimizedResize.js
+++ b/internal/OptimizedResize.js
@@ -7,7 +7,7 @@ const OptimizedResize = (function optimizedResize() {
 
   // run the actual callbacks
   function runCallbacks() {
-    callbacks.forEach((callback) => {
+    callbacks.forEach(callback => {
       callback();
     });
 
@@ -34,7 +34,7 @@ const OptimizedResize = (function optimizedResize() {
 
   return {
     // public method to add additional callback
-    add: (callback) => {
+    add: callback => {
       if (!callbacks.length) {
         window.addEventListener('resize', resize);
       }
@@ -49,6 +49,6 @@ const OptimizedResize = (function optimizedResize() {
       };
     },
   };
-}());
+})();
 
 export default OptimizedResize;

--- a/lib/array.js
+++ b/lib/array.js
@@ -5,7 +5,11 @@
  * @returns {boolean} true if both arrays have the same contents, otherwise false
  */
 export function equals(arr1, arr2) {
-  if (!Array.isArray(arr1) || !Array.isArray(arr2) || arr1.length !== arr2.length) {
+  if (
+    !Array.isArray(arr1) ||
+    !Array.isArray(arr2) ||
+    arr1.length !== arr2.length
+  ) {
     return false;
   }
   if (arr1 === arr2) {

--- a/lib/uniqueId.js
+++ b/lib/uniqueId.js
@@ -1,6 +1,6 @@
 let lastId = 0;
 
-export default function (prefix = 'id') {
+export default function(prefix = 'id') {
   lastId++;
   return `${prefix}${lastId}`;
 }

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "main": "cjs/index.js",
   "module": "es/index.js",
   "scripts": {
+    "build": "node scripts/build.js",
+    "build-storybook": "build-storybook",
     "check": "npm run lint && npm run test",
+    "commit": "git cz",
+    "commitmsg": "validate-commit-msg",
     "lint": "eslint {components,internal}/**",
-    "test": "jest '/(__tests__|components|lib|internal)/' && npm run test-ssr",
-    "test-watch": "jest '/(__tests__|components|lib|internal)/' --watch",
+    "test": "jest",
     "test-ssr": "npm run build && node server-side-rendering-tests/*.js",
     "prepublish": "npm run build",
-    "build": "node scripts/build.js",
-    "commitmsg": "validate-commit-msg",
-    "commit": "git cz",
-    "storybook": "start-storybook -p 9000",
-    "build-storybook": "build-storybook",
+    "prettier": "prettier --write **/*.js",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "start": "npm run storybook",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "storybook": "start-storybook -p 9000"
   },
   "keywords": [
     "react",
@@ -112,7 +112,9 @@
     "commitizen": "^2.9.5",
     "css-loader": "^0.28.4",
     "cz-conventional-changelog-components": "^1.0.0",
-    "enzyme": "^2.6.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-15": "^1.0.1",
+    "enzyme-to-json": "^3.1.1",
     "eslint": "^3.0.0",
     "eslint-plugin-jsx-a11y": "^2.0.0",
     "eslint-plugin-react": "^6.0.0",
@@ -122,8 +124,10 @@
     "lcov2badge": "^0.1.0",
     "lint-staged": "^3.4.0",
     "node-sass": "3.8.0",
+    "object-assign": "^4.1.1",
     "postcss-loader": "^2.0.5",
-    "prettier": "^1.2.2",
+    "prettier": "^1.7.0",
+    "promise": "^8.0.1",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
@@ -134,22 +138,8 @@
     "semantic-release": "^6.3.6",
     "shelljs": "^0.7.5",
     "storybook-addon-a11y": "^3.0.0",
-    "validate-commit-msg": "^2.10.1"
-  },
-  "jest": {
-    "coverageDirectory": "./coverage",
-    "moduleNameMapper": {
-      "^.+\\.(scss)$": "<rootDir>/lib/styleMock.js"
-    },
-    "setupFiles": [
-      "<rootDir>/setup-jest.js"
-    ]
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --trailing-comma es5 --single-quote --write",
-      "git add"
-    ]
+    "validate-commit-msg": "^2.10.1",
+    "whatwg-fetch": "^2.0.3"
   },
   "config": {
     "validate-commit-msg": {
@@ -172,6 +162,51 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog-components"
     }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "jsxBracketSameLine": true,
+    "printWidth": 80,
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "components/**/*.js"
+    ],
+    "setupFiles": [
+      "<rootDir>/config/polyfills.js",
+      "<rootDir>/config/jest/setup.js"
+    ],
+    "testMatch": [
+      "<rootDir>/**/__tests__/**/*.js?(x)",
+      "<rootDir>/**/?(*.)(spec|test).js?(x)"
+    ],
+    "testURL": "http://localhost",
+    "transform": {
+      "^.+\\.(js|jsx)$": "<rootDir>/config/jest/jsTransform.js",
+      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
+      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+    },
+    "testPathIgnorePatterns": [
+      "/config/",
+      "/lib/"
+    ],
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "json"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   },
   "repository": {
     "type": "git",

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -3,13 +3,13 @@ const BABEL_ENV = process.env.BABEL_ENV;
 module.exports = {
   presets: [
     [
-      "env",
+      'env',
       {
-        "modules": BABEL_ENV === 'es' ? false : "commonjs",
-        "targets": {
-          "browsers": ['last 1 versions', 'Firefox ESR']
-        }
-      }
+        modules: BABEL_ENV === 'es' ? false : 'commonjs',
+        targets: {
+          browsers: ['last 1 versions', 'Firefox ESR'],
+        },
+      },
     ],
   ],
 };

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,1 +1,0 @@
-window.requestAnimationFrame = (callback) => { callback(); };

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,10 @@
     react-treebeard "^2.0.3"
     redux "^3.6.0"
 
+"@types/node@^6.0.46":
+  version "6.0.88"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -1661,9 +1665,9 @@ caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000715:
   version "1.0.30000715"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz#c327f5e6d907ebcec62cde598c3bf0dd793fb9a0"
 
-carbon-components@^7.13.0:
-  version "7.19.2"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-7.19.2.tgz#1d589a119203614fcccf599c8ae7e137dd1b3c78"
+carbon-components@^7.20.0:
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-7.23.2.tgz#85b159f602f583e6b190625339a21fc401ebcd53"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"
@@ -1714,26 +1718,16 @@ chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-cheerio@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
   dependencies:
     css-select "~1.2.0"
     dom-serializer "~0.1.0"
     entities "~1.1.1"
     htmlparser2 "^3.9.1"
-    lodash.assignin "^4.0.9"
-    lodash.bind "^4.1.4"
-    lodash.defaults "^4.0.1"
-    lodash.filter "^4.4.0"
-    lodash.flatten "^4.2.0"
-    lodash.foreach "^4.3.0"
-    lodash.map "^4.4.0"
-    lodash.merge "^4.4.0"
-    lodash.pick "^4.2.1"
-    lodash.reduce "^4.4.0"
-    lodash.reject "^4.4.0"
-    lodash.some "^4.4.0"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
@@ -1876,6 +1870,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@~0.6.0-1:
   version "0.6.2"
@@ -2405,6 +2403,10 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2530,20 +2532,44 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme@^2.6.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.9.1.tgz#07d5ce691241240fb817bf2c4b18d6e530240df6"
+enzyme-adapter-react-15@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.1.tgz#c1a3e5966bf1c7221c40aa0f877850175035406f"
   dependencies:
-    cheerio "^0.22.0"
-    function.prototype.name "^1.0.0"
+    enzyme-adapter-utils "^1.0.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.5.10"
+
+enzyme-adapter-utils@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.0.1.tgz#fcd81223339a55a312f7552641e045c404084009"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.5.10"
+
+enzyme-to-json@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.1.1.tgz#b161b4ef34f12d9e25af8e24f2a0cab68fb2fb54"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.1.0.tgz#d8ca84085790fbcec6ed40badd14478faee4c25a"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.0.3"
     is-subset "^0.1.1"
     lodash "^4.17.4"
     object-is "^1.0.1"
     object.assign "^4.0.4"
     object.entries "^1.0.4"
     object.values "^1.0.4"
-    prop-types "^15.5.10"
-    uuid "^3.0.1"
+    raf "^3.3.2"
+    rst-selector-parser "^2.2.2"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"
@@ -3174,7 +3200,7 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-function.prototype.name@^1.0.0, function.prototype.name@^1.0.3:
+function.prototype.name@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.0.3.tgz#0099ae5572e9dd6f03c97d023fd92bcc5e639eac"
   dependencies:
@@ -4571,14 +4597,6 @@ lodash.assign@^3.0.0:
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash.assignin@^4.0.9:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
-
-lodash.bind@^4.1.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -4595,25 +4613,9 @@ lodash.debounce@4.0.8, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
-lodash.filter@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
-lodash.flatten@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
-lodash.foreach@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -4631,17 +4633,13 @@ lodash.keys@^3.0.0, lodash.keys@^3.1.2:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.map@^4.4.0, lodash.map@^4.5.1:
+lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.merge@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash.pad@^4.1.0:
   version "4.5.1"
@@ -4655,25 +4653,13 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
-lodash.pick@^4.2.1, lodash.pick@^4.4.0:
+lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.reduce@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-
-lodash.reject@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.some@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4691,7 +4677,7 @@ lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4948,6 +4934,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nearley@^2.7.10:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.11.0.tgz#5e626c79a6cd2f6ab9e7e5d5805e7668967757ae"
+  dependencies:
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "^0.4.2"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
@@ -5068,6 +5062,13 @@ node-sass@3.8.0:
 node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 "nopt@2 || 3", nopt@~3.0.1:
   version "3.0.6"
@@ -5429,6 +5430,12 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+parse5@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  dependencies:
+    "@types/node" "^6.0.46"
+
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -5507,6 +5514,10 @@ pbkdf2@^3.0.3:
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -5839,9 +5850,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.2.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+prettier@^1.7.0:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-format@^20.0.3:
   version "20.0.3"
@@ -5881,6 +5892,12 @@ promise.prototype.finally@^3.0.0:
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
   dependencies:
     asap "~2.0.3"
 
@@ -5988,6 +6005,23 @@ radium@^0.19.0:
     exenv "^1.2.1"
     inline-style-prefixer "^2.0.5"
     prop-types "^15.5.8"
+
+raf@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@^0.4.2:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -6490,6 +6524,10 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
 retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
@@ -6516,6 +6554,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+rst-selector-parser@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.2.tgz#9927b619bd5af8dc23a76c64caef04edf90d2c65"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 run-async@^0.1.0:
   version "0.1.0"
@@ -7258,6 +7303,10 @@ underscore.string@~2.2.0rc:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -7324,7 +7373,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -7486,7 +7535,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 


### PR DESCRIPTION
This PR is for handling updating the current Jest configuration and including updates for both `enzyme` and `prettier`, with support for snapshot testing through `enzyme-to-json` set as a serializer for Jest.

With the update to `enzyme`, approximately 30 test suites had to be updated because of their usage of older `enzyme` APIs. For example, consider the following example:

```js
it('should set defaultChecked as expected', () => {
    const wrapper = render({
      defaultChecked: true,
    });

    const input = wrapper.find('input');
    expect(input.props().defaultChecked).toEqual(true);
    wrapper.setProps({ defaultChecked: false });
    expect(input.props().defaultChecked).toEqual(false);
  });
```

In `enzyme@2.x`, the reference that `input` held would be the up-to-date version of the wrapper. However, with `enzyme@3`, the operations no longer happen in-memory and so we have to do the following variation of the above test:

```
  it('should set defaultChecked as expected', () => {
    const wrapper = render({
      defaultChecked: true,
    });

    const input = () => wrapper.find('input');
    expect(input().props().defaultChecked).toEqual(true);
    wrapper.setProps({ defaultChecked: false });
    expect(input().props().defaultChecked).toEqual(false);
  });
```

#### Changelog

**New**

- New `config` directory with a nested `jest` sub-directory with various file transformers

**Changed**

- `package.json`
  - now uses the `test` target as an alias to jest, all jest commands should be run off of that
  - Now includes a dedicated Jest config
  - Now includes a dedicated Prettier config
  - Scripts are now in alphabetical order
- `components`
  - Formatting updates
  - Test updates
- `CI`
  - Updated `.travis.yml` to account for the new `test` script

**Removed**

- `jest-setup.js` in favor of the `config` directory