### PR TITLE
fix(a11y): fix a11y warnings in various components

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "jsx-a11y/onclick-has-role": 1,
       "jsx-a11y/click-events-have-key-events": 1,
       "jsx-a11y/href-no-hash": 1,
-      "jsx-a11y/onclick-has-focus": 1
+      "jsx-a11y/onclick-has-focus": 1,
+      "jsx-a11y/no-static-element-interactions": 0
     },
     "env": {
       "node": true,

--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
       "react/jsx-uses-vars": 1,
       "react/jsx-uses-react": 1,
       "react/no-find-dom-node": 1,
-      "jsx-a11y/onclick-has-role": 1,
+      "jsx-a11y/no-static-element-interactions": 1,
+      "jsx-a11y/no-noninteractive-element-interactions": 1,
       "jsx-a11y/click-events-have-key-events": 1,
       "jsx-a11y/href-no-hash": 1,
-      "jsx-a11y/onclick-has-focus": 1,
-      "jsx-a11y/no-static-element-interactions": 0
+      "jsx-a11y/interactive-supports-focus": 1
     },
     "env": {
       "node": true,
@@ -117,7 +117,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.1.2",
     "eslint": "^4.11.0",
-    "eslint-plugin-jsx-a11y": "^2.0.0",
+    "eslint-plugin-jsx-a11y": "^5.0.0",
     "eslint-plugin-react": "^7.4.0",
     "gh-pages": "1.0.0",
     "husky": "^0.14.3",

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -9,8 +9,7 @@ const Accordion = ({ children, className, ...other }) => {
       className={classNames}
       role="tablist"
       aria-multiselectable="true"
-      {...other}
-    >
+      {...other}>
       {children}
     </ul>
   );

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -5,7 +5,12 @@ import classnames from 'classnames';
 const Accordion = ({ children, className, ...other }) => {
   const classNames = classnames('bx--accordion', className);
   return (
-    <ul className={classNames} {...other}>
+    <ul
+      className={classNames}
+      role="tablist"
+      aria-multiselectable="true"
+      {...other}
+    >
       {children}
     </ul>
   );

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -71,18 +71,21 @@ export default class AccordionItem extends Component {
         className={classNames}
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
+        role="button"
         {...other}
-        tabIndex="0">
-        <div
+        tabIndex="0"
+      >
+        <button
           className="bx--accordion__heading"
-          onClick={this.handleHeadingClick}>
+          onClick={this.handleHeadingClick}
+        >
           <Icon
             className="bx--accordion__arrow"
             name="chevron--right"
             description="Expand/Collapse"
           />
           <p className="bx--accordion__title">{title}</p>
-        </div>
+        </button>
         <div className="bx--accordion__content">{children}</div>
       </li>
     );

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -72,13 +72,11 @@ export default class AccordionItem extends Component {
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
         role="presentation"
-        {...other}
-      >
+        {...other}>
         <button
           className="bx--accordion__heading"
           role="tab"
-          onClick={this.handleHeadingClick}
-        >
+          onClick={this.handleHeadingClick}>
           <Icon
             className="bx--accordion__arrow"
             name="chevron--right"

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -71,12 +71,12 @@ export default class AccordionItem extends Component {
         className={classNames}
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
-        role="button"
+        role="presentation"
         {...other}
-        tabIndex="0"
       >
         <button
           className="bx--accordion__heading"
+          role="tab"
           onClick={this.handleHeadingClick}
         >
           <Icon

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -79,6 +79,7 @@ export default class ComposedModal extends Component {
 
     return (
       <div
+        role="presentation"
         ref={modal => (this.modal = modal)}
         onKeyDown={this.handleKeyDown}
         className={modalClass}

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -82,7 +82,8 @@ export default class ComposedModal extends Component {
         ref={modal => (this.modal = modal)}
         onKeyDown={this.handleKeyDown}
         className={modalClass}
-        {...other}>
+        {...other}
+      >
         <div className={containerClass}>{childrenWithProps}</div>
       </div>
     );
@@ -166,7 +167,8 @@ export class ModalHeader extends Component {
         <button
           onClick={this.handleCloseButtonClick}
           className={closeClass}
-          type="button">
+          type="button"
+        >
           <Icon
             name="close"
             className={closeIconClass}
@@ -257,7 +259,8 @@ export class ModalFooter extends Component {
           <Button
             className={secondaryClass}
             onClick={this.handleRequestClose}
-            kind="secondary">
+            kind="secondary"
+          >
             {secondaryButtonText}
           </Button>
         )}
@@ -267,7 +270,8 @@ export class ModalFooter extends Component {
             onClick={this.onRequestSubmit}
             className={primaryClass}
             disabled={primaryButtonDisabled}
-            kind="primary">
+            kind="primary"
+          >
             {primaryButtonText}
           </Button>
         )}

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -83,8 +83,7 @@ export default class ComposedModal extends Component {
         ref={modal => (this.modal = modal)}
         onKeyDown={this.handleKeyDown}
         className={modalClass}
-        {...other}
-      >
+        {...other}>
         <div className={containerClass}>{childrenWithProps}</div>
       </div>
     );
@@ -168,8 +167,7 @@ export class ModalHeader extends Component {
         <button
           onClick={this.handleCloseButtonClick}
           className={closeClass}
-          type="button"
-        >
+          type="button">
           <Icon
             name="close"
             className={closeIconClass}
@@ -260,8 +258,7 @@ export class ModalFooter extends Component {
           <Button
             className={secondaryClass}
             onClick={this.handleRequestClose}
-            kind="secondary"
-          >
+            kind="secondary">
             {secondaryButtonText}
           </Button>
         )}
@@ -271,8 +268,7 @@ export class ModalFooter extends Component {
             onClick={this.onRequestSubmit}
             className={primaryClass}
             disabled={primaryButtonDisabled}
-            kind="primary"
-          >
+            kind="primary">
             {primaryButtonText}
           </Button>
         )}

--- a/src/components/DatePicker/DatePicker-test.js
+++ b/src/components/DatePicker/DatePicker-test.js
@@ -39,9 +39,9 @@ describe('DatePicker', () => {
     });
 
     it('has the value as expected', () => {
-          expect(wrapper.props().value).toEqual(undefined);
-          wrapper.setProps({ value: '11/08/2017' });
-          expect(wrapper.props().value).toEqual('11/08/2017');
+      expect(wrapper.props().value).toEqual(undefined);
+      wrapper.setProps({ value: '11/08/2017' });
+      expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should render the children as expected', () => {
@@ -64,9 +64,9 @@ describe('DatePicker', () => {
     });
 
     it('has the value as expected', () => {
-          expect(wrapper.props().value).toEqual(undefined);
-          wrapper.setProps({ value: '11/08/2017' });
-          expect(wrapper.props().value).toEqual('11/08/2017');
+      expect(wrapper.props().value).toEqual(undefined);
+      wrapper.setProps({ value: '11/08/2017' });
+      expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should not initalize a calendar', () => {
@@ -108,9 +108,9 @@ describe('DatePicker', () => {
     });
 
     it('has the value as expected', () => {
-          expect(wrapper.props().value).toEqual(undefined);
-          wrapper.setProps({ value: '11/08/2017' });
-          expect(wrapper.props().value).toEqual('11/08/2017');
+      expect(wrapper.props().value).toEqual(undefined);
+      wrapper.setProps({ value: '11/08/2017' });
+      expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should not render an icon', () => {
@@ -158,9 +158,9 @@ describe('DatePicker', () => {
     });
 
     it('has the value as expected', () => {
-          expect(wrapper.props().value).toEqual(undefined);
-          wrapper.setProps({ value: '11/08/2017' });
-          expect(wrapper.props().value).toEqual('11/08/2017');
+      expect(wrapper.props().value).toEqual(undefined);
+      wrapper.setProps({ value: '11/08/2017' });
+      expect(wrapper.props().value).toEqual('11/08/2017');
     });
 
     it('should render an icon', () => {

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -32,10 +32,11 @@ export default class DatePicker extends Component {
 
   componentWillUpdate(nextProps) {
     if (nextProps.value !== this.props.value) {
-      if ( this.props.datePickerType === 'single' ||
-            this.props.datePickerType === 'range'
+      if (
+        this.props.datePickerType === 'single' ||
+        this.props.datePickerType === 'range'
       ) {
-        this.cal.setDate( nextProps.value );
+        this.cal.setDate(nextProps.value);
         this.updateClassNames(this.cal);
       } else {
         if (this.inputField) {

--- a/src/components/Dropdown/Dropdown-story.js
+++ b/src/components/Dropdown/Dropdown-story.js
@@ -22,8 +22,7 @@ storiesOf('Dropdown', module)
       <Dropdown
         {...dropdownEvents}
         onChange={action('onChange')}
-        defaultText="Dropdown label"
-      >
+        defaultText="Dropdown label">
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -43,8 +42,7 @@ storiesOf('Dropdown', module)
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Option 1"
-        value="all"
-      >
+        value="all">
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -64,8 +62,7 @@ storiesOf('Dropdown', module)
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Dropdown label"
-        disabled
-      >
+        disabled>
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -86,8 +83,7 @@ storiesOf('Dropdown', module)
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Dropdown label"
         value="all"
-        selectedText="Option 4"
-      >
+        selectedText="Option 4">
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />

--- a/src/components/Dropdown/Dropdown-story.js
+++ b/src/components/Dropdown/Dropdown-story.js
@@ -2,31 +2,11 @@
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import Dropdown from '../Dropdown';
 import DropdownItem from '../DropdownItem';
 
 const dropdownEvents = {
-  onBlur: () => {
-    console.log('blur');
-  },
-  onClick: () => {
-    console.log('click');
-  },
-  onFocus: () => {
-    console.log('focus');
-  },
-  onMouseDown: () => {
-    console.log('mouseDown');
-  },
-  onMouseEnter: () => {
-    console.log('mouseEnter');
-  },
-  onMouseLeave: () => {
-    console.log('mouseLeave');
-  },
-  onMouseUp: () => {
-    console.log('mouseUp');
-  },
   className: 'some-class',
 };
 
@@ -41,8 +21,9 @@ storiesOf('Dropdown', module)
     () => (
       <Dropdown
         {...dropdownEvents}
-        onChange={selectedItemInfo => console.log(selectedItemInfo)}
-        defaultText="Dropdown label">
+        onChange={action('onChange')}
+        defaultText="Dropdown label"
+      >
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -62,7 +43,8 @@ storiesOf('Dropdown', module)
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Option 1"
-        value="all">
+        value="all"
+      >
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -82,7 +64,8 @@ storiesOf('Dropdown', module)
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Dropdown label"
-        disabled>
+        disabled
+      >
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />
@@ -103,7 +86,8 @@ storiesOf('Dropdown', module)
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
         defaultText="Dropdown label"
         value="all"
-        selectedText="Option 4">
+        selectedText="Option 4"
+      >
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
         <DropdownItem itemText="Option 3" value="option3" />

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -121,8 +121,7 @@ export default class Dropdown extends PureComponent {
           value={this.state.value}
           className={dropdownClasses}
           tabIndex={tabIndex}
-          role="presentation"
-        >
+          role="presentation">
           <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>
             <Icon

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -120,7 +120,9 @@ export default class Dropdown extends PureComponent {
           onKeyPress={this.toggle}
           value={this.state.value}
           className={dropdownClasses}
-          tabIndex={tabIndex}>
+          tabIndex={tabIndex}
+          role="list"
+        >
           <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>
             <Icon

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -121,7 +121,7 @@ export default class Dropdown extends PureComponent {
           value={this.state.value}
           className={dropdownClasses}
           tabIndex={tabIndex}
-          role="list"
+          role="presentation"
         >
           <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -39,8 +39,8 @@ const DropdownItem = ({
       className={dropdownItemClasses}
       onClick={handleClick}
       onKeyPress={handleKeypress}
-      role="listitem"
       tabIndex={-1}
+      role="menuitem"
     >
       <a
         href={href}

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -2,7 +2,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const DropdownItem = ({ className, value, itemText, onClick, ...other }) => {
+const DropdownItem = ({
+  className,
+  value,
+  itemText,
+  onClick,
+  onKeyPress,
+  href,
+  ...other
+}) => {
   const dropdownItemClasses = classNames({
     'bx--dropdown-item': true,
     [className]: className,
@@ -16,16 +24,29 @@ const DropdownItem = ({ className, value, itemText, onClick, ...other }) => {
     onClick(info);
   };
 
+  const handleKeypress = () => {
+    const info = {
+      value,
+      itemText,
+    };
+    onKeyPress(info);
+  };
+
   return (
     <li
       {...other}
       value={value}
       className={dropdownItemClasses}
-      onClick={handleClick}>
+      onClick={handleClick}
+      onKeyPress={handleKeypress}
+      role="listitem"
+      tabIndex={-1}
+    >
       <a
-        href="#"
+        href={href}
         onClick={/* istanbul ignore next */ evt => evt.preventDefault()}
-        className="bx--dropdown-link">
+        className="bx--dropdown-link"
+      >
         {itemText}
       </a>
     </li>
@@ -37,10 +58,14 @@ DropdownItem.propTypes = {
   itemText: PropTypes.string.isRequired,
   className: PropTypes.string,
   onClick: PropTypes.func,
+  onKeyPress: PropTypes.func,
+  href: PropTypes.string,
 };
 
 DropdownItem.defaultProps = {
   onClick: /* istanbul ignore next */ () => {},
+  onKeyPress: /* istanbul ignore next */ () => {},
+  href: '',
 };
 
 export default DropdownItem;

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -40,13 +40,11 @@ const DropdownItem = ({
       onClick={handleClick}
       onKeyPress={handleKeypress}
       tabIndex={-1}
-      role="menuitem"
-    >
+      role="menuitem">
       <a
         href={href}
         onClick={/* istanbul ignore next */ evt => evt.preventDefault()}
-        className="bx--dropdown-link"
-      >
+        className="bx--dropdown-link">
         {itemText}
       </a>
     </li>

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -72,18 +72,21 @@ export class FileUploaderButton extends Component {
 
     return (
       <div
+        role="button"
         className={classes}
         tabIndex={tabIndex}
         onKeyDown={evt => {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();
           }
-        }}>
+        }}
+      >
         <label
           className={`bx--btn bx--btn--${buttonKind}`}
           htmlFor={this.uid}
           role={role}
-          {...other}>
+          {...other}
+        >
           {this.state.labelText}
         </label>
         <input
@@ -122,7 +125,8 @@ export class Filename extends Component {
         <div
           className="bx--loading"
           style={Object.assign(style, { width: '1rem', height: '1rem' })}
-          {...other}>
+          {...other}
+        >
           <svg className="bx--loading__svg" viewBox="-42 -42 84 84">
             <circle cx="0" cy="0" r="37.5" />
           </svg>
@@ -241,7 +245,8 @@ export default class FileUploader extends Component {
                   key={index}
                   className="bx--file__selected-file"
                   ref={node => (this.nodes[index] = node)} // eslint-disable-line
-                  {...other}>
+                  {...other}
+                >
                   <p className="bx--file-filename">{name}</p>
                   <span className="bx--file__state-container">
                     <Filename

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -79,14 +79,12 @@ export class FileUploaderButton extends Component {
           if (evt.which === 13 || evt.which === 32) {
             this.input.click();
           }
-        }}
-      >
+        }}>
         <label
           className={`bx--btn bx--btn--${buttonKind}`}
           htmlFor={this.uid}
           role={role}
-          {...other}
-        >
+          {...other}>
           {this.state.labelText}
         </label>
         <input
@@ -125,8 +123,7 @@ export class Filename extends Component {
         <div
           className="bx--loading"
           style={Object.assign(style, { width: '1rem', height: '1rem' })}
-          {...other}
-        >
+          {...other}>
           <svg className="bx--loading__svg" viewBox="-42 -42 84 84">
             <circle cx="0" cy="0" r="37.5" />
           </svg>
@@ -245,8 +242,7 @@ export default class FileUploader extends Component {
                   key={index}
                   className="bx--file__selected-file"
                   ref={node => (this.nodes[index] = node)} // eslint-disable-line
-                  {...other}
-                >
+                  {...other}>
                   <p className="bx--file-filename">{name}</p>
                   <span className="bx--file__state-container">
                     <Filename

--- a/src/components/Form/Form-story.js
+++ b/src/components/Form/Form-story.js
@@ -18,10 +18,10 @@ import Toggle from '../Toggle';
 
 const additionalProps = {
   className: 'some-class',
-  onSubmit: (e) => {
-    e.preventDefault()
-    action('FormSubmitted')(e)
-  }
+  onSubmit: e => {
+    e.preventDefault();
+    action('FormSubmitted')(e);
+  },
 };
 
 const checkboxEvents = {

--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -15,27 +15,27 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
     <InteriorLeftNav>
       <InteriorLeftNavList title="Example Item 1">
         <InteriorLeftNavItem href="#example-item-1A">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1B">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1C">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavList title="Example Item 2">
         <InteriorLeftNavItem href="#example-item-2A">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2B">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2C">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2D">
-          <a href="#">Link Child</a>
+          <a href="">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavItem href="#example-item-3" label="Link Label" />

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -27,10 +27,11 @@ describe('InteriorLeftNav', () => {
         <InteriorLeftNav>
           <InteriorLeftNavList className="test-child" />
           <InteriorLeftNavItem
-            href="#"
+            href=""
             title="test-title"
-            className="test-child">
-            <a href="#">test-title</a>
+            className="test-child"
+          >
+            <a href="">test-title</a>
           </InteriorLeftNavItem>
         </InteriorLeftNav>
       );
@@ -104,8 +105,8 @@ describe('InteriorLeftNav', () => {
   describe('check accordion behaviour', () => {
     const twoLists = mount(
       <InteriorLeftNav>
-        <InteriorLeftNavList className="first" isExpanded/>
-        <InteriorLeftNavList className="second" isExpanded open/>
+        <InteriorLeftNavList className="first" isExpanded />
+        <InteriorLeftNavList className="second" isExpanded open />
       </InteriorLeftNav>
     );
 
@@ -119,5 +120,5 @@ describe('InteriorLeftNav', () => {
       expect(first().hasClass('left-nav-list__item--expanded')).toBe(true);
       expect(second().hasClass('left-nav-list__item--expanded')).toBe(true);
     });
-  })
+  });
 });

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -29,8 +29,7 @@ describe('InteriorLeftNav', () => {
           <InteriorLeftNavItem
             href=""
             title="test-title"
-            className="test-child"
-          >
+            className="test-child">
             <a href="">test-title</a>
           </InteriorLeftNavItem>
         </InteriorLeftNav>

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -116,17 +116,23 @@ export default class InteriorLeftNav extends Component {
       className
     );
 
+    const buttonStyles = {
+      border: 'none'
+    }
+
     return (
       <nav
+        tabIndex={-1}
         role="navigation"
         aria-label="Interior Left Navigation"
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
+        onKeyPress={!this.state.open ? this.toggle : () => {}}
         {...other}>
         <ul key="main_list" className="left-nav-list" role="menubar">
           {newChildren}
         </ul>
-        <div className="bx--interior-left-nav-collapse" onClick={this.toggle}>
+        <button className="bx--interior-left-nav-collapse" onClick={this.toggle} style={buttonStyles}>
           <a className="bx--interior-left-nav-collapse__link">
             <Icon
               name="chevron--left"
@@ -134,7 +140,7 @@ export default class InteriorLeftNav extends Component {
               className="bx--interior-left-nav-collapse__arrow"
             />
           </a>
-        </div>
+        </button>
       </nav>
     );
   }

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -117,22 +117,27 @@ export default class InteriorLeftNav extends Component {
     );
 
     const buttonStyles = {
-      border: 'none'
-    }
+      border: 'none',
+    };
 
     return (
       <nav
+        role="presentation"
         tabIndex={-1}
-        role="navigation"
         aria-label="Interior Left Navigation"
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
         onKeyPress={!this.state.open ? this.toggle : () => {}}
-        {...other}>
+        {...other}
+      >
         <ul key="main_list" className="left-nav-list" role="menubar">
           {newChildren}
         </ul>
-        <button className="bx--interior-left-nav-collapse" onClick={this.toggle} style={buttonStyles}>
+        <button
+          className="bx--interior-left-nav-collapse"
+          onClick={this.toggle}
+          style={buttonStyles}
+        >
           <a className="bx--interior-left-nav-collapse__link">
             <Icon
               name="chevron--left"

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -128,16 +128,14 @@ export default class InteriorLeftNav extends Component {
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
         onKeyPress={!this.state.open ? this.toggle : () => {}}
-        {...other}
-      >
+        {...other}>
         <ul key="main_list" className="left-nav-list" role="menubar">
           {newChildren}
         </ul>
         <button
           className="bx--interior-left-nav-collapse"
           onClick={this.toggle}
-          style={buttonStyles}
-        >
+          style={buttonStyles}>
           <a className="bx--interior-left-nav-collapse__link">
             <Icon
               name="chevron--left"

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
@@ -8,8 +8,7 @@ describe('InteriorLeftNavItem', () => {
       <InteriorLeftNavItem
         className="extra-class"
         href="test-href"
-        activeHref="test-href"
-      >
+        activeHref="test-href">
         <a href="test-href">link</a>
       </InteriorLeftNavItem>
     );

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
@@ -8,7 +8,8 @@ describe('InteriorLeftNavItem', () => {
       <InteriorLeftNavItem
         className="extra-class"
         href="test-href"
-        activeHref="test-href">
+        activeHref="test-href"
+      >
         <a href="test-href">link</a>
       </InteriorLeftNavItem>
     );
@@ -67,8 +68,8 @@ describe('InteriorLeftNavItem', () => {
     const onClick = jest.fn();
 
     const wrapper = shallow(
-      <InteriorLeftNavItem onClick={onClick} href="#">
-        <a href="#">test-title</a>
+      <InteriorLeftNavItem onClick={onClick} href="">
+        <a href="">test-title</a>
       </InteriorLeftNavItem>
     );
 

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -26,16 +26,21 @@ const InteriorLeftNavItem = ({
 
   return (
     <li
+      tabIndex={children ? -1 : tabIndex}
       role="menuitem"
-      tabIndex={tabIndex}
       className={classNames}
       onClick={evt => onClick(evt, href)}
       onKeyPress={evt => onClick(evt, href)}
-      {...other}>
+      {...other}
+    >
       {children ? (
         newChild(children, tabIndex)
       ) : (
-        <a className="left-nav-list__item-link" href={href} tabIndex={tabIndex}>
+        <a
+          className="left-nav-list__item-link"
+          href={href}
+          tabIndex={children ? tabIndex : -1}
+        >
           {label}
         </a>
       )}

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -31,16 +31,14 @@ const InteriorLeftNavItem = ({
       className={classNames}
       onClick={evt => onClick(evt, href)}
       onKeyPress={evt => onClick(evt, href)}
-      {...other}
-    >
+      {...other}>
       {children ? (
         newChild(children, tabIndex)
       ) : (
         <a
           className="left-nav-list__item-link"
           href={href}
-          tabIndex={children ? tabIndex : -1}
-        >
+          tabIndex={children ? tabIndex : -1}>
           {label}
         </a>
       )}

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
@@ -8,27 +8,27 @@ describe('InteriorLeftNavList', () => {
   describe('Renders as expected', () => {
     const openList = shallow(
       <InteriorLeftNavList className="extra-class" title="test-title" open>
-        <InteriorLeftNavItem href="#">
-          <a href="#">test-title</a>
+        <InteriorLeftNavItem href="">
+          <a href="">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
 
     const closedList = shallow(
       <InteriorLeftNavList>
-        <InteriorLeftNavItem href="#">
-          <a href="#">test-title</a>
+        <InteriorLeftNavItem href="">
+          <a href="">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
 
     const expectedChildrenList = shallow(
       <InteriorLeftNavList>
-        <InteriorLeftNavItem href="#" className="test-child">
-          <a href="#">test-title</a>
+        <InteriorLeftNavItem href="" className="test-child">
+          <a href="">test-title</a>
         </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#" className="test-child">
-          <a href="#">test-title</a>
+        <InteriorLeftNavItem href="" className="test-child">
+          <a href="">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
@@ -101,8 +101,8 @@ describe('InteriorLeftNavList', () => {
   describe('actions', () => {
     const list = mount(
       <InteriorLeftNavList title="test-title">
-        <InteriorLeftNavItem href="#">
-          <a href="#">test-title</a>
+        <InteriorLeftNavItem href="">
+          <a href="">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -91,8 +91,7 @@ export default class InteriorLeftNavList extends Component {
         tabIndex={tabIndex}
         onClick={this.toggle}
         onKeyPress={this.toggle}
-        role="menuitem"
-       >
+        role="menuitem">
         <a className="left-nav-list__item-link">
           {title}
           <div className="left-nav-list__item-icon">

--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -163,7 +163,7 @@ describe('Modal', () => {
 });
 describe('Modal Wrapper', () => {
   describe('Renders as expected', () => {
-    const wrapper = mount(<ModalWrapper/>);
+    const wrapper = mount(<ModalWrapper />);
 
     it('should default to primary button', () => {
       expect(wrapper.find('.bx--btn--primary').length).toEqual(2);
@@ -172,7 +172,6 @@ describe('Modal Wrapper', () => {
     it('should render ghost button when ghost is passed', () => {
       wrapper.setProps({ triggerButtonkind: 'ghost' });
       expect(wrapper.find('.bx--btn--ghost').length).toEqual(1);
-
     });
 
     it('should render danger button when danger is passed', () => {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -77,8 +77,7 @@ export default class Modal extends Component {
       <button
         className="bx--modal-close"
         type="button"
-        onClick={onRequestClose}
-      >
+        onClick={onRequestClose}>
         <Icon
           name="close"
           className="bx--modal-close__icon"
@@ -92,8 +91,7 @@ export default class Modal extends Component {
         ref={modal => {
           this.innerModal = modal;
         }}
-        className="bx--modal-container"
-      >
+        className="bx--modal-container">
         <div className="bx--modal-header">
           {passiveModal && modalButton}
           {modalLabel && (
@@ -112,8 +110,7 @@ export default class Modal extends Component {
               <Button
                 kind="primary"
                 disabled={primaryButtonDisabled}
-                onClick={onRequestSubmit}
-              >
+                onClick={onRequestSubmit}>
                 {primaryButtonText}
               </Button>
             </div>
@@ -129,8 +126,7 @@ export default class Modal extends Component {
         onClick={this.handleClick}
         className={modalClasses}
         role="presentation"
-        tabIndex={-1}
-      >
+        tabIndex={-1}>
         {modalBody}
       </div>
     );

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -128,7 +128,7 @@ export default class Modal extends Component {
         onKeyDown={this.handleKeyDown}
         onClick={this.handleClick}
         className={modalClasses}
-        role="dialog"
+        role="presentation"
         tabIndex={-1}
       >
         {modalBody}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -77,7 +77,8 @@ export default class Modal extends Component {
       <button
         className="bx--modal-close"
         type="button"
-        onClick={onRequestClose}>
+        onClick={onRequestClose}
+      >
         <Icon
           name="close"
           className="bx--modal-close__icon"
@@ -91,7 +92,8 @@ export default class Modal extends Component {
         ref={modal => {
           this.innerModal = modal;
         }}
-        className="bx--modal-container">
+        className="bx--modal-container"
+      >
         <div className="bx--modal-header">
           {passiveModal && modalButton}
           {modalLabel && (
@@ -110,7 +112,8 @@ export default class Modal extends Component {
               <Button
                 kind="primary"
                 disabled={primaryButtonDisabled}
-                onClick={onRequestSubmit}>
+                onClick={onRequestSubmit}
+              >
                 {primaryButtonText}
               </Button>
             </div>
@@ -125,7 +128,9 @@ export default class Modal extends Component {
         onKeyDown={this.handleKeyDown}
         onClick={this.handleClick}
         className={modalClasses}
-        tabIndex={-1}>
+        role="dialog"
+        tabIndex={-1}
+      >
         {modalBody}
       </div>
     );

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -19,13 +19,18 @@ export default class ModalWrapper extends React.Component {
     primaryButtonText: PropTypes.string,
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
-    triggerButtonkind: PropTypes.oneOf(['primary', 'secondary', 'danger', 'ghost']),
+    triggerButtonkind: PropTypes.oneOf([
+      'primary',
+      'secondary',
+      'danger',
+      'ghost',
+    ]),
   };
 
   static defaultProps = {
     primaryButtonText: 'Save',
     secondaryButtonText: 'Cancel',
-    triggerButtonkind: 'primary'
+    triggerButtonkind: 'primary',
   };
 
   state = {
@@ -72,13 +77,17 @@ export default class ModalWrapper extends React.Component {
 
     return (
       <div
+        role="presentation"
         onKeyDown={evt => {
           if (evt.which === 27) {
             this.handleClose();
             this.props.onKeyDown(evt);
           }
-        }}>
-        <Button kind={triggerButtonkind} onClick={this.handleOpen}>{buttonTriggerText}</Button>
+        }}
+      >
+        <Button kind={triggerButtonkind} onClick={this.handleOpen}>
+          {buttonTriggerText}
+        </Button>
         <Modal {...props} {...other}>
           {this.props.children}
         </Modal>

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -83,8 +83,7 @@ export default class ModalWrapper extends React.Component {
             this.handleClose();
             this.props.onKeyDown(evt);
           }
-        }}
-      >
+        }}>
         <Button kind={triggerButtonkind} onClick={this.handleOpen}>
           {buttonTriggerText}
         </Button>

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -49,12 +49,14 @@ export default class NumberInput extends Component {
 
   handleChange = evt => {
     if (!this.props.disabled) {
-      this.setState({
-        value: evt.target.value,
-      }, (evt) => {
-        this.props.onChange(evt);
-      });
-
+      this.setState(
+        {
+          value: evt.target.value,
+        },
+        evt => {
+          this.props.onChange(evt);
+        }
+      );
     }
   };
 
@@ -72,12 +74,15 @@ export default class NumberInput extends Component {
     if (!disabled && conditional) {
       value = direction === 'down' ? value - step : value + step;
 
-      this.setState({
-        value,
-      }, (evt) => {
-        this.props.onClick(evt);
-        this.props.onChange(evt);
-      });
+      this.setState(
+        {
+          value,
+        },
+        evt => {
+          this.props.onClick(evt);
+          this.props.onChange(evt);
+        }
+      );
     }
   };
 

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -146,8 +146,7 @@ export default class OverflowMenu extends Component {
           aria-label={ariaLabel}
           id={id}
           tabIndex={tabIndex}
-          ref={this.bindMenuEl}
-        >
+          ref={this.bindMenuEl}>
           <Icon
             onClick={this.handleClick}
             className={overflowMenuIconClasses}
@@ -159,8 +158,7 @@ export default class OverflowMenu extends Component {
             <FloatingMenu
               menuPosition={this.state.menuPosition}
               menuDirection="bottom"
-              menuOffset={flipped ? menuOffsetFlip : menuOffset}
-            >
+              menuOffset={flipped ? menuOffsetFlip : menuOffset}>
               <ul className={overflowMenuOptionsClasses}>
                 {childrenWithProps}
               </ul>

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -140,12 +140,14 @@ export default class OverflowMenu extends Component {
       <ClickListener onClickOutside={this.handleClickOutside}>
         <div
           {...other}
+          role="button"
           className={overflowMenuClasses}
           onKeyDown={this.handleKeyPress}
           aria-label={ariaLabel}
           id={id}
           tabIndex={tabIndex}
-          ref={this.bindMenuEl}>
+          ref={this.bindMenuEl}
+        >
           <Icon
             onClick={this.handleClick}
             className={overflowMenuIconClasses}
@@ -157,7 +159,8 @@ export default class OverflowMenu extends Component {
             <FloatingMenu
               menuPosition={this.state.menuPosition}
               menuDirection="bottom"
-              menuOffset={flipped ? menuOffsetFlip : menuOffset}>
+              menuOffset={flipped ? menuOffsetFlip : menuOffset}
+            >
               <ul className={overflowMenuOptionsClasses}>
                 {childrenWithProps}
               </ul>

--- a/src/components/Slider/Slider-story.js
+++ b/src/components/Slider/Slider-story.js
@@ -20,7 +20,7 @@ storiesOf('Slider', module)
           max={100}
           step={1}
           labelText="Slider Label"
-          onChange={() => {}}
+          onChange={action('onChange')}
         />
       </div>
     )

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -241,6 +241,12 @@ export default class Slider extends PureComponent {
               this.element = node;
             }}
             onClick={this.updatePosition}
+            onKeyPress={this.updatePosition}
+            role="slider"
+            tabIndex={-1}
+            aria-valuemax={max}
+            aria-valuemin={min}
+            aria-valuenow={value}
             {...other}
           >
             <div
@@ -255,7 +261,7 @@ export default class Slider extends PureComponent {
             />
             <div
               className="bx--slider__thumb"
-              tabIndex="0"
+              tabIndex={0}
               style={thumbStyle}
               onMouseDown={this.handleMouseStart}
               onTouchStart={this.handleTouchStart}

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -244,8 +244,7 @@ export default class Slider extends PureComponent {
             onKeyPress={this.updatePosition}
             role="presentation"
             tabIndex={-1}
-            {...other}
-          >
+            {...other}>
             <div
               className="bx--slider__track"
               ref={node => {

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -242,11 +242,8 @@ export default class Slider extends PureComponent {
             }}
             onClick={this.updatePosition}
             onKeyPress={this.updatePosition}
-            role="slider"
+            role="presentation"
             tabIndex={-1}
-            aria-valuemax={max}
-            aria-valuemin={min}
-            aria-valuenow={value}
             {...other}
           >
             <div
@@ -261,7 +258,11 @@ export default class Slider extends PureComponent {
             />
             <div
               className="bx--slider__thumb"
+              role="slider"
               tabIndex={0}
+              aria-valuemax={max}
+              aria-valuemin={min}
+              aria-valuenow={value}
               style={thumbStyle}
               onMouseDown={this.handleMouseStart}
               onTouchStart={this.handleTouchStart}

--- a/src/components/StructuredList/StructuredList.js
+++ b/src/components/StructuredList/StructuredList.js
@@ -130,7 +130,9 @@ export class StructuredListRow extends Component {
         tabIndex={tabIndex}
         className={classes}
         htmlFor={htmlFor}
-        onKeyDown={onKeyDown}>
+        onKeyDown={onKeyDown}
+        role="presentation"
+      >
         {children}
       </label>
     ) : (

--- a/src/components/StructuredList/StructuredList.js
+++ b/src/components/StructuredList/StructuredList.js
@@ -131,8 +131,7 @@ export class StructuredListRow extends Component {
         className={classes}
         htmlFor={htmlFor}
         onKeyDown={onKeyDown}
-        role="presentation"
-      >
+        role="presentation">
         {children}
       </label>
     ) : (

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -12,6 +12,7 @@ const Switch = props => {
     onKeyDown,
     selected,
     text,
+    href,
     ...other
   } = props;
 
@@ -47,7 +48,7 @@ const Switch = props => {
   }
 
   return (
-    <a href="#" {...other} {...commonProps}>
+    <a href={href} {...other} {...commonProps}>
       {text}
     </a>
   );
@@ -62,12 +63,14 @@ Switch.propTypes = {
   onKeyDown: PropTypes.func,
   selected: PropTypes.bool,
   text: PropTypes.string.isRequired,
+  href: PropTypes.string,
 };
 
 Switch.defaultProps = {
   selected: false,
   kind: 'anchor',
   text: 'Provide text',
+  href: '',
   onClick: () => {},
   onKeyDown: () => {},
 };

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -77,15 +77,13 @@ export default class Tab extends React.Component {
           onKeyDown(evt);
         }}
         role="presentation"
-        selected={selected}
-      >
+        selected={selected}>
         <a
           className="bx--tabs__nav-link"
           href={href}
           role="tab"
           tabIndex={tabIndex}
-          ref="tabAnchor"
-        >
+          ref="tabAnchor">
           {label}
         </a>
       </li>

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -66,6 +66,7 @@ export default class Tab extends React.Component {
     return (
       <li
         {...other}
+        tabIndex={-1}
         className={classes}
         onClick={evt => {
           handleTabClick(index, label, evt);
@@ -77,13 +78,15 @@ export default class Tab extends React.Component {
           onKeyDown(evt);
         }}
         role={role}
-        selected={selected}>
+        selected={selected}
+      >
         <a
           className="bx--tabs__nav-link"
           href={href}
           role="tab"
           tabIndex={tabIndex}
-          ref="tabAnchor">
+          ref="tabAnchor"
+        >
           {label}
         </a>
       </li>

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -49,7 +49,6 @@ export default class Tab extends React.Component {
       href,
       index,
       label,
-      role,
       selected,
       tabIndex,
       onClick,
@@ -77,7 +76,7 @@ export default class Tab extends React.Component {
           handleTabKeyDown(index, label, evt);
           onKeyDown(evt);
         }}
-        role={role}
+        role="presentation"
         selected={selected}
       >
         <a

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -118,7 +118,8 @@ export default class Tabs extends React.Component {
         <TabContent
           className="tab-content"
           hidden={!selected}
-          selected={selected}>
+          selected={selected}
+        >
           {children}
         </TabContent>
       );
@@ -134,11 +135,19 @@ export default class Tabs extends React.Component {
     return (
       <div>
         <nav {...other} className={classes.tabs} role={role}>
-          <div className="bx--tabs-trigger" onClick={this.handleDropdownClick}>
+          <div
+            role="listbox"
+            tabIndex={0}
+            className="bx--tabs-trigger"
+            onClick={this.handleDropdownClick}
+            onKeyPress={this.handleDropdownClick}
+          >
             <a
+              tabIndex={-1}
               className="bx--tabs-trigger-text"
               href={triggerHref}
-              onClick={this.handleDropdownClick}>
+              onClick={this.handleDropdownClick}
+            >
               {this.state.selectedLabel}
             </a>
             <Icon description={iconDescription} name="caret--down" />

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -118,8 +118,7 @@ export default class Tabs extends React.Component {
         <TabContent
           className="tab-content"
           hidden={!selected}
-          selected={selected}
-        >
+          selected={selected}>
           {children}
         </TabContent>
       );
@@ -140,14 +139,12 @@ export default class Tabs extends React.Component {
             tabIndex={0}
             className="bx--tabs-trigger"
             onClick={this.handleDropdownClick}
-            onKeyPress={this.handleDropdownClick}
-          >
+            onKeyPress={this.handleDropdownClick}>
             <a
               tabIndex={-1}
               className="bx--tabs-trigger-text"
               href={triggerHref}
-              onClick={this.handleDropdownClick}
-            >
+              onClick={this.handleDropdownClick}>
               {this.state.selectedLabel}
             </a>
             <Icon description={iconDescription} name="caret--down" />

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -81,8 +81,7 @@ export class ClickableTile extends Component {
         className={classes}
         {...other}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
-      >
+        onKeyDown={this.handleKeyDown}>
         {children}
       </a>
     );
@@ -163,8 +162,7 @@ export class SelectableTile extends Component {
         {...other}
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
-        role="presentation"
-      >
+        role="presentation">
         <input
           ref={input => {
             this.input = input;
@@ -279,8 +277,7 @@ export class ExpandableTile extends Component {
         {...other}
         role="button"
         onClick={this.handleClick}
-        tabIndex={tabIndex}
-      >
+        tabIndex={tabIndex}>
         <button className="bx--tile__chevron">
           <Icon name="chevron--down" description="Tile chevron" />
         </button>
@@ -288,8 +285,7 @@ export class ExpandableTile extends Component {
           ref={tileContent => {
             this.tileContent = tileContent;
           }}
-          className="bx--tile-content"
-        >
+          className="bx--tile-content">
           {content}
         </div>
       </div>

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -81,7 +81,8 @@ export class ClickableTile extends Component {
         className={classes}
         {...other}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}>
+        onKeyDown={this.handleKeyDown}
+      >
         {children}
       </a>
     );
@@ -161,7 +162,9 @@ export class SelectableTile extends Component {
         tabIndex={tabIndex}
         {...other}
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}>
+        onKeyDown={this.handleKeyDown}
+        role="presentation"
+      >
         <input
           ref={input => {
             this.input = input;
@@ -276,7 +279,8 @@ export class ExpandableTile extends Component {
         {...other}
         role="button"
         onClick={this.handleClick}
-        tabIndex={tabIndex}>
+        tabIndex={tabIndex}
+      >
         <button className="bx--tile__chevron">
           <Icon name="chevron--down" description="Tile chevron" />
         </button>
@@ -284,7 +288,8 @@ export class ExpandableTile extends Component {
           ref={tileContent => {
             this.tileContent = tileContent;
           }}
-          className="bx--tile-content">
+          className="bx--tile-content"
+        >
           {content}
         </div>
       </div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -81,8 +81,7 @@ export default class Tooltip extends Component {
               onMouseOver={() => this.handleMouse('over')}
               onMouseOut={() => this.handleMouse('out')}
               onFocus={() => this.handleMouse('over')}
-              onBlur={() => this.handleMouse('out')}
-            >
+              onBlur={() => this.handleMouse('out')}>
               <Icon
                 role="button"
                 tabIndex="0"
@@ -100,21 +99,18 @@ export default class Tooltip extends Component {
             onMouseOver={() => this.handleMouse('over')}
             onMouseOut={() => this.handleMouse('out')}
             onFocus={() => this.handleMouse('over')}
-            onBlur={() => this.handleMouse('out')}
-          >
+            onBlur={() => this.handleMouse('out')}>
             {triggerText}
           </div>
         )}
         <FloatingMenu
           menuPosition={this.state.triggerPosition}
           menuDirection={direction}
-          menuOffset={menuOffset}
-        >
+          menuOffset={menuOffset}>
           <div
             className={tooltipClasses}
             {...other}
-            data-floating-menu-direction={direction}
-          >
+            data-floating-menu-direction={direction}>
             {children}
           </div>
         </FloatingMenu>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -81,11 +81,13 @@ export default class Tooltip extends Component {
               onMouseOver={() => this.handleMouse('over')}
               onMouseOut={() => this.handleMouse('out')}
               onFocus={() => this.handleMouse('over')}
-              onBlur={() => this.handleMouse('out')}>
+              onBlur={() => this.handleMouse('out')}
+            >
               <Icon
+                role="button"
+                tabIndex="0"
                 name={iconName}
                 description={iconDescription}
-                tabIndex="0"
               />
             </div>
           </div>
@@ -98,18 +100,21 @@ export default class Tooltip extends Component {
             onMouseOver={() => this.handleMouse('over')}
             onMouseOut={() => this.handleMouse('out')}
             onFocus={() => this.handleMouse('over')}
-            onBlur={() => this.handleMouse('out')}>
+            onBlur={() => this.handleMouse('out')}
+          >
             {triggerText}
           </div>
         )}
         <FloatingMenu
           menuPosition={this.state.triggerPosition}
           menuDirection={direction}
-          menuOffset={menuOffset}>
+          menuOffset={menuOffset}
+        >
           <div
             className={tooltipClasses}
             {...other}
-            data-floating-menu-direction={direction}>
+            data-floating-menu-direction={direction}
+          >
             {children}
           </div>
         </FloatingMenu>

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -19,12 +19,15 @@ const TooltipSimple = ({
   return (
     <div className={tooltipWrapperClasses}>
       {children}
-      <div
-        tabIndex="0"
-        className={tooltipClasses}
-        data-tooltip-text={text}
-        {...other}>
-        {showIcon && <Icon name={iconName} description={iconDescription} />}
+      <div className={tooltipClasses} data-tooltip-text={text} {...other}>
+        {showIcon && (
+          <Icon
+            role="button"
+            tabIndex="0"
+            name={iconName}
+            description={iconDescription}
+          />
+        )}
       </div>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,6 +458,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -543,6 +549,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
 ast-types@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.11.tgz#371177bb59232ff5ceaa1d09ee5cad705b1a5aa9"
@@ -616,6 +626,12 @@ aws4@^1.2.1, aws4@^1.6.0:
 axe-core@^2.0.7:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.3.1.tgz#be87acabe8c2c6a979761ea7c2b423791fb32f3f"
+
+axobject-query@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-cli@^6.24.1:
   version "6.26.0"
@@ -2902,6 +2918,10 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-regex@^6.1.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -3097,13 +3117,17 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-jsx-a11y@^2.0.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz#4e35cb71b8a7db702ac415c806eb8e8d9ea6c65d"
+eslint-plugin-jsx-a11y@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
   dependencies:
+    aria-query "^0.7.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
     damerau-levenshtein "^1.0.0"
-    jsx-ast-utils "^1.0.0"
-    object-assign "^4.0.1"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.4.0"
 
 eslint-plugin-react@^7.4.0:
   version "7.5.1"
@@ -5041,7 +5065,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^1.0.0:
+jsx-ast-utils@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 


### PR DESCRIPTION
Fixes the `a11y` warnings being thrown during the linting step. To avoid breaking changes, I've removed `jsx-a11y/no-static-element-interactions

#### Changelog

**New**

- Added `tabIndex`, `role` to select components

**Changed**

- `AccordionItem`
- `ComposedModal`
- `Dropdown`
- `DropdownItem`
- `InteriorLeftNav`
- `InteriorLeftNavItem`
- `Modal`
- `Slider`
- `Switch`
- `Tab`
- `Tabs`

**Removed**

- A bit of extra things from `Dropdown` story


#### Testing

Make sure none of the above components are broken 
