### PR TITLE
feat(ModalWrapper): set kind for trigger button (#342)

### DIFF
--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -161,3 +161,28 @@ describe('Modal', () => {
     });
   });
 });
+describe('Modal Wrapper', () => {
+  describe('Renders as expected', () => {
+    const wrapper = mount(<ModalWrapper/>);
+
+    it('should default to primary button', () => {
+      expect(wrapper.find('.bx--btn--primary').length).toEqual(2);
+    });
+
+    it('should render ghost button when ghost is passed', () => {
+      wrapper.setProps({ triggerButtonkind: 'ghost' });
+      expect(wrapper.find('.bx--btn--ghost').length).toEqual(1);
+
+    });
+
+    it('should render danger button when danger is passed', () => {
+      wrapper.setProps({ triggerButtonkind: 'danger' });
+      expect(wrapper.find('.bx--btn--danger').length).toEqual(1);
+    });
+
+    it('should render secondary button when secondary is passed', () => {
+      wrapper.setProps({ triggerButtonkind: 'secondary' });
+      expect(wrapper.find('.bx--btn--secondary').length).toEqual(2);
+    });
+  });
+});

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -19,11 +19,13 @@ export default class ModalWrapper extends React.Component {
     primaryButtonText: PropTypes.string,
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
+    triggerButtonkind: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost']),
   };
 
   static defaultProps = {
     primaryButtonText: 'Save',
     secondaryButtonText: 'Cancel',
+    triggerButtonkind: 'primary'
   };
 
   state = {
@@ -46,6 +48,7 @@ export default class ModalWrapper extends React.Component {
     const {
       id,
       buttonTriggerText,
+      triggerButtonkind,
       modalLabel,
       modalHeading,
       passiveModal,
@@ -75,7 +78,7 @@ export default class ModalWrapper extends React.Component {
             this.props.onKeyDown(evt);
           }
         }}>
-        <Button onClick={this.handleOpen}>{buttonTriggerText}</Button>
+        <Button kind={triggerButtonkind} onClick={this.handleOpen}>{buttonTriggerText}</Button>
         <Modal {...props} {...other}>
           {this.props.children}
         </Modal>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#342

Allow product teams to pass in a prop to set kind for modalWrapper's trigger button 

#### Changelog

**New**

- pass props through modalWrapper to set kind for the trigger button
- default to primary button if no props passed
