### PR TITLE
fix(Form): do not submit story for real

### DIFF
--- a/src/components/Form/Form-story.js
+++ b/src/components/Form/Form-story.js
@@ -18,6 +18,10 @@ import Toggle from '../Toggle';
 
 const additionalProps = {
   className: 'some-class',
+  onSubmit: (e) => {
+    e.preventDefault()
+    action('FormSubmitted')(e)
+  }
 };
 
 const checkboxEvents = {


### PR DESCRIPTION
The current story tries to submit the form for real making the page change. This prevents this and shows an item in the action panel instead