### PR TITLE
fix: react warning in ComposedModal component, resolves #354

### DIFF
--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -209,6 +209,7 @@ export class ModalFooter extends Component {
     primaryButtonDisabled: PropTypes.bool,
     onRequestClose: PropTypes.func,
     onRequestSubmit: PropTypes.func,
+    closeModal: PropTypes.func,
     children: PropTypes.node,
   };
 
@@ -230,6 +231,7 @@ export class ModalFooter extends Component {
       secondaryButtonText,
       primaryButtonText,
       primaryButtonDisabled,
+      closeModal, // eslint-disable-line
       onRequestClose, // eslint-disable-line
       onRequestSubmit, // eslint-disable-line
       children,


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#354

Fixed react warning `Unknown prop `closeModal` on <div> tag` in the `ComposedModal` component

#### Changelog

**New**

- Added `closeModal` to `propTypes` and the render method of `ModalFooter`


