### PR TITLE
fix(TableData): add a11y for expand toggle

### DIFF
--- a/components/TableData.js
+++ b/components/TableData.js
@@ -32,6 +32,12 @@ const TableData = props => {
             name="chevron--right"
             description="expand row"
             style={style}
+            tabIndex={0}
+            onKeyPress={evt => {
+              if (props.onClick && (evt.which === 13 || evt.which === 32)) {
+                props.onClick(evt)
+              }
+            }}
           />}
     </td>
   );

--- a/components/__tests__/TableData-test.js
+++ b/components/__tests__/TableData-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import TableData from '../TableData';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 describe('TableData', () => {
   describe('Renders as expected', () => {
@@ -16,6 +16,46 @@ describe('TableData', () => {
       td.setProps({ className: 'extra-class' });
       const tdEl = td.find('td');
       expect(tdEl.hasClass('extra-class')).toEqual(true);
+    });
+  });
+
+  describe('events', () => {
+    const onClick = jest.fn();
+    let wrapper;
+    let icon;
+
+    beforeEach(() => {
+      wrapper = mount(
+        <table>
+          <tbody>
+            <tr>
+              <TableData expanded onClick={onClick}>Content</TableData>
+            </tr>
+          </tbody>
+        </table>
+      );
+
+      icon = wrapper.find('.bx--table-expand__svg');
+    })
+
+    afterEach(() => {
+      onClick.mockClear()
+    })
+
+    it('should fire onClick on click', () => {
+      icon.simulate('click');
+      expect(onClick).toHaveBeenCalled();
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire onClick on enter or space', () => {
+      icon.simulate('keypress', { which: 13 });
+      expect(onClick).toHaveBeenCalled();
+      expect(onClick).toHaveBeenCalledTimes(1);
+      icon.simulate('keypress', { which: 32 });
+      expect(onClick).toHaveBeenCalledTimes(2);
+      icon.simulate('keypress', { which: 1 });
+      expect(onClick).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
Allows the icon to toggle with enter and space keys, not just click

Fixes #244