### PR TITLE
fix(NumberInput): call onClick, onChange after setState

### DIFF
--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -51,9 +51,10 @@ export default class NumberInput extends Component {
     if (!this.props.disabled) {
       this.setState({
         value: evt.target.value,
+      }, (evt) => {
+        this.props.onChange(evt);
       });
 
-      this.props.onChange(evt);
     }
   };
 
@@ -73,10 +74,10 @@ export default class NumberInput extends Component {
 
       this.setState({
         value,
+      }, (evt) => {
+        this.props.onClick(evt);
+        this.props.onChange(evt);
       });
-
-      this.props.onClick(evt);
-      this.props.onChange(evt);
     }
   };
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#361

pass onClick and OnChange as a callback to setState to ensure they are not called before state.value is updated. This will keep any parent component that accesses this.state.value via refs during onChange synchronized with the value displayed in the input field.

**Changed**

- don't call onClick or onChange until this.state.value is changed.
