### PR TITLE
feat(checkbox): allow more props to be rendered when not modified

### DIFF
--- a/components/Checkbox.js
+++ b/components/Checkbox.js
@@ -9,7 +9,7 @@ const propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  labelText: PropTypes.string,
+  labelText: PropTypes.node,
   onChange: PropTypes.func,
   iconDescription: PropTypes.string,
 };


### PR DESCRIPTION
e.g. the checkbox labelText is limited to be used with the string proptypes, so there will be warnings when passing in a number, or a valid component. 

As no modifications happen on the props and this is only something that gets rendered down the line, why limit its use? Use the proptype.node instead of proptype.string, proptype.number to allow anything that can be rendered to be passed in.

Everywhere in the code where props are simply being rendered without being modified, change the proptype from e.g. proptype.string, proptype.number to proptype.node