### PR TITLE
fix(Dropdown): call onClick for items if one exists

### DIFF
--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -91,7 +91,10 @@ class Dropdown extends PureComponent {
 
     const children = React.Children.map(this.props.children, child =>
       React.cloneElement(child, {
-        onClick: this.handleItemClick,
+        onClick: (...args) => {
+          child.props.onClick && child.props.onClick(...args);
+          this.handleItemClick(...args);
+        },
       }),
     );
 

--- a/components/__tests__/Dropdown-test.js
+++ b/components/__tests__/Dropdown-test.js
@@ -131,6 +131,7 @@ describe('Dropdown', () => {
       child.simulate('click');
       expect(wrapper.state().selectedText).toEqual('test-child');
     });
+
     it('should close dropdown on click outside', () => {
       wrapper.setState({ open: true });
       const listener = wrapper.find(ClickListener);
@@ -153,6 +154,32 @@ describe('Dropdown', () => {
       dropdown.simulate('keypress', { which: 32 });
       expect(dropdown.hasClass('bx--dropdown--open')).toEqual(false);
       expect(wrapper.state().open).toBe(false);
+    });
+
+    it('should invoke the `onClick` handler for a DropdownItem if one exists', () => {
+      const onChange = jest.fn();
+      const onClick = jest.fn();
+      const dropdown = mount(
+        <Dropdown
+          defaultText="Choose something..."
+          selectedText="NotValue"
+          onChange={onChange}>
+          <DropdownItem itemText="Value" value="Value" onClick={onClick} />
+        </Dropdown>
+      ).find('.bx--dropdown');
+      const item = dropdown.find(DropdownItem);
+
+      dropdown.simulate('click');
+      item.simulate('click');
+
+      const info = {
+        value: 'Value',
+        itemText: 'Value',
+      };
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledWith(info);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(info);
     });
   });
 });


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#29

Bugfix PR for #29, didn't know if we wanted to support this officially but figured I'd PR it to start the discussion 😄 

#### Changelog

**New**

**Changed**

- `Dropdown`
  - `children` in Dropdown are now cloned with an `onClick` handler that invokes the child's `onClick` prop (if it exists) and then calls `handleItemClick`.
- `Dropdown-test`
  - Added a simple test to verify the above behavior

**Removed**
