### PR TITLE
fix: Modify default props values

### DIFF
--- a/src/components/AccordionItem/AccordionItem-test.js
+++ b/src/components/AccordionItem/AccordionItem-test.js
@@ -122,4 +122,16 @@ describe('AccordionItem', () => {
       expect(toggler.state().open).toEqual(true);
     });
   });
+
+  describe('Check that defaults are working properly', () => {
+    const wrapper = shallow(
+      <AccordionItem className="extra-class">
+        Lorem ipsum.
+      </AccordionItem>
+    );
+
+    it('should not have a title attached', () => {
+      expect(wrapper.find('.bx--accordion__title').length).toBe(0);
+    });
+  });
 });

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -14,7 +14,7 @@ export default class AccordionItem extends Component {
   };
 
   static defaultProps = {
-    title: 'title',
+    title: '',
     open: false,
     onClick: () => {},
     onHeadingClick: () => {},
@@ -81,7 +81,9 @@ export default class AccordionItem extends Component {
             name="chevron--right"
             description="Expand/Collapse"
           />
-          <p className="bx--accordion__title">{title}</p>
+          {title && (
+            <p className="bx--accordion__title">{title}</p>
+          )}
         </div>
         <div className="bx--accordion__content">{children}</div>
       </li>

--- a/src/components/CardContent/CardContent-test.js
+++ b/src/components/CardContent/CardContent-test.js
@@ -94,4 +94,24 @@ describe('CardContent', () => {
       });
     });
   });
