### PR TITLE
Update Component exports and PropType definitions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 node_modules
-cjs
+lib
 es
 storybook-static

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const Accordion = ({ children, className, ...other }) => {
   const classNames = classnames('bx--accordion', className);
   return (
@@ -16,6 +11,9 @@ const Accordion = ({ children, className, ...other }) => {
   );
 };
 
-Accordion.propTypes = propTypes;
+Accordion.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default Accordion;

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -1,2 +1,1 @@
-import Accordion from './Accordion';
-export default Accordion;
+export default from './Accordion';

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import Icon from '../Icon';
 
-class AccordionItem extends Component {
+export default class AccordionItem extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -88,5 +88,3 @@ class AccordionItem extends Component {
     );
   }
 }
-
-export default AccordionItem;

--- a/src/components/AccordionItem/index.js
+++ b/src/components/AccordionItem/index.js
@@ -1,2 +1,1 @@
-import AccordionItem from './AccordionItem';
-export default AccordionItem;
+export default from './AccordionItem';

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const Breadcrumb = ({ children, className, ...other }) => {
   const classNames = classnames('bx--breadcrumb', className);
   return (
@@ -16,6 +11,9 @@ const Breadcrumb = ({ children, className, ...other }) => {
   );
 };
 
-Breadcrumb.propTypes = propTypes;
+Breadcrumb.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default Breadcrumb;

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -1,2 +1,1 @@
-import Breadcrumb from './Breadcrumb';
-export default Breadcrumb;
+export default from './Breadcrumb';

--- a/src/components/BreadcrumbItem/BreadcrumbItem.js
+++ b/src/components/BreadcrumbItem/BreadcrumbItem.js
@@ -3,12 +3,6 @@ import React from 'react';
 import classnames from 'classnames';
 import Link from '../Link';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  href: PropTypes.string,
-};
-
 const BreadcrumbItem = ({ children, className, href, ...other }) => {
   const classNames = classnames('bx--breadcrumb-item', className);
   return (
@@ -18,6 +12,10 @@ const BreadcrumbItem = ({ children, className, href, ...other }) => {
   );
 };
 
-BreadcrumbItem.propTypes = propTypes;
+BreadcrumbItem.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  href: PropTypes.string,
+};
 
 export default BreadcrumbItem;

