### PR TITLE
feat(CodeSnippet): add wrappedContentRef to access <pre> contents

### DIFF
--- a/components/CodeSnippet.js
+++ b/components/CodeSnippet.js
@@ -8,13 +8,21 @@ const propTypes = {
   className: PropTypes.string,
   children: PropTypes.string,
   onClick: PropTypes.func,
+  wrappedContentRef: PropTypes.func,
 };
 
 const defaultProps = {
   type: 'terminal',
 };
 
-const CodeSnippet = ({ className, type, children, onClick, ...other }) => {
+const CodeSnippet = ({
+  className,
+  type,
+  children,
+  onClick,
+  wrappedContentRef,
+  ...other,
+}) => {
   const snippetType = type === 'terminal'
     ? 'bx--snippet--terminal'
     : 'bx--snippet--code';
@@ -23,7 +31,7 @@ const CodeSnippet = ({ className, type, children, onClick, ...other }) => {
     <div className={wrapperClasses} {...other}>
       <div className="bx--snippet-container">
         <code>
-          <pre>{children}</pre>
+          <pre ref={wrappedContentRef}>{children}</pre>
         </code>
       </div>
       <CopyButton onClick={onClick} />

--- a/components/__tests__/CodeSnippet-test.js
+++ b/components/__tests__/CodeSnippet-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import CodeSnippet from '../CodeSnippet';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 describe('Code Snippet', () => {
   describe('Renders as expected', () => {
@@ -9,15 +9,31 @@ describe('Code Snippet', () => {
         {'node -v'}
       </CodeSnippet>,
     );
+
     it('should use the appropriate snippet class', () => {
       expect(snippet.hasClass('bx--snippet')).toEqual(true);
       expect(snippet.hasClass('bx--snippet--terminal')).toEqual(true);
     });
+
     it('should render children as expected', () => {
       expect(snippet.find('.bx--snippet-container').length).toBe(1);
     });
+
     it('should all for custom classes to be applied', () => {
       expect(snippet.hasClass('some-class')).toEqual(true);
     });
+  });
+
+  it('should expose a `ref` to the content through `wrappedContentRef`', () => {
+    let mockRef;
+    const wrappedContentRef = jest.fn(el => (mockRef = el));
+    const content = 'node -v';
+    mount(
+      <CodeSnippet type="terminal" wrappedContentRef={wrappedContentRef}>
+        {content}
+      </CodeSnippet>
+    );
+    expect(mockRef.textContent).toBe(content);
+    expect(wrappedContentRef).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#55

Updates `CodeSnippet` to include a new prop, `wrappedContentRef`, that allows access to the `<pre>` element in the component (making it easier to copy!).

#### Changelog

**New**

**Changed**

- `CodeSnippet`
  - Added `wrappedContentRef` as a new prop
- `CodeSnippet-test`
  - Added test to assert ref is called and passes the correct node

**Removed**
