### PR TITLE
Added a new prop to set the date value programmatically, resolves #350

### DIFF
--- a/src/components/DatePicker/DatePicker-test.js
+++ b/src/components/DatePicker/DatePicker-test.js
@@ -38,6 +38,12 @@ describe('DatePicker', () => {
       expect(wrapper.props().dateFormat).toEqual('d/m/Y');
     });
 
+    it('has the value as expected', () => {
+          expect(wrapper.props().value).toEqual(undefined);
+          wrapper.setProps({ value: '11/08/2017' });
+          expect(wrapper.props().value).toEqual('11/08/2017');
+    });
+
     it('should render the children as expected', () => {
       expect(wrapper.props().children.length).toEqual(2);
     });
@@ -55,6 +61,12 @@ describe('DatePicker', () => {
       expect(datepicker.children().hasClass('bx--date-picker--simple')).toBe(
         true
       );
+    });
+
+    it('has the value as expected', () => {
+          expect(wrapper.props().value).toEqual(undefined);
+          wrapper.setProps({ value: '11/08/2017' });
+          expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should not initalize a calendar', () => {
@@ -93,6 +105,12 @@ describe('DatePicker', () => {
           .instance()
           .cal.calendarContainer.classList.contains('bx--date-picker__calendar')
       ).toBe(true);
+    });
+
+    it('has the value as expected', () => {
+          expect(wrapper.props().value).toEqual(undefined);
+          wrapper.setProps({ value: '11/08/2017' });
+          expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should not render an icon', () => {
@@ -137,6 +155,12 @@ describe('DatePicker', () => {
           .instance()
           .cal.calendarContainer.classList.contains('bx--date-picker__calendar')
       ).toBe(true);
+    });
+
+    it('has the value as expected', () => {
+          expect(wrapper.props().value).toEqual(undefined);
+          wrapper.setProps({ value: '11/08/2017' });
+          expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should render an icon', () => {

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -22,12 +22,26 @@ export default class DatePicker extends Component {
     short: PropTypes.bool,
     datePickerType: PropTypes.string,
     dateFormat: PropTypes.string,
+    value: PropTypes.string,
   };
 
   static defaultProps = {
     short: false,
     dateFormat: 'm/d/Y',
   };
+
+  componentWillUpdate(nextProps) {
+    if (nextProps.value !== this.props.value) {
+      if ( this.props.datePickerType === 'single' ||
+            this.props.datePickerType === 'range'
+      ) {
+        this.cal.setDate( nextProps.value );
+        this.updateClassNames(this.cal);
+      } else {
+        this.inputField = nextProps.value;
+      }
+    }
+  }
 
   componentDidMount() {
     if (

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -38,7 +38,9 @@ export default class DatePicker extends Component {
         this.cal.setDate( nextProps.value );
         this.updateClassNames(this.cal);
       } else {
-        this.inputField = nextProps.value;
+        if (this.inputField) {
+          this.inputField.value = nextProps.value;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#350

Added a new prop 'value' in DatePicker Component and the code to handle the date change to set the value programmatically.

Change log
Changed:
Added new Prop value, to set the value programmatically
Updated tests