--- a/src/components/BreadcrumbItem/index.js
+++ b/src/components/BreadcrumbItem/index.js
@@ -1,2 +1,1 @@
-import BreadcrumbItem from './BreadcrumbItem';
-export default BreadcrumbItem;
+export default from './BreadcrumbItem';

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,36 +3,6 @@ import React from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  small: PropTypes.bool,
-  kind: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost']).isRequired,
-  href: PropTypes.string,
-  tabIndex: PropTypes.number,
-  type: PropTypes.oneOf(['button', 'reset', 'submit']),
-  role: PropTypes.string,
-  icon: PropTypes.string,
-  iconDescription: props => {
-    if (props.icon && !props.iconDescription) {
-      return new Error(
-        'icon property specified without also providing an iconDescription property.'
-      );
-    }
-    return undefined;
-  },
-};
-
-const defaultProps = {
-  iconDescription: 'Provide icon description if icon is used',
-  tabIndex: 0,
-  type: 'button',
-  disabled: false,
-  small: false,
-  kind: 'primary',
-};
-
 const Button = ({
   children,
   className,
@@ -81,7 +51,34 @@ const Button = ({
   return href ? anchor : button;
 };
 
-Button.propTypes = propTypes;
-Button.defaultProps = defaultProps;
+Button.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  small: PropTypes.bool,
+  kind: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost']).isRequired,
+  href: PropTypes.string,
+  tabIndex: PropTypes.number,
+  type: PropTypes.oneOf(['button', 'reset', 'submit']),
+  role: PropTypes.string,
+  icon: PropTypes.string,
+  iconDescription: props => {
+    if (props.icon && !props.iconDescription) {
+      return new Error(
+        'icon property specified without also providing an iconDescription property.'
+      );
+    }
+    return undefined;
+  },
+};
+
+Button.defaultProps = {
+  iconDescription: 'Provide icon description if icon is used',
+  tabIndex: 0,
+  type: 'button',
+  disabled: false,
+  small: false,
+  kind: 'primary',
+};
 
 export default Button;

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,2 +1,1 @@
-import Button from './Button';
-export default Button;
+export default from './Button';

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -2,7 +2,20 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
+const Card = ({ children, className, tabIndex, ...other }) => {
+  const cardClasses = classNames({
+    'bx--card': true,
+    [className]: className,
+  });
+
+  return (
+    <div {...other} className={cardClasses} tabIndex={tabIndex}>
+      {children}
+    </div>
+  );
+};
+
+Card.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   tabIndex: PropTypes.number,
@@ -17,24 +30,8 @@ const propTypes = {
   onMouseUp: PropTypes.func,
 };
 
-const defaultProps = {
+Card.defaultProps = {
   tabIndex: 0,
 };
-
-const Card = ({ children, className, tabIndex, ...other }) => {
-  const cardClasses = classNames({
-    'bx--card': true,
-    [className]: className,
-  });
-
-  return (
-    <div {...other} className={cardClasses} tabIndex={tabIndex}>
-      {children}
-    </div>
-  );
-};
-
-Card.propTypes = propTypes;
-Card.defaultProps = defaultProps;
 
 export default Card;

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,2 +1,1 @@
-import Card from './Card';
-export default Card;
+export default from './Card';

--- a/src/components/CardActionItem/CardActionItem.js
+++ b/src/components/CardActionItem/CardActionItem.js
@@ -3,19 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  className: PropTypes.string,
-  id: PropTypes.string,
-  ariaLabel: PropTypes.string,
-  iconName: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  ariaLabel: '',
-  description: 'card action',
-};
-
 const CardActionItem = ({
   className,
   id,
@@ -44,7 +31,17 @@ const CardActionItem = ({
   );
 };
 
-CardActionItem.propTypes = propTypes;
-CardActionItem.defaultProps = defaultProps;
+CardActionItem.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  iconName: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+CardActionItem.defaultProps = {
+  ariaLabel: '',
+  description: 'card action',
+};
 
 export default CardActionItem;

--- a/src/components/CardActionItem/index.js
+++ b/src/components/CardActionItem/index.js
@@ -1,2 +1,1 @@
-import CardActionItem from './CardActionItem';
-export default CardActionItem;
+export default from './CardActionItem';

--- a/src/components/CardActions/CardActions.js
+++ b/src/components/CardActions/CardActions.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const CardActions = ({ children, className, ...other }) => {
   const cardActionClasses = classNames({
     'bx--card-footer__app-actions': true,
@@ -20,6 +15,9 @@ const CardActions = ({ children, className, ...other }) => {
   );
 };
 
-CardActions.propTypes = propTypes;
+CardActions.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default CardActions;

--- a/src/components/CardActions/index.js
+++ b/src/components/CardActions/index.js
@@ -1,2 +1,1 @@
-import CardActions from './CardActions';
-export default CardActions;
+export default from './CardActions';

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -3,22 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  children: PropTypes.node,
-  cardIcon: PropTypes.string,
-  cardTitle: PropTypes.string,
-  cardLink: PropTypes.node,
-  cardInfo: PropTypes.array,
-  className: PropTypes.string,
-  iconDescription: PropTypes.string,
-};
-
-const defaultProps = {
-  iconDescription: 'card icon',
-  cardIcon: 'app-services',
-  cardTitle: 'card title',
-};
-
 const CardContent = ({
   className,
   children,
@@ -76,7 +60,20 @@ const CardContent = ({
   );
 };
 
-CardContent.propTypes = propTypes;
-CardContent.defaultProps = defaultProps;
+CardContent.propTypes = {
+  children: PropTypes.node,
+  cardIcon: PropTypes.string,
+  cardTitle: PropTypes.string,
+  cardLink: PropTypes.node,
+  cardInfo: PropTypes.array,
+  className: PropTypes.string,
+  iconDescription: PropTypes.string,
+};
+
+CardContent.defaultProps = {
+  iconDescription: 'card icon',
+  cardIcon: 'app-services',
+  cardTitle: 'card title',
+};
 
 export default CardContent;

--- a/src/components/CardContent/index.js
+++ b/src/components/CardContent/index.js
@@ -1,2 +1,1 @@
-import CardContent from './CardContent';
-export default CardContent;
+export default from './CardContent';

--- a/src/components/CardFooter/CardFooter.js
+++ b/src/components/CardFooter/CardFooter.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const CardFooter = ({ children, className, ...other }) => {
   const cardFooterClasses = classNames({
     'bx--card-footer': true,
@@ -20,6 +15,9 @@ const CardFooter = ({ children, className, ...other }) => {
   );
 };
 
-CardFooter.propTypes = propTypes;
+CardFooter.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default CardFooter;

--- a/src/components/CardFooter/index.js
+++ b/src/components/CardFooter/index.js
@@ -1,2 +1,1 @@
-import CardFooter from './CardFooter';
-export default CardFooter;
+export default from './CardFooter';

--- a/src/components/CardStatus/CardStatus.js
+++ b/src/components/CardStatus/CardStatus.js
@@ -2,21 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  status: PropTypes.number,
-  className: PropTypes.string,
-  runningText: PropTypes.string,
-  notRunningText: PropTypes.string,
-  stoppedText: PropTypes.string,
-};
-
-const defaultProps = {
-  status: 0,
-  runningText: 'Running',
-  notRunningText: 'Not Running',
-  stoppedText: 'Stopped',
-};
-
 const appStatus = {
   RUNNING: 0,
   NOT_RUNNING: 1,
@@ -71,8 +56,21 @@ const CardStatus = ({
   );
 };
 
-CardStatus.propTypes = propTypes;
-CardStatus.defaultProps = defaultProps;
+CardStatus.propTypes = {
+  status: PropTypes.number,
+  className: PropTypes.string,
+  runningText: PropTypes.string,
+  notRunningText: PropTypes.string,
+  stoppedText: PropTypes.string,
+};
+
+CardStatus.defaultProps = {
+  status: 0,
+  runningText: 'Running',
+  notRunningText: 'Not Running',
+  stoppedText: 'Stopped',
+};
+
 CardStatus.appStatus = appStatus;
 
 export default CardStatus;

--- a/src/components/CardStatus/index.js
+++ b/src/components/CardStatus/index.js
@@ -1,2 +1,1 @@
-import CardStatus from './CardStatus';
-export default CardStatus;
+export default from './CardStatus';

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -3,23 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  checked: PropTypes.bool,
-  defaultChecked: PropTypes.bool,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  id: PropTypes.string.isRequired,
-  labelText: PropTypes.node,
-  onChange: PropTypes.func,
-  iconDescription: PropTypes.string,
-};
-
-const defaultProps = {
-  onChange: () => {},
-  labelText: 'Provide checkbox label text',
-  iconDescription: 'Provide icon description for a11y',
-};
-
 const Checkbox = ({
   className,
   id,
@@ -60,7 +43,21 @@ const Checkbox = ({
   );
 };
 
-Checkbox.propTypes = propTypes;
-Checkbox.defaultProps = defaultProps;
+Checkbox.propTypes = {
+  checked: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  labelText: PropTypes.node,
+  onChange: PropTypes.func,
+  iconDescription: PropTypes.string,
+};
+
+Checkbox.defaultProps = {
+  onChange: () => {},
+  labelText: 'Provide checkbox label text',
+  iconDescription: 'Provide icon description for a11y',
+};
 
 export default Checkbox;

--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -1,2 +1,1 @@
-import Checkbox from './Checkbox';
-export default Checkbox;
+export default from './Checkbox';

--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -3,18 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import CopyButton from '../CopyButton';
 
-const propTypes = {
-  type: PropTypes.string,
-  className: PropTypes.string,
-  children: PropTypes.string,
-  onClick: PropTypes.func,
-  wrappedContentRef: PropTypes.func,
-};
-
-const defaultProps = {
-  type: 'terminal',
-};
-
 const CodeSnippet = ({
   className,
   type,
@@ -39,7 +27,16 @@ const CodeSnippet = ({
   );
 };
 
-CodeSnippet.propTypes = propTypes;
-CodeSnippet.defaultProps = defaultProps;
+CodeSnippet.propTypes = {
+  type: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.string,
+  onClick: PropTypes.func,
+  wrappedContentRef: PropTypes.func,
+};
+
+CodeSnippet.defaultProps = {
+  type: 'terminal',
+};
 
 export default CodeSnippet;

--- a/src/components/CodeSnippet/index.js
+++ b/src/components/CodeSnippet/index.js
@@ -1,2 +1,1 @@
-import CodeSnippet from './CodeSnippet';
-export default CodeSnippet;
+export default from './CodeSnippet';

--- a/src/components/ComposedModal/index.js
+++ b/src/components/ComposedModal/index.js
@@ -1,5 +1,2 @@
-export {
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-} from './ComposedModal';
+export * from './ComposedModal';
+export default from './ComposedModal';

--- a/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/src/components/ContentSwitcher/ContentSwitcher.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-class ContentSwitcher extends React.Component {
+export default class ContentSwitcher extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -56,5 +56,3 @@ class ContentSwitcher extends React.Component {
     );
   }
 }
-
-export default ContentSwitcher;

--- a/src/components/ContentSwitcher/index.js
+++ b/src/components/ContentSwitcher/index.js
@@ -1,2 +1,1 @@
-import ContentSwitcher from './ContentSwitcher';
-export default ContentSwitcher;
+export default from './ContentSwitcher';

--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -1,2 +1,1 @@
-import CopyButton from './CopyButton';
-export default CopyButton;
+export default from './CopyButton';

--- a/src/components/DangerButton/index.js
+++ b/src/components/DangerButton/index.js
@@ -1,2 +1,1 @@
-import DangerButton from './DangerButton';
-export default DangerButton;
+export default from './DangerButton';

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -15,7 +15,7 @@ flatpickr.l10ns.en.weekdays.shorthand.forEach((day, index) => {
   }
 });
 
-class DatePicker extends Component {
+export default class DatePicker extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -222,5 +222,3 @@ class DatePicker extends Component {
     );
   }
 }
-
-export default DatePicker;

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -1,2 +1,1 @@
-import DatePicker from './DatePicker';
-export default DatePicker;
+export default from './DatePicker';

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 
-class DatePickerInput extends Component {
+export default class DatePickerInput extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     children: PropTypes.node,
@@ -109,5 +109,3 @@ class DatePickerInput extends Component {
     );
   }
 }
-
-export default DatePickerInput;

--- a/src/components/DatePickerInput/index.js
+++ b/src/components/DatePickerInput/index.js
@@ -1,2 +1,1 @@
-import DatePickerInput from './DatePickerInput';
-export default DatePickerInput;
+export default from './DatePickerInput';

--- a/src/components/DetailPageHeader/DetailPageHeader.js
+++ b/src/components/DetailPageHeader/DetailPageHeader.js
@@ -8,7 +8,7 @@ import Tabs from '../Tabs';
 import OverflowMenu from '../OverflowMenu';
 import Icon from '../Icon';
 
-class DetailPageHeader extends Component {
+export default class DetailPageHeader extends Component {
   static propTypes = {
     children: PropTypes.node,
     title: PropTypes.string.isRequired,
@@ -165,5 +165,3 @@ class DetailPageHeader extends Component {
     );
   }
 }
-
-export default DetailPageHeader;

--- a/src/components/DetailPageHeader/index.js
+++ b/src/components/DetailPageHeader/index.js
@@ -1,2 +1,1 @@
-import DetailPageHeader from './DetailPageHeader';
-export default DetailPageHeader;
+export default from './DetailPageHeader';

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import ClickListener from '../../internal/ClickListener';
 import Icon from '../Icon';
 
-class Dropdown extends PureComponent {
+export default class Dropdown extends PureComponent {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -139,5 +139,3 @@ class Dropdown extends PureComponent {
     return dropdown;
   }
 }
-
-export default Dropdown;

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,2 +1,1 @@
-import Dropdown from './Dropdown';
-export default Dropdown;
+export default from './Dropdown';

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -2,17 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  value: PropTypes.string.isRequired,
-  itemText: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  onClick: PropTypes.func,
-};
-
-const defaultProps = {
-  onClick: /* istanbul ignore next */ () => {},
-};
-
 const DropdownItem = ({ className, value, itemText, onClick, ...other }) => {
   const dropdownItemClasses = classNames({
     'bx--dropdown-item': true,
@@ -43,7 +32,15 @@ const DropdownItem = ({ className, value, itemText, onClick, ...other }) => {
   );
 };
 
-DropdownItem.propTypes = propTypes;
-DropdownItem.defaultProps = defaultProps;
+DropdownItem.propTypes = {
+  value: PropTypes.string.isRequired,
+  itemText: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+DropdownItem.defaultProps = {
+  onClick: /* istanbul ignore next */ () => {},
+};
 
 export default DropdownItem;

--- a/src/components/DropdownItem/index.js
+++ b/src/components/DropdownItem/index.js
@@ -1,2 +1,1 @@
-import DropdownItem from './DropdownItem';
-export default DropdownItem;
+export default from './DropdownItem';

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import uid from '../../tools/uniqueId';
 
-class FileUploaderButton extends Component {
+export class FileUploaderButton extends Component {
   static propTypes = {
     className: PropTypes.string,
     disableLabelChanges: PropTypes.bool,
@@ -99,7 +99,7 @@ class FileUploaderButton extends Component {
   }
 }
 
-class Filename extends Component {
+export class Filename extends Component {
   static propTypes = {
     style: PropTypes.object,
     status: PropTypes.oneOf(['edit', 'complete', 'uploading']),
@@ -154,7 +154,7 @@ class Filename extends Component {
   }
 }
 
-class FileUploader extends Component {
+export default class FileUploader extends Component {
   static propTypes = {
     iconDescription: PropTypes.string,
     buttonLabel: PropTypes.string,
@@ -272,6 +272,3 @@ class FileUploader extends Component {
     );
   }
 }
-
-export default FileUploader;
-export { FileUploaderButton, Filename };

--- a/src/components/FileUploader/index.js
+++ b/src/components/FileUploader/index.js
@@ -1,3 +1,2 @@
-import FileUploader, { FileUploaderButton, Filename } from './FileUploader';
-export default FileUploader;
-export { FileUploaderButton, Filename };
+export * from './FileUploader';
+export default from './FileUploader';

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -4,28 +4,6 @@ import classnames from 'classnames';
 import Link from '../Link';
 import Button from '../Button';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  labelOne: PropTypes.string,
-  linkTextOne: PropTypes.string,
-  linkHrefOne: PropTypes.string,
-  labelTwo: PropTypes.string,
-  linkTextTwo: PropTypes.string,
-  linkHrefTwo: PropTypes.string,
-  buttonText: PropTypes.string,
-};
-
-const defaultProps = {
-  labelOne: 'Need Help?',
-  linkTextOne: 'Contact Bluemix Sales',
-  linkHrefOne: '#',
-  labelTwo: 'Estimate Monthly Cost',
-  linkTextTwo: 'Cost Calculator',
-  linkHrefTwo: '#',
-  buttonText: 'Create',
-};
-
 const Footer = ({
   className,
   children,
@@ -68,7 +46,26 @@ const Footer = ({
   return footer;
 };
 
-Footer.propTypes = propTypes;
-Footer.defaultProps = defaultProps;
+Footer.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  labelOne: PropTypes.string,
+  linkTextOne: PropTypes.string,
+  linkHrefOne: PropTypes.string,
+  labelTwo: PropTypes.string,
+  linkTextTwo: PropTypes.string,
+  linkHrefTwo: PropTypes.string,
+  buttonText: PropTypes.string,
+};
+
+Footer.defaultProps = {
+  labelOne: 'Need Help?',
+  linkTextOne: 'Contact Bluemix Sales',
+  linkHrefOne: '#',
+  labelTwo: 'Estimate Monthly Cost',
+  linkTextTwo: 'Cost Calculator',
+  linkHrefTwo: '#',
+  buttonText: 'Create',
+};
 
 export default Footer;

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,2 +1,1 @@
-import Footer from './Footer';
-export default Footer;
+export default from './Footer';

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const Form = ({ className, children, ...other }) => {
   const classNames = classnames('bx--form', className);
 
@@ -18,6 +13,9 @@ const Form = ({ className, children, ...other }) => {
   );
 };
 
-Form.propTypes = propTypes;
+Form.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default Form;

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -1,2 +1,1 @@
-import Form from './Form';
-export default Form;
+export default from './Form';

--- a/src/components/FormGroup/FormGroup.js
+++ b/src/components/FormGroup/FormGroup.js
@@ -2,21 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  legendText: PropTypes.string,
-  className: PropTypes.string,
-  invalid: PropTypes.bool,
-  message: PropTypes.bool,
-  messageText: PropTypes.string,
-};
-const defaultProps = {
-  invalid: false,
-  message: false,
-  messageText: 'Provide message text',
-  legendText: 'Provide legend text',
-};
-
 const FormGroup = ({
   legendText,
   invalid,
@@ -43,7 +28,20 @@ const FormGroup = ({
   );
 };
 
-FormGroup.propTypes = propTypes;
-FormGroup.defaultProps = defaultProps;
+FormGroup.propTypes = {
+  children: PropTypes.node,
+  legendText: PropTypes.string,
+  className: PropTypes.string,
+  invalid: PropTypes.bool,
+  message: PropTypes.bool,
+  messageText: PropTypes.string,
+};
+
+FormGroup.defaultProps = {
+  invalid: false,
+  message: false,
+  messageText: 'Provide message text',
+  legendText: 'Provide legend text',
+};
 
 export default FormGroup;

--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -1,2 +1,1 @@
-import FormGroup from './FormGroup';
-export default FormGroup;
+export default from './FormGroup';

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -2,25 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import icons from 'carbon-icons';
 
-const propTypes = {
-  className: PropTypes.string,
-  description: PropTypes.string.isRequired,
-  fill: PropTypes.string,
-  fillRule: PropTypes.string,
-  height: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  role: PropTypes.string,
-  style: PropTypes.object,
-  viewBox: PropTypes.string,
-  width: PropTypes.string,
-};
-
-const defaultProps = {
-  fillRule: 'evenodd',
-  role: 'img',
-  description: 'Provide a description that will be used as the title',
-};
-
 /**
  * Returns a single icon Object
  * @param {string} iconName - "name" property of icon
@@ -131,9 +112,24 @@ const Icon = ({
   );
 };
 
-Icon.propTypes = propTypes;
-Icon.defaultProps = defaultProps;
+Icon.propTypes = {
+  className: PropTypes.string,
+  description: PropTypes.string.isRequired,
+  fill: PropTypes.string,
+  fillRule: PropTypes.string,
+  height: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  role: PropTypes.string,
+  style: PropTypes.object,
+  viewBox: PropTypes.string,
+  width: PropTypes.string,
+};
+
+Icon.defaultProps = {
+  fillRule: 'evenodd',
+  role: 'img',
+  description: 'Provide a description that will be used as the title',
+};
 
 export { icons };
-
 export default Icon;

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,3 +1,2 @@
-import Icon, { findIcon, svgShapes, getSvgData, icons, isPrefixed } from './Icon';
-export default Icon;
-export { findIcon, svgShapes, getSvgData, icons, isPrefixed };
+export * from './Icon';
+export default from './Icon';

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -7,7 +7,7 @@ import InteriorLeftNavList from '../InteriorLeftNavList';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import Icon from '../Icon';
 
-class InteriorLeftNav extends Component {
+export default class InteriorLeftNav extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -139,5 +139,3 @@ class InteriorLeftNav extends Component {
     );
   }
 }
-
-export default InteriorLeftNav;

--- a/src/components/InteriorLeftNav/index.js
+++ b/src/components/InteriorLeftNav/index.js
@@ -1,2 +1,1 @@
-import InteriorLeftNav from './InteriorLeftNav';
-export default InteriorLeftNav;
+export default from './InteriorLeftNav';

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -2,24 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  href: PropTypes.string.isRequired,
-  activeHref: PropTypes.string,
-  tabIndex: PropTypes.number,
-  onClick: PropTypes.func,
-  blankTarget: PropTypes.bool,
-  children: PropTypes.node,
-  label: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  activeHref: '#',
-  tabIndex: 0,
-  label: 'InteriorLeftNavItem Label',
-  onClick: /* istanbul ignore next */ () => {},
-};
-
 const newChild = (children, tabIndex) => {
   const child = React.Children.only(children);
   return React.cloneElement(React.Children.only(child), {
@@ -61,7 +43,22 @@ const InteriorLeftNavItem = ({
   );
 };
 
-InteriorLeftNavItem.propTypes = propTypes;
-InteriorLeftNavItem.defaultProps = defaultProps;
+InteriorLeftNavItem.propTypes = {
+  className: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  activeHref: PropTypes.string,
+  tabIndex: PropTypes.number,
+  onClick: PropTypes.func,
+  blankTarget: PropTypes.bool,
+  children: PropTypes.node,
+  label: PropTypes.string.isRequired,
+};
+
+InteriorLeftNavItem.defaultProps = {
+  activeHref: '#',
+  tabIndex: 0,
+  label: 'InteriorLeftNavItem Label',
+  onClick: /* istanbul ignore next */ () => {},
+};
 
 export default InteriorLeftNavItem;

--- a/src/components/InteriorLeftNavItem/index.js
+++ b/src/components/InteriorLeftNavItem/index.js
@@ -1,2 +1,1 @@
-import InteriorLeftNavItem from './InteriorLeftNavItem';
-export default InteriorLeftNavItem;
+export default from './InteriorLeftNavItem';

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import Icon from '../Icon';
 
-class InteriorLeftNavList extends Component {
+export default class InteriorLeftNavList extends Component {
   static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
@@ -112,5 +112,3 @@ class InteriorLeftNavList extends Component {
     );
   }
 }
-
-export default InteriorLeftNavList;

--- a/src/components/InteriorLeftNavList/index.js
+++ b/src/components/InteriorLeftNavList/index.js
@@ -1,2 +1,1 @@
-import InteriorLeftNavList from './InteriorLeftNavList';
-export default InteriorLeftNavList;
+export default from './InteriorLeftNavList';

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -2,12 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  href: PropTypes.string,
-};
-
 const Link = ({ children, className, href, ...other }) => {
   const classNames = classnames('bx--link', className);
   return (
@@ -17,6 +11,10 @@ const Link = ({ children, className, href, ...other }) => {
   );
 };
 
-Link.propTypes = propTypes;
+Link.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  href: PropTypes.string,
+};
 
 export default Link;

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,2 +1,1 @@
-import Link from './Link';
-export default Link;
+export default from './Link';

--- a/src/components/ListItem/ListItem.js
+++ b/src/components/ListItem/ListItem.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const ListItem = ({ children, className, ...other }) => {
   const classNames = classnames('bx--list__item', className);
   return (
@@ -16,6 +11,9 @@ const ListItem = ({ children, className, ...other }) => {
   );
 };
 
-ListItem.propTypes = propTypes;
+ListItem.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default ListItem;

--- a/src/components/ListItem/index.js
+++ b/src/components/ListItem/index.js
@@ -1,2 +1,1 @@
-import ListItem from './ListItem';
-export default ListItem;
+export default from './ListItem';

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-class Loading extends React.Component {
+export default class Loading extends React.Component {
   static propTypes = {
     active: PropTypes.bool,
     className: PropTypes.string,
@@ -39,5 +39,3 @@ class Loading extends React.Component {
     );
   }
 }
-
-export default Loading;

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -1,2 +1,1 @@
-import Loading from './Loading';
-export default Loading;
+export default from './Loading';

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import Button from '../Button';
 
-class Modal extends Component {
+export default class Modal extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -132,5 +132,3 @@ class Modal extends Component {
     );
   }
 }
-
-export default Modal;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,2 +1,1 @@
-import Modal from './Modal';
-export default Modal;
+export default from './Modal';

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
 
-class ModalWrapper extends React.Component {
+export default class ModalWrapper extends React.Component {
   static propTypes = {
     status: PropTypes.string,
     handleOpen: PropTypes.func,
@@ -83,5 +83,3 @@ class ModalWrapper extends React.Component {
     );
   }
 }
-
-export default ModalWrapper;

--- a/src/components/ModalWrapper/index.js
+++ b/src/components/ModalWrapper/index.js
@@ -1,2 +1,1 @@
-import ModalWrapper from './ModalWrapper';
-export default ModalWrapper;
+export default from './ModalWrapper';

--- a/src/components/Module/index.js
+++ b/src/components/Module/index.js
@@ -1,1 +1,2 @@
-export { Module, ModuleBody, ModuleHeader } from './Module';
+export * from './Module';
+export default from './Module';

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-class NotificationButton extends Component {
+export class NotificationButton extends Component {
   static propTypes = {
     className: PropTypes.string,
     ariaLabel: PropTypes.string,
@@ -56,7 +56,7 @@ class NotificationButton extends Component {
   }
 }
 
-class NotificationTextDetails extends Component {
+export class NotificationTextDetails extends Component {
   static propTypes = {
     title: PropTypes.string,
     subtitle: PropTypes.node,
@@ -95,7 +95,7 @@ class NotificationTextDetails extends Component {
   }
 }
 
-class ToastNotification extends Component {
+export class ToastNotification extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -176,7 +176,7 @@ class ToastNotification extends Component {
   }
 }
 
-class InlineNotification extends Component {
+export class InlineNotification extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -259,7 +259,7 @@ class InlineNotification extends Component {
 
 // Deprecated
 
-class Notification extends Component {
+export default class Notification extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -369,11 +369,3 @@ class Notification extends Component {
     return caption ? toastHTML : inlineHTML;
   }
 }
-
-export default Notification;
-export {
-  ToastNotification,
-  InlineNotification,
-  NotificationButton,
-  NotificationTextDetails,
-};

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -1,13 +1,2 @@
-import Notification, {
-  NotificationButton,
-  NotificationTextDetails,
-  ToastNotification,
-  InlineNotification
-} from './Notification';
-export {
-  ToastNotification,
-  InlineNotification,
-  NotificationButton,
-  NotificationTextDetails,
-};
-export default Notification;
+export * from './Notification';
+export default from './Notification';

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
-class NumberInput extends Component {
+export default class NumberInput extends Component {
   static propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
@@ -139,5 +139,3 @@ class NumberInput extends Component {
     );
   }
 }
-
-export default NumberInput;

--- a/src/components/NumberInput/index.js
+++ b/src/components/NumberInput/index.js
@@ -1,2 +1,1 @@
-import NumberInput from './NumberInput';
-export default NumberInput;
+export default from './NumberInput';

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Link from '../Link';
 
-class OrderSummary extends Component {
+export class OrderSummary extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -21,7 +21,7 @@ class OrderSummary extends Component {
   }
 }
 
-class OrderSummaryHeader extends Component {
+export class OrderSummaryHeader extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -45,7 +45,7 @@ class OrderSummaryHeader extends Component {
   }
 }
 
-class OrderSummaryList extends Component {
+export class OrderSummaryList extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -63,7 +63,7 @@ class OrderSummaryList extends Component {
   }
 }
 
-class OrderSummaryCategory extends Component {
+export class OrderSummaryCategory extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -87,7 +87,7 @@ class OrderSummaryCategory extends Component {
   }
 }
 
-class OrderSummaryListItem extends Component {
+export class OrderSummaryListItem extends Component {
   static propTypes = {
     className: PropTypes.string,
     text: PropTypes.string,
@@ -112,7 +112,7 @@ class OrderSummaryListItem extends Component {
   }
 }
 
-class OrderSummaryTotal extends Component {
+export class OrderSummaryTotal extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -153,7 +153,7 @@ class OrderSummaryTotal extends Component {
   }
 }
 
-class OrderSummaryFooter extends Component {
+export class OrderSummaryFooter extends Component {
   static propTypes = {
     className: PropTypes.string,
     linkText: PropTypes.string,
@@ -193,13 +193,3 @@ class OrderSummaryFooter extends Component {
     );
   }
 }
-
-export {
-  OrderSummary,
-  OrderSummaryHeader,
-  OrderSummaryCategory,
-  OrderSummaryList,
-  OrderSummaryListItem,
-  OrderSummaryTotal,
-  OrderSummaryFooter,
-};

--- a/src/components/OrderSummary/index.js
+++ b/src/components/OrderSummary/index.js
@@ -1,9 +1,1 @@
-export {
-  OrderSummary,
-  OrderSummaryHeader,
-  OrderSummaryCategory,
-  OrderSummaryTotal,
-  OrderSummaryFooter,
-  OrderSummaryList,
-  OrderSummaryListItem,
-} from './OrderSummary';
+export * from './OrderSummary';

--- a/src/components/OrderedList/OrderedList.js
+++ b/src/components/OrderedList/OrderedList.js
@@ -2,16 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  nested: PropTypes.bool,
-};
-
-const defaultProps = {
-  nested: false,
-};
-
 const OrderedList = ({ children, className, nested, ...other }) => {
   const classNames = classnames('bx--list--ordered', className, {
     'bx--list--nested': nested,
@@ -23,7 +13,14 @@ const OrderedList = ({ children, className, nested, ...other }) => {
   );
 };
 
-OrderedList.propTypes = propTypes;
-OrderedList.defaultProps = defaultProps;
+OrderedList.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  nested: PropTypes.bool,
+};
+
+OrderedList.defaultProps = {
+  nested: false,
+};
 
 export default OrderedList;

--- a/src/components/OrderedList/index.js
+++ b/src/components/OrderedList/index.js
@@ -1,2 +1,1 @@
-import OrderedList from './OrderedList';
-export default OrderedList;
+export default from './OrderedList';

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -6,7 +6,7 @@ import FloatingMenu from '../../internal/FloatingMenu';
 import OptimizedResize from '../../internal/OptimizedResize';
 import Icon from '../Icon';
 
-class OverflowMenu extends Component {
+export default class OverflowMenu extends Component {
   static propTypes = {
     open: PropTypes.bool,
     flipped: PropTypes.bool,
@@ -170,5 +170,3 @@ class OverflowMenu extends Component {
     );
   }
 }
-
-export default OverflowMenu;

--- a/src/components/OverflowMenu/index.js
+++ b/src/components/OverflowMenu/index.js
@@ -1,2 +1,1 @@
-import OverflowMenu from './OverflowMenu';
-export default OverflowMenu;
+export default from './OverflowMenu';

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -2,30 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  itemText: PropTypes.string.isRequired,
-  hasDivider: PropTypes.bool,
-  isDelete: PropTypes.bool,
-  onBlur: PropTypes.func,
-  onClick: PropTypes.func,
-  onFocus: PropTypes.func,
-  onKeyDown: PropTypes.func,
-  onKeyUp: PropTypes.func,
-  onMouseDown: PropTypes.func,
-  onMouseEnter: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  onMouseUp: PropTypes.func,
-  closeMenu: PropTypes.func,
-};
-
-const defaultProps = {
-  hasDivider: false,
-  isDelete: false,
-  itemText: 'Provide itemText',
-  onClick: () => {},
-};
-
 const OverflowMenuItem = ({
   className,
   itemText,
@@ -68,7 +44,28 @@ const OverflowMenuItem = ({
   return item;
 };
 
-OverflowMenuItem.propTypes = propTypes;
-OverflowMenuItem.defaultProps = defaultProps;
+OverflowMenuItem.propTypes = {
+  className: PropTypes.string,
+  itemText: PropTypes.string.isRequired,
+  hasDivider: PropTypes.bool,
+  isDelete: PropTypes.bool,
+  onBlur: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onKeyUp: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  closeMenu: PropTypes.func,
+};
+
+OverflowMenuItem.defaultProps = {
+  hasDivider: false,
+  isDelete: false,
+  itemText: 'Provide itemText',
+  onClick: () => {},
+};
 
 export default OverflowMenuItem;

--- a/src/components/OverflowMenuItem/index.js
+++ b/src/components/OverflowMenuItem/index.js
@@ -1,2 +1,1 @@
-import OverflowMenuItem from './OverflowMenuItem';
-export default OverflowMenuItem;
+export default from './OverflowMenuItem';

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -7,7 +7,7 @@ import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
 import { equals } from '../../tools/array';
 
-class Pagination extends Component {
+export default class Pagination extends Component {
   static propTypes = {
     backwardText: PropTypes.string,
     className: PropTypes.string,
@@ -206,5 +206,3 @@ class Pagination extends Component {
     );
   }
 }
-
-export default Pagination;

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,2 +1,1 @@
-import Pagination from './Pagination';
-export default Pagination;
+export default from './Pagination';

--- a/src/components/PrimaryButton/index.js
+++ b/src/components/PrimaryButton/index.js
@@ -1,2 +1,1 @@
-import PrimaryButton from './PrimaryButton';
-export default PrimaryButton;
+export default from './PrimaryButton';

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -2,20 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  label: PropTypes.string,
-  className: PropTypes.string,
-  current: PropTypes.bool,
-  complete: PropTypes.bool,
-  incomplete: PropTypes.bool,
-  description: PropTypes.string,
-};
-
-const defaultProps = {
-  label: 'Provide label',
-};
-
-const ProgressStep = ({ ...props }) => {
+export const ProgressStep = ({ ...props }) => {
   const {
     label,
     description,
@@ -64,10 +51,20 @@ const ProgressStep = ({ ...props }) => {
   );
 };
 
-ProgressStep.propTypes = propTypes;
-ProgressStep.defaultProps = defaultProps;
+ProgressStep.propTypes = {
+  label: PropTypes.string,
+  className: PropTypes.string,
+  current: PropTypes.bool,
+  complete: PropTypes.bool,
+  incomplete: PropTypes.bool,
+  description: PropTypes.string,
+};
 
-class ProgressIndicator extends Component {
+ProgressStep.defaultProps = {
+  label: 'Provide label',
+};
+
+export class ProgressIndicator extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -119,5 +116,3 @@ class ProgressIndicator extends Component {
     );
   }
 }
-
-export { ProgressIndicator, ProgressStep };

--- a/src/components/ProgressIndicator/index.js
+++ b/src/components/ProgressIndicator/index.js
@@ -1,1 +1,1 @@
-export { ProgressIndicator, ProgressStep } from './ProgressIndicator';
+export * from './ProgressIndicator';

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import uid from '../../tools/uniqueId';
 
-class RadioButton extends React.Component {
+export default class RadioButton extends React.Component {
   static propTypes = {
     checked: PropTypes.bool,
     className: PropTypes.string,
@@ -54,5 +54,3 @@ class RadioButton extends React.Component {
     );
   }
 }
-
-export default RadioButton;

--- a/src/components/RadioButton/index.js
+++ b/src/components/RadioButton/index.js
@@ -1,2 +1,2 @@
-import RadioButton from './RadioButton';
-export default RadioButton;
+export * from './RadioButton';
+export default from './RadioButton';

--- a/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -3,7 +3,7 @@ import React from 'react';
 import RadioButton from '../RadioButton';
 import warning from 'warning';
 
-class RadioButtonGroup extends React.Component {
+export default class RadioButtonGroup extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -83,5 +83,3 @@ class RadioButtonGroup extends React.Component {
     );
   }
 }
-
-export default RadioButtonGroup;

--- a/src/components/RadioButtonGroup/index.js
+++ b/src/components/RadioButtonGroup/index.js
@@ -1,2 +1,1 @@
-import RadioButtonGroup from './RadioButtonGroup';
-export default RadioButtonGroup;
+export default from './RadioButtonGroup';

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-class Search extends Component {
+export default class Search extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -172,5 +172,3 @@ class Search extends Component {
     );
   }
 }
-
-export default Search;

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -1,2 +1,1 @@
-import Search from './Search';
-export default Search;
+export default from './Search';

--- a/src/components/SecondaryButton/index.js
+++ b/src/components/SecondaryButton/index.js
@@ -1,2 +1,1 @@
-import SecondaryButton from './SecondaryButton';
-export default SecondaryButton;
+export default from './SecondaryButton';

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -3,26 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  id: PropTypes.string.isRequired,
-  inline: PropTypes.bool,
-  labelText: PropTypes.string,
-  onChange: PropTypes.func,
-  disabled: PropTypes.bool,
-  defaultValue: PropTypes.any,
-  iconDescription: PropTypes.string,
-  hideLabel: PropTypes.bool,
-};
-
-const defaultProps = {
-  disabled: false,
-  labelText: 'Select',
-  inline: false,
-  iconDescription: 'open list of options',
-};
-
 const Select = ({
   className,
   id,
@@ -72,7 +52,24 @@ const Select = ({
   );
 };
 
-Select.propTypes = propTypes;
-Select.defaultProps = defaultProps;
+Select.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  inline: PropTypes.bool,
+  labelText: PropTypes.string,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  defaultValue: PropTypes.any,
+  iconDescription: PropTypes.string,
+  hideLabel: PropTypes.bool,
+};
+
+Select.defaultProps = {
+  disabled: false,
+  labelText: 'Select',
+  inline: false,
+  iconDescription: 'open list of options',
+};
 
 export default Select;

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -1,2 +1,1 @@
-import Select from './Select';
-export default Select;
+export default from './Select';

--- a/src/components/SelectItem/SelectItem.js
+++ b/src/components/SelectItem/SelectItem.js
@@ -2,21 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  value: PropTypes.any.isRequired,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  hidden: PropTypes.bool,
-  text: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  disabled: false,
-  hidden: false,
-  value: '',
-  text: '',
-};
-
 const SelectItem = ({ className, value, disabled, hidden, text, ...other }) => {
   const selectItemClasses = classNames({
     'bx--select-option': true,
@@ -35,7 +20,19 @@ const SelectItem = ({ className, value, disabled, hidden, text, ...other }) => {
   );
 };
 
-SelectItem.propTypes = propTypes;
-SelectItem.defaultProps = defaultProps;
+SelectItem.propTypes = {
+  value: PropTypes.any.isRequired,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  hidden: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+};
+
+SelectItem.defaultProps = {
+  disabled: false,
+  hidden: false,
+  value: '',
+  text: '',
+};
 
 export default SelectItem;

--- a/src/components/SelectItem/index.js
+++ b/src/components/SelectItem/index.js
@@ -1,2 +1,1 @@
-import SelectItem from './SelectItem';
-export default SelectItem;
+export default from './SelectItem';

--- a/src/components/SelectItemGroup/SelectItemGroup.js
+++ b/src/components/SelectItemGroup/SelectItemGroup.js
@@ -2,18 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  disabled: false,
-  label: 'Provide label',
-};
-
 const SelectItemGroup = ({
   children,
   className,
@@ -33,7 +21,16 @@ const SelectItemGroup = ({
   );
 };
 
-SelectItemGroup.propTypes = propTypes;
-SelectItemGroup.defaultProps = defaultProps;
+SelectItemGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+};
+
+SelectItemGroup.defaultProps = {
+  disabled: false,
+  label: 'Provide label',
+};
 
 export default SelectItemGroup;

--- a/src/components/SelectItemGroup/index.js
+++ b/src/components/SelectItemGroup/index.js
@@ -1,2 +1,1 @@
-import SelectItemGroup from './SelectItemGroup';
-export default SelectItemGroup;
+export default from './SelectItemGroup';

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TextInput from '../TextInput';
 
-class Slider extends PureComponent {
+export default class Slider extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     hideTextInput: PropTypes.bool,
@@ -290,5 +290,3 @@ class Slider extends PureComponent {
     );
   }
 }
-
-export default Slider;

--- a/src/components/Slider/index.js
+++ b/src/components/Slider/index.js
@@ -1,2 +1,1 @@
-import Slider from './Slider';
-export default Slider;
+export default from './Slider';

--- a/src/components/StructuredList/StructuredList.js
+++ b/src/components/StructuredList/StructuredList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import uid from '../../tools/uniqueId';
 
-class StructuredListWrapper extends Component {
+export class StructuredListWrapper extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -32,7 +32,7 @@ class StructuredListWrapper extends Component {
   }
 }
 
-class StructuredListHead extends Component {
+export class StructuredListHead extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -50,7 +50,7 @@ class StructuredListHead extends Component {
   }
 }
 
-class StructuredListInput extends Component {
+export class StructuredListInput extends Component {
   static propTypes = {
     className: PropTypes.string,
     id: PropTypes.string,
@@ -89,7 +89,7 @@ class StructuredListInput extends Component {
   }
 }
 
-class StructuredListRow extends Component {
+export class StructuredListRow extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -141,7 +141,7 @@ class StructuredListRow extends Component {
   }
 }
 
-class StructuredListBody extends Component {
+export class StructuredListBody extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -169,7 +169,7 @@ class StructuredListBody extends Component {
   }
 }
 
-class StructuredListCell extends Component {
+export class StructuredListCell extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -198,12 +198,3 @@ class StructuredListCell extends Component {
     );
   }
 }
-
-export {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-};

--- a/src/components/StructuredList/index.js
+++ b/src/components/StructuredList/index.js
@@ -1,8 +1,1 @@
-export {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListInput,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListCell,
-} from './StructuredList';
+export * from './StructuredList';

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -2,25 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  index: PropTypes.number,
-  kind: PropTypes.oneOf(['button', 'anchor']).isRequired,
-  name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onClick: PropTypes.func,
-  onKeyDown: PropTypes.func,
-  selected: PropTypes.bool,
-  text: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  selected: false,
-  kind: 'anchor',
-  text: 'Provide text',
-  onClick: () => {},
-  onKeyDown: () => {},
-};
-
 const Switch = props => {
   const {
     className,
@@ -72,7 +53,23 @@ const Switch = props => {
   );
 };
 
-Switch.defaultProps = defaultProps;
-Switch.propTypes = propTypes;
+Switch.propTypes = {
+  className: PropTypes.string,
+  index: PropTypes.number,
+  kind: PropTypes.oneOf(['button', 'anchor']).isRequired,
+  name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onClick: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  selected: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+};
+
+Switch.defaultProps = {
+  selected: false,
+  kind: 'anchor',
+  text: 'Provide text',
+  onClick: () => {},
+  onKeyDown: () => {},
+};
 
 export default Switch;

--- a/src/components/Switch/index.js
+++ b/src/components/Switch/index.js
@@ -1,2 +1,1 @@
-import Switch from './Switch';
-export default Switch;
+export default from './Switch';

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-class Tab extends React.Component {
+export default class Tab extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     handleTabClick: PropTypes.func,
@@ -90,5 +90,3 @@ class Tab extends React.Component {
     );
   }
 }
-
-export default Tab;

--- a/src/components/Tab/index.js
+++ b/src/components/Tab/index.js
@@ -1,2 +1,1 @@
-import Tab from './Tab';
-export default Tab;
+export default from './Tab';

--- a/src/components/TabContent/TabContent.js
+++ b/src/components/TabContent/TabContent.js
@@ -1,15 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const propTypes = {
-  selected: PropTypes.bool,
-  children: PropTypes.node,
-};
-
-const defaultProps = {
-  selected: false,
-};
-
 const TabContent = props => {
   const { selected, children, ...other } = props;
 
@@ -20,7 +11,13 @@ const TabContent = props => {
   );
 };
 
-TabContent.propTypes = propTypes;
-TabContent.defaultProps = defaultProps;
+TabContent.propTypes = {
+  selected: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+TabContent.defaultProps = {
+  selected: false,
+};
 
 export default TabContent;

--- a/src/components/TabContent/index.js
+++ b/src/components/TabContent/index.js
@@ -1,2 +1,1 @@
-import TabContent from './TabContent';
-export default TabContent;
+export default from './TabContent';

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -2,12 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  containerClassName: PropTypes.string,
-};
-
 const Table = props => {
   const { children, className, containerClassName, ...other } = props;
 
@@ -33,6 +27,10 @@ const Table = props => {
   );
 };
 
-Table.propTypes = propTypes;
+Table.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  containerClassName: PropTypes.string,
+};
 
 export default Table;

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,2 +1,1 @@
-import Table from './Table';
-export default Table;
+export default from './Table';

--- a/src/components/TableBody/TableBody.js
+++ b/src/components/TableBody/TableBody.js
@@ -3,11 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import TableRow from '../TableRow';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 /**
  * Adds striping to TableRows if the `even` prop wasn’t explicitly set.
  * @param  {array} rows  React elements that are children of the TableBody
@@ -48,6 +43,9 @@ const TableBody = props => {
   );
 };
 
-TableBody.propTypes = propTypes;
+TableBody.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default TableBody;

--- a/src/components/TableBody/index.js
+++ b/src/components/TableBody/index.js
@@ -1,2 +1,1 @@
-import TableBody from './TableBody';
-export default TableBody;
+export default from './TableBody';

--- a/src/components/TableData/TableData.js
+++ b/src/components/TableData/TableData.js
@@ -3,13 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  iconClassName: PropTypes.string,
-  expanded: PropTypes.bool,
-};
-
 const TableData = props => {
   const { children, className, iconClassName, expanded, ...other } = props;
 
@@ -43,6 +36,11 @@ const TableData = props => {
   );
 };
 
-TableData.propTypes = propTypes;
+TableData.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  iconClassName: PropTypes.string,
+  expanded: PropTypes.bool,
+};
 
 export default TableData;

--- a/src/components/TableData/index.js
+++ b/src/components/TableData/index.js
@@ -1,2 +1,1 @@
-import TableData from './TableData';
-export default TableData;
+export default from './TableData';

--- a/src/components/TableHead/TableHead.js
+++ b/src/components/TableHead/TableHead.js
@@ -2,11 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
 const TableHead = props => {
   const { children, className, ...other } = props;
 
@@ -19,6 +14,9 @@ const TableHead = props => {
   );
 };
 
-TableHead.propTypes = propTypes;
+TableHead.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
 
 export default TableHead;

--- a/src/components/TableHead/index.js
+++ b/src/components/TableHead/index.js
@@ -1,2 +1,1 @@
-import TableHead from './TableHead';
-export default TableHead;
+export default from './TableHead';

--- a/src/components/TableHeader/TableHeader.js
+++ b/src/components/TableHeader/TableHeader.js
@@ -3,13 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  iconClassName: PropTypes.string,
-  sortDir: PropTypes.string,
-};
-
 const TableHeader = props => {
   const { children, className, iconClassName, sortDir, ...other } = props;
 
@@ -45,6 +38,11 @@ const TableHeader = props => {
   );
 };
 
-TableHeader.propTypes = propTypes;
+TableHeader.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  iconClassName: PropTypes.string,
+  sortDir: PropTypes.string,
+};
 
 export default TableHeader;

--- a/src/components/TableHeader/index.js
+++ b/src/components/TableHeader/index.js
@@ -1,2 +1,1 @@
-import TableHeader from './TableHeader';
-export default TableHeader;
+export default from './TableHeader';

--- a/src/components/TableRow/TableRow.js
+++ b/src/components/TableRow/TableRow.js
@@ -2,17 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const defaultProps = {
-  header: false,
-};
-
-const propTypes = {
-  header: PropTypes.bool,
-  className: PropTypes.string,
-  children: PropTypes.node,
-  even: PropTypes.bool,
-};
-
 const TableRow = props => {
   const { even, header, className, children, ...other } = props;
 
@@ -28,7 +17,15 @@ const TableRow = props => {
   );
 };
 
-TableRow.defaultProps = defaultProps;
-TableRow.propTypes = propTypes;
+TableRow.propTypes = {
+  header: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  even: PropTypes.bool,
+};
+
+TableRow.defaultProps = {
+  header: false,
+};
 
 export default TableRow;

--- a/src/components/TableRow/index.js
+++ b/src/components/TableRow/index.js
@@ -1,2 +1,1 @@
-import TableRow from './TableRow';
-export default TableRow;
+export default from './TableRow';

--- a/src/components/TableRowExpanded/TableRowExpanded.js
+++ b/src/components/TableRowExpanded/TableRowExpanded.js
@@ -2,18 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  colSpan: PropTypes.number,
-  expanded: PropTypes.bool,
-  even: PropTypes.bool,
-};
-
-const defaultProps = {
-  expanded: false,
-};
-
 const TableRowExpanded = props => {
   const { children, className, even, colSpan, expanded, ...other } = props;
 
@@ -35,7 +23,16 @@ const TableRowExpanded = props => {
   );
 };
 
-TableRowExpanded.propTypes = propTypes;
-TableRowExpanded.defaultProps = defaultProps;
+TableRowExpanded.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  colSpan: PropTypes.number,
+  expanded: PropTypes.bool,
+  even: PropTypes.bool,
+};
+
+TableRowExpanded.defaultProps = {
+  expanded: false,
+};
 
 export default TableRowExpanded;

--- a/src/components/TableRowExpanded/index.js
+++ b/src/components/TableRowExpanded/index.js
@@ -1,2 +1,1 @@
-import TableRowExpanded from './TableRowExpanded';
-export default TableRowExpanded;
+export default from './TableRowExpanded';

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import TabContent from '../TabContent';
 
-class Tabs extends React.Component {
+export default class Tabs extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -152,5 +152,3 @@ class Tabs extends React.Component {
     );
   }
 }
-
-export default Tabs;

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,2 +1,1 @@
-import Tabs from './Tabs';
-export default Tabs;
+export default from './Tabs';

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -14,12 +14,6 @@ const TYPES = {
   'third-party': 'Third-Party',
 };
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  type: PropTypes.oneOf(Object.keys(TYPES)).isRequired,
-};
-
 const Tag = ({ children, className, type, ...other }) => {
   const tagClass = `bx--tag--${type}`;
   const tagClasses = classNames('bx--tag', tagClass, className);
@@ -30,7 +24,11 @@ const Tag = ({ children, className, type, ...other }) => {
   );
 };
 
-Tag.propTypes = propTypes;
+Tag.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  type: PropTypes.oneOf(Object.keys(TYPES)).isRequired,
+};
 
 export const types = Object.keys(TYPES);
 export default Tag;

--- a/src/components/Tag/index.js
+++ b/src/components/Tag/index.js
@@ -1,2 +1,2 @@
-import Tag from './Tag';
-export default Tag;
+export * from './Tag';
+export default from './Tag';

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -2,34 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  cols: PropTypes.number,
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  disabled: PropTypes.bool,
-  id: PropTypes.string,
-  labelText: PropTypes.string,
-  onChange: PropTypes.func,
-  onClick: PropTypes.func,
-  placeholder: PropTypes.string,
-  rows: PropTypes.number,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  invalid: PropTypes.bool,
-  invalidText: PropTypes.string,
-};
-
-const defaultProps = {
-  disabled: false,
-  onChange: () => {},
-  onClick: () => {},
-  placeholder: 'Hint text here',
-  rows: 4,
-  cols: 50,
-  invalid: false,
-  labelText: 'Provide labelText',
-  invalidText: 'Provide invalidText',
-};
-
 const Textarea = ({
   className,
   id,
@@ -85,7 +57,32 @@ const Textarea = ({
   );
 };
 
-Textarea.propTypes = propTypes;
-Textarea.defaultProps = defaultProps;
+Textarea.propTypes = {
+  className: PropTypes.string,
+  cols: PropTypes.number,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  labelText: PropTypes.string,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  placeholder: PropTypes.string,
+  rows: PropTypes.number,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  invalid: PropTypes.bool,
+  invalidText: PropTypes.string,
+};
+
+Textarea.defaultProps = {
+  disabled: false,
+  onChange: () => {},
+  onClick: () => {},
+  placeholder: 'Hint text here',
+  rows: 4,
+  cols: 50,
+  invalid: false,
+  labelText: 'Provide labelText',
+  invalidText: 'Provide invalidText',
+};
 
 export default Textarea;

--- a/src/components/TextArea/index.js
+++ b/src/components/TextArea/index.js
@@ -1,2 +1,1 @@
-import TextArea from './TextArea';
-export default TextArea;
+export default from './TextArea';

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -2,33 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  disabled: PropTypes.bool,
-  id: PropTypes.string.isRequired,
-  labelText: PropTypes.string,
-  onChange: PropTypes.func,
-  onClick: PropTypes.func,
-  placeholder: PropTypes.string,
-  type: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  hideLabel: PropTypes.bool,
-  invalid: PropTypes.bool,
-  invalidText: PropTypes.string,
-};
-
-const defaultProps = {
-  className: 'bx--text__input',
-  disabled: false,
-  type: 'text',
-  onChange: () => {},
-  onClick: () => {},
-  invalid: false,
-  labelText: '',
-  invalidText: 'Provide invalidText',
-};
-
 const TextInput = ({
   labelText,
   className,
@@ -93,7 +66,31 @@ const TextInput = ({
   );
 };
 
-TextInput.propTypes = propTypes;
-TextInput.defaultProps = defaultProps;
+TextInput.propTypes = {
+  className: PropTypes.string,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  labelText: PropTypes.string,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  placeholder: PropTypes.string,
+  type: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  hideLabel: PropTypes.bool,
+  invalid: PropTypes.bool,
+  invalidText: PropTypes.string,
+};
+
+TextInput.defaultProps = {
+  className: 'bx--text__input',
+  disabled: false,
+  type: 'text',
+  onChange: () => {},
+  onClick: () => {},
+  invalid: false,
+  labelText: '',
+  invalidText: 'Provide invalidText',
+};
 
 export default TextInput;

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -1,2 +1,1 @@
-import TextInput from './TextInput';
-export default TextInput;
+export default from './TextInput';

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
-class Tile extends Component {
+export class Tile extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -22,7 +22,7 @@ class Tile extends Component {
   }
 }
 
-class ClickableTile extends Component {
+export class ClickableTile extends Component {
   state = {
     clicked: this.props.clicked,
   };
@@ -88,7 +88,7 @@ class ClickableTile extends Component {
   }
 }
 
-class SelectableTile extends Component {
+export class SelectableTile extends Component {
   state = {
     selected: this.props.selected,
   };
@@ -184,7 +184,7 @@ class SelectableTile extends Component {
   }
 }
 
-class ExpandableTile extends Component {
+export class ExpandableTile extends Component {
   state = {
     expanded: this.props.expanded,
     tileMaxHeight: this.props.tileMaxHeight,
@@ -292,7 +292,7 @@ class ExpandableTile extends Component {
   }
 }
 
-class TileAboveTheFoldContent extends Component {
+export class TileAboveTheFoldContent extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -305,7 +305,7 @@ class TileAboveTheFoldContent extends Component {
   }
 }
 
-class TileBelowTheFoldContent extends Component {
+export class TileBelowTheFoldContent extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -317,12 +317,3 @@ class TileBelowTheFoldContent extends Component {
     return <span className="bx--tile-content__below-the-fold">{children}</span>;
   }
 }
-
-export {
-  Tile,
-  ClickableTile,
-  SelectableTile,
-  ExpandableTile,
-  TileAboveTheFoldContent,
-  TileBelowTheFoldContent,
-};

--- a/src/components/Tile/index.js
+++ b/src/components/Tile/index.js
@@ -1,8 +1,1 @@
-export {
-  Tile,
-  ClickableTile,
-  SelectableTile,
-  ExpandableTile,
-  TileAboveTheFoldContent,
-  TileBelowTheFoldContent,
-} from './Tile';
+export * from './Tile';

--- a/src/components/TimePicker/index.js
+++ b/src/components/TimePicker/index.js
@@ -1,2 +1,1 @@
-import TimePicker from './TimePicker';
-export default TimePicker;
+export default from './TimePicker';

--- a/src/components/TimePickerSelect/index.js
+++ b/src/components/TimePickerSelect/index.js
@@ -1,2 +1,1 @@
-import TimePickerSelect from './TimePickerSelect';
-export default TimePickerSelect;
+export default from './TimePickerSelect';

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -2,23 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const propTypes = {
-  className: PropTypes.string,
-  defaultToggled: PropTypes.bool,
-  onToggle: PropTypes.func,
-  id: PropTypes.string.isRequired,
-  toggled: PropTypes.bool,
-  labelA: PropTypes.string.isRequired,
-  labelB: PropTypes.string.isRequired,
-};
-
-const defaultProps = {
-  defaultToggled: false,
-  labelA: 'Off',
-  labelB: 'On',
-  onToggle: () => {},
-};
-
 const Toggle = ({
   className,
   defaultToggled,
@@ -68,7 +51,21 @@ const Toggle = ({
   );
 };
 
-Toggle.propTypes = propTypes;
-Toggle.defaultProps = defaultProps;
+Toggle.propTypes = {
+  className: PropTypes.string,
+  defaultToggled: PropTypes.bool,
+  onToggle: PropTypes.func,
+  id: PropTypes.string.isRequired,
+  toggled: PropTypes.bool,
+  labelA: PropTypes.string.isRequired,
+  labelB: PropTypes.string.isRequired,
+};
+
+Toggle.defaultProps = {
+  defaultToggled: false,
+  labelA: 'Off',
+  labelB: 'On',
+  onToggle: () => {},
+};
 
 export default Toggle;

--- a/src/components/Toggle/index.js
+++ b/src/components/Toggle/index.js
@@ -1,2 +1,1 @@
-import Toggle from './Toggle';
-export default Toggle;
+export default from './Toggle';

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -3,33 +3,6 @@ import PropTypes from 'prop-types';
 import ToolbarSearch from '../ToolbarSearch';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
-
-const toolbarItemPropTypes = {
-  children: PropTypes.node,
-  type: PropTypes.string,
-  placeHolderText: PropTypes.string,
-};
-
-const toolbarTitlePropTypes = {
-  title: PropTypes.string,
-};
-
-const toolbarTitleDefaultProps = {
-  title: PropTypes.string,
-};
-
-const toolbarItemDefaultProps = {
-  placeHolderText: 'Provide placeHolderText',
-};
-
-const toolbarOptionPropTypes = {
-  children: PropTypes.node,
-};
-
 const Toolbar = ({ children, className, ...other }) => {
   const wrapperClasses = classNames('bx--toolbar', className);
 
@@ -40,7 +13,12 @@ const Toolbar = ({ children, className, ...other }) => {
   );
 };
 
-const ToolbarItem = ({ children, type, placeHolderText }) => {
+Toolbar.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export const ToolbarItem = ({ children, type, placeHolderText }) => {
   const toolbarItem =
     type === 'search' ? (
       <ToolbarSearch placeHolderText={placeHolderText} />
@@ -50,23 +28,32 @@ const ToolbarItem = ({ children, type, placeHolderText }) => {
   return toolbarItem;
 };
 
-const ToolbarTitle = ({ title }) => (
+ToolbarItem.propTypes = {
+  children: PropTypes.node,
+  type: PropTypes.string,
+  placeHolderText: PropTypes.string,
+};
+
+ToolbarItem.defaultProps = {
+  placeHolderText: 'Provide placeHolderText',
+};
+
+export const ToolbarTitle = ({ title }) => (
   <li className="bx--toolbar-menu__title">{title}</li>
 );
 
-const ToolbarOption = ({ children }) => (
+ToolbarTitle.propTypes = {
+  title: PropTypes.string,
+};
+
+export const ToolbarOption = ({ children }) => (
   <li className="bx--toolbar-menu__option">{children}</li>
 );
 
-const ToolbarDivider = () => <hr className="bx--toolbar-menu__divider" />;
+ToolbarOption.propTypes = {
+  children: PropTypes.node,
+};
 
-Toolbar.propTypes = propTypes;
-ToolbarItem.propTypes = toolbarItemPropTypes;
-ToolbarTitle.propTypes = toolbarTitlePropTypes;
-ToolbarOption.propTypes = toolbarOptionPropTypes;
-
-ToolbarItem.defaultProps = toolbarItemDefaultProps;
-ToolbarTitle.defaultProps = toolbarTitleDefaultProps;
+export const ToolbarDivider = () => <hr className="bx--toolbar-menu__divider" />;
 
 export default Toolbar;
-export { ToolbarItem, ToolbarTitle, ToolbarOption, ToolbarDivider };

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -1,8 +1,2 @@
-import Toolbar, {
-  ToolbarItem,
-  ToolbarTitle,
-  ToolbarOption,
-  ToolbarDivider,
-} from './Toolbar';
-export default Toolbar;
-export { ToolbarItem, ToolbarTitle, ToolbarOption, ToolbarDivider };
+export * from './Toolbar';
+export default from './Toolbar';

--- a/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/src/components/ToolbarSearch/ToolbarSearch.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import ClickListener from '../../internal/ClickListener';
 
-class ToolbarSearch extends Component {
+export default class ToolbarSearch extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -87,5 +87,3 @@ class ToolbarSearch extends Component {
     );
   }
 }
-
-export default ToolbarSearch;

--- a/src/components/ToolbarSearch/index.js
+++ b/src/components/ToolbarSearch/index.js
@@ -1,2 +1,1 @@
-import ToolbarSearch from './ToolbarSearch';
-export default ToolbarSearch;
+export default from './ToolbarSearch';

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -4,7 +4,7 @@ import Icon from '../Icon';
 import classNames from 'classnames';
 import FloatingMenu from '../../internal/FloatingMenu';
 
-class Tooltip extends Component {
+export default class Tooltip extends Component {
   static propTypes = {
     open: PropTypes.bool,
     children: PropTypes.node,
@@ -117,5 +117,3 @@ class Tooltip extends Component {
     );
   }
 }
-
-export default Tooltip;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,2 +1,1 @@
-import Tooltip from './Tooltip';
-export default Tooltip;
+export default from './Tooltip';

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -3,24 +3,6 @@ import PropTypes from 'prop-types';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  position: PropTypes.oneOf(['bottom', 'top']),
-  text: PropTypes.string.isRequired,
-  showIcon: PropTypes.bool,
-  iconName: PropTypes.string,
-  iconDescription: PropTypes.string,
-};
-
-const defaultProps = {
-  position: 'top',
-  showIcon: true,
-  iconName: 'info--glyph',
-  iconDescription: 'tooltip',
-  text: 'Provide text',
-};
-
 const TooltipSimple = ({
   children,
   className,
@@ -48,7 +30,22 @@ const TooltipSimple = ({
   );
 };
 
-TooltipSimple.propTypes = propTypes;
-TooltipSimple.defaultProps = defaultProps;
+TooltipSimple.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  position: PropTypes.oneOf(['bottom', 'top']),
+  text: PropTypes.string.isRequired,
+  showIcon: PropTypes.bool,
+  iconName: PropTypes.string,
+  iconDescription: PropTypes.string,
+};
+
+TooltipSimple.defaultProps = {
+  position: 'top',
+  showIcon: true,
+  iconName: 'info--glyph',
+  iconDescription: 'tooltip',
+  text: 'Provide text',
+};
 
 export default TooltipSimple;

--- a/src/components/TooltipSimple/index.js
+++ b/src/components/TooltipSimple/index.js
@@ -1,2 +1,1 @@
-import TooltipSimple from './TooltipSimple';
-export default TooltipSimple;
+export default from './TooltipSimple';

--- a/src/components/UnorderedList/UnorderedList.js
+++ b/src/components/UnorderedList/UnorderedList.js
@@ -2,16 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  nested: PropTypes.bool,
-};
-
-const defaultProps = {
-  nested: false,
-};
-
 const UnorderedList = ({ children, className, nested, ...other }) => {
   const classNames = classnames('bx--list--unordered', className, {
     'bx--list--nested': nested,
@@ -23,7 +13,14 @@ const UnorderedList = ({ children, className, nested, ...other }) => {
   );
 };
 
-UnorderedList.propTypes = propTypes;
-UnorderedList.defaultProps = defaultProps;
+UnorderedList.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  nested: PropTypes.bool,
+};
+
+UnorderedList.defaultProps = {
+  nested: false,
+};
 
 export default UnorderedList;

--- a/src/components/UnorderedList/index.js
+++ b/src/components/UnorderedList/index.js
@@ -1,2 +1,1 @@
-import UnorderedList from './UnorderedList';
-export default UnorderedList;
+export default from './UnorderedList';


### PR DESCRIPTION
Quick fix PR that updates how we export from component files since the last merge had missed some of them (thankfully Storybook gave us the heads up 😄 ). Basically it updates to one of the following export patterns (or both!):

When a component exports multiple items, `index.js` we export by doing:

```js
export * from './Component';
```

Which essentially desugars into an `Object.keys` call on the export and places all of them on `exports` in CommonJS.

In addition, if the component just has an `export default` definition, we export by doing:

```js
export default from './Component';
```

Which is just a convenience over the `import` then `export default` pattern we had before 😄 

Finally, this PR also updates `propTypes` and `defaultProps` throughout the codebase. The change places them on the property themselves instead of creating a new binding and then assigning that binding to the property.

#### Changelog

**New**

**Changed**

- Export files changed
- Components `propTypes` definitions updated
- `prettierignore` file updated with `lib`

**Removed**