+
+  describe('Uses default props', () => {
+    const wrapper = shallow(
+      <CardContent>
+        <div className="child">Test</div>
+      </CardContent>
+    );
+
+    it('should not have a title attached', () => {
+      expect(wrapper.find('#card-app-title').length).toBe(0);
+    });
+
+    it('uses default card icon title', () => {
+      expect(wrapper.find('.bx--about__icon--img').props().name).toBe('app-services');
+    });
+
+    it('uses default card icon description', () => {
+      expect(wrapper.find('.bx--about__icon--img').props().description).toBe('card icon');
+    });
+  });
 });

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -49,9 +49,11 @@ const CardContent = ({
           />
         </div>
         <div className="bx--about__title">
-          <p id="card-app-title" className="bx--about__title--name">
+          {cardTitle && (
+            <p id="card-app-title" className="bx--about__title--name">
             {cardTitle}
           </p>
+          )}
           {cardLinkContentArray.map((info, key) => cardLinkContent[key])}
           {cardInfoContentArray.map((info, key) => cardInfoContent[key])}
         </div>
@@ -73,7 +75,7 @@ CardContent.propTypes = {
 CardContent.defaultProps = {
   iconDescription: 'card icon',
   cardIcon: 'app-services',
-  cardTitle: 'card title',
+  cardTitle: '',
 };
 
 export default CardContent;

--- a/src/components/Checkbox/Checkbox-test.js
+++ b/src/components/Checkbox/Checkbox-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Checkbox from '../Checkbox';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 describe('Checkbox', () => {
   describe('Renders as expected', () => {
@@ -102,6 +102,20 @@ describe('Checkbox', () => {
       expect(call[0]).toEqual(true);
       expect(call[1]).toEqual(id);
       expect(call[2].target).toBe(inputElement);
+    });
+  });
+
+  describe('Uses default props', () => {
+    const wrapper = shallow(
+      <Checkbox id="test" />
+    );
+
+    it('should not have a label attached', () => {
+      expect(wrapper.find('.bx--checkbox-label-text').length).toBe(0);
+    });
+
+    it('uses default icon description', () => {
+      expect(wrapper.find('.bx--checkbox-checkmark').props().description).toBe('Provide icon description for a11y');
     });
   });
 });

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -37,7 +37,9 @@ const Checkbox = ({
             name="checkmark"
           />
         </span>
-        <span className="bx--checkbox-label-text">{labelText}</span>
+        {labelText && (
+          <span className="bx--checkbox-label-text">{labelText}</span>
+        )}
       </label>
     </div>
   );
@@ -56,7 +58,7 @@ Checkbox.propTypes = {
 
 Checkbox.defaultProps = {
   onChange: () => {},
-  labelText: 'Provide checkbox label text',
+  labelText: '',
   iconDescription: 'Provide icon description for a11y',
 };
 

--- a/src/components/DatePickerInput/DatePickerInput-test.js
+++ b/src/components/DatePickerInput/DatePickerInput-test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import DatePickerInput from '../DatePickerInput';
+import { shallow } from 'enzyme';
+
+describe('DatePickerInput', () => {
+  describe('Uses default props', () => {
+    const wrapper = shallow(
+      <DatePickerInput id='testing'/>
+    );
+
+    it('does not include a label', () => {
+      expect(wrapper.find('.bx--label').length).toBe(0);
+    });
+
+  });
+});

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -13,7 +13,7 @@ export default class DatePickerInput extends Component {
     type: 'text',
     disabled: false,
     invalid: false,
-    labelText: 'Please provide label text',
+    labelText: '',
   };
 
   render() {

--- a/src/components/FormGroup/FormGroup-test.js
+++ b/src/components/FormGroup/FormGroup-test.js
@@ -43,5 +43,11 @@ describe('FormGroup', () => {
       );
       expect(formGroup1.find('.test-child').length).toBe(2);
     });
+    it('should not attach a message', () => {
+      expect(wrapper.find('.bx--form__requirements').length).toBe(0);
+    });
+    it('should not attach a label', () => {
+      expect(wrapper.find('label').length).toBe(0);
+    });
   });
 });

--- a/src/components/FormGroup/FormGroup.js
+++ b/src/components/FormGroup/FormGroup.js
@@ -19,9 +19,11 @@ const FormGroup = ({
       {...invalid && { 'data-invalid': '' }}
       className={classNamesFieldset}
       {...other}>
-      <legend className={classNamesLegend}>{legendText}</legend>
+      {legendText && (
+        <legend className={classNamesLegend}>{legendText}</legend>
+      )}
       {children}
-      {message ? (
+      {message && messageText ? (
         <div className="bx--form__requirements">{messageText}</div>
       ) : null}
     </fieldset>

--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -61,6 +61,14 @@ describe('Modal', () => {
         .at(1);
       expect(primaryButton.props().disabled).toEqual(true);
     });
+
+    it('does not have a heading attached', () => {
+      expect(wrapper.find('.bx--modal-header__heading').length).toBe(0);
+    });
+
+    it('does not have label attached', () => {
+      expect(wrapper.find('.bx--modal-header__label').length).toBe(0);
+    })
   });
 
   describe('Adds props as expected to the right children', () => {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -30,8 +30,8 @@ export default class Modal extends Component {
     onKeyDown: () => {},
     passiveModal: false,
     iconDescription: 'close the modal',
-    modalHeading: 'Provide a heading',
-    modalLabel: 'Provide a label',
+    modalHeading: '',
+    modalLabel: '',
   };
 
   handleKeyDown = evt => {
@@ -97,7 +97,11 @@ export default class Modal extends Component {
           {modalLabel && (
             <h4 className="bx--modal-header__label">{modalLabel}</h4>
           )}
-          <h2 className="bx--modal-header__heading">{modalHeading}</h2>
+          {modalHeading && (
+            <h2 className="bx--modal-header__heading">
+              {modalHeading}
+            </h2>
+          )}
           {!passiveModal && modalButton}
         </div>
         <div className="bx--modal-content">{this.props.children}</div>

--- a/src/components/ProgressIndicator/ProgressIndicator-test.js
+++ b/src/components/ProgressIndicator/ProgressIndicator-test.js
@@ -26,10 +26,7 @@ describe('ProgressIndicator', () => {
           label="label"
           description="Step 5: Getting Started with Node.js"
         />
-        <ProgressStep
-          label="label"
-          description="Step 6: Getting Started with Node.js"
-        />
+        <ProgressStep description="Step 6: Getting Started with Node.js" />
       </ProgressIndicator>
     );
     const list = shallow(progress);
@@ -75,6 +72,10 @@ describe('ProgressIndicator', () => {
             .props().label
         ).toEqual('label');
       });
+
+      it('should use default blank label', () => {
+        expect(mountedList.find(ProgressStep).at(5).props().label).toBe('');
+      })
 
       it('should render with a description', () => {
         expect(

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -45,7 +45,9 @@ export const ProgressStep = ({ ...props }) => {
         ) : null}
         {incomplete ? <circle cx="12" cy="12" r="12" /> : null}
       </svg>
-      <p className="bx--progress-label">{label}</p>
+      {label && (
+        <p className="bx--progress-label">{label}</p>
+      )}
       <span className="bx--progress-line" />
     </li>
   );
@@ -61,7 +63,7 @@ ProgressStep.propTypes = {
 };
 
 ProgressStep.defaultProps = {
-  label: 'Provide label',
+  label: '',
 };
 
 export class ProgressIndicator extends Component {

--- a/src/components/RadioButton/RadioButton-test.js
+++ b/src/components/RadioButton/RadioButton-test.js
@@ -59,6 +59,10 @@ describe('RadioButton', () => {
         expect(span.hasClass('bx--radio-button__appearance')).toEqual(true);
       });
 
+      it('should use default blank label', () => {
+        expect(label.text()).toBe('');
+      })
+
       it('should render label text', () => {
         wrapper.setProps({ labelText: 'test label text' });
         expect(label.text()).toMatch(/test label text/);

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -17,7 +17,7 @@ export default class RadioButton extends React.Component {
   };
 
   static defaultProps = {
-    labelText: 'Provide labelText',
+    labelText: '',
     onChange: () => {},
   };
 

--- a/src/components/Search/Search-test.js
+++ b/src/components/Search/Search-test.js
@@ -204,4 +204,14 @@ describe('Search', () => {
       });
     });
   });
+
+  describe('uses default props', () => {
+    const wrapper = mount(
+      <Search id="test" className="extra-class" />
+    );
+
+    it('does not attach a label', () => {
+      expect(wrapper.find('.bx--label').length).toBe(0);
+    });
+  })
 });

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -21,7 +21,7 @@ export default class Search extends Component {
     small: false,
     placeHolderText: '',
     onChange: () => {},
-    labelText: 'Provide labelText',
+    labelText: '',
   };
 
   state = {
@@ -146,9 +146,11 @@ export default class Search extends Component {
           description="search"
           className="bx--search-magnifier"
         />
-        <label htmlFor={id} className="bx--label">
-          {labelText}
-        </label>
+        {this.props.label && (
+          <label htmlFor={id} className="bx--label">
+            {labelText}
+          </label>
+        )}
         <input
           {...other}
           type={type}

--- a/src/components/TextArea/TextArea-test.js
+++ b/src/components/TextArea/TextArea-test.js
@@ -40,7 +40,7 @@ describe('TextArea', () => {
       });
 
       it('should set placeholder as expected', () => {
-        expect(textarea().props().placeholder).toEqual('Hint text here');
+        expect(textarea().props().placeholder).toEqual('');
         wrapper.setProps({ placeholder: 'Type here' });
         expect(textarea().props().placeholder).toEqual('Type here');
       });

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -77,12 +77,12 @@ Textarea.defaultProps = {
   disabled: false,
   onChange: () => {},
   onClick: () => {},
-  placeholder: 'Hint text here',
+  placeholder: '',
   rows: 4,
   cols: 50,
   invalid: false,
-  labelText: 'Provide labelText',
-  invalidText: 'Provide invalidText',
+  labelText: '',
+  invalidText: '',
 };
 
 export default Textarea;

--- a/src/components/TimePickerSelect/TimePickerSelect.js
+++ b/src/components/TimePickerSelect/TimePickerSelect.js
@@ -21,7 +21,7 @@ export default class TimePickerSelect extends Component {
     inline: true,
     iconDescription: 'open list of options',
     hideLabel: true,
-    labelText: 'Provide label text',
+    labelText: '',
   };
 
   render() {

--- a/src/components/Toolbar/Toolbar-test.js
+++ b/src/components/Toolbar/Toolbar-test.js
@@ -61,6 +61,20 @@ describe('Toolbar', () => {
       rootWrapper.props().onClickOutside();
       expect(rootWrapper.state().expanded).toEqual(false);
     });
+
+    describe('should use default props', () => {
+      const defaultToolbarSearch = shallow(
+        <ToolbarSearch />
+      );
+
+      it('should use default blank placeholder text', () => {
+        expect(defaultToolbarSearch.find('.bx--search-input').props().placeholder).toBe('');
+      });
+
+      it('should not attach a label', () => {
+        expect(defaultToolbarSearch.find('label').length).toBe(0);
+      });
+    });
   });
 
   describe('ToolbarItem with an overflow menu', () => {

--- a/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/src/components/ToolbarSearch/ToolbarSearch.js
@@ -18,8 +18,8 @@ export default class ToolbarSearch extends Component {
   static defaultProps = {
     type: 'search',
     id: 'search__input',
-    labelText: 'Provide labelText',
-    placeHolderText: 'Provide placeHolderText',
+    labelText: '',
+    placeHolderText: '',
     role: 'search',
   };
 
@@ -60,9 +60,11 @@ export default class ToolbarSearch extends Component {
     return (
       <ClickListener onClickOutside={this.handleClickOutside}>
         <div className={searchClasses} role={role}>
-          <label htmlFor={id} className="bx--label">
-            {labelText}
-          </label>
+          {labelText && (
+            <label htmlFor={id} className="bx--label">
+              {labelText}
+            </label>
+          )}
           <input
             {...other}
             type={type}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -22,7 +22,7 @@ export default class Tooltip extends Component {
     showIcon: true,
     iconName: 'info--glyph',
     iconDescription: 'tooltip',
-    triggerText: 'Provide triggerText',
+    triggerText: '',
   };
 
   state = {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#299
Closes https://github.com/carbon-design-system/carbon-components-react/issues/168

Modifies default values for placeholder and label text. This allows product teams to decide if they want to use certain props, without forcing a default message.

### Changelog

**Changed**

- Changed default label/placeholder text in a number of models.
- Added tests to account for defaults.