### PR TITLE
feat(NumberInput): add invalidText and invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     }
   },
   "peerDependencies": {
-    "carbon-components": "^8.0.0",
+    "carbon-components": "^8.1.11",
     "carbon-icons": "^5.1.2 || ^6.0.0",
     "react": "^16.1.0",
     "react-dom": "^16.1.0"

--- a/src/components/NumberInput/NumberInput-story.js
+++ b/src/components/NumberInput/NumberInput-story.js
@@ -13,24 +13,35 @@ const numberInputProps = {
   max: 100,
   value: 50,
   step: 10,
+  invalidText: 'Number is not valid',
 };
 
-storiesOf('NumberInput', module).addWithInfo(
-  'enabled',
-  `
-      Number inputs are similar to text fields, but contain controls used to increase or decrease an incremental value.
-      The example below shows an enabled Number Input component. The Number Input component can be
-      passed a starting value, a min, a max, and the step.
-    `,
-  () => <NumberInput {...numberInputProps} />
-);
+const introText = `
+  Number inputs are similar to text fields, but contain controls used to increase or decrease an incremental value. The Number Input component can be passed a starting value, a min, a max, and the step.
+`;
 
-storiesOf('NumberInput', module).addWithInfo(
-  'disabled',
-  `
-      Number inputs are similar to text fields, but contain controls used to increase or decrease an incremental value.
-      The example below shows an disabled Number Input component. The Number Input component can be
-      passed a starting value, a min, a max, and the step.
+storiesOf('NumberInput', module)
+  .addWithInfo(
+    'enabled',
+    `
+      ${introText}
+      The example below shows an enabled Number Input component.
     `,
-  () => <NumberInput disabled {...numberInputProps} />
-);
+    () => <NumberInput {...numberInputProps} />
+  )
+  .addWithInfo(
+    'disabled',
+    `
+      ${introText}
+      The example below shows an disabled Number Input component.
+    `,
+    () => <NumberInput disabled {...numberInputProps} />
+  )
+  .addWithInfo(
+    'invalid',
+    `
+      ${introText}
+      The example below shows an disabled Number Input component.
+    `,
+    () => <NumberInput {...numberInputProps} invalid />
+  );

--- a/src/components/NumberInput/NumberInput-test.js
+++ b/src/components/NumberInput/NumberInput-test.js
@@ -5,20 +5,31 @@ import NumberInput from '../NumberInput';
 
 describe('NumberInput', () => {
   describe('should render as expected', () => {
-    const wrapper = mount(
-      <NumberInput
-        min={0}
-        max={100}
-        id="test"
-        label="Number Input"
-        className="extra-class"
-      />
-    );
+    let wrapper;
+    let label;
+    let numberInput;
+    let container;
+    let formItem;
+    let icons;
 
-    const label = wrapper.find('label');
-    const numberInput = wrapper.find('input');
-    const container = wrapper.find('.bx--number');
-    const formItem = wrapper.find('.bx--form-item');
+    beforeEach(() => {
+      wrapper = mount(
+        <NumberInput
+          min={0}
+          max={100}
+          id="test"
+          label="Number Input"
+          className="extra-class"
+          invalidText="invalid text"
+        />
+      );
+
+      label = wrapper.find('label');
+      numberInput = wrapper.find('input');
+      container = wrapper.find('.bx--number');
+      formItem = wrapper.find('.bx--form-item');
+      icons = wrapper.find(Icon);
+    });
 
     describe('input', () => {
       it('renders a numberInput', () => {
@@ -38,27 +49,41 @@ describe('NumberInput', () => {
       });
 
       it('should set a min as expected', () => {
-        expect(numberInput.props().min).toEqual(0);
+        expect(numberInput.prop('min')).toEqual(0);
         wrapper.setProps({ min: 10 });
-        expect(wrapper.find('input').props().min).toEqual(10);
+        expect(wrapper.find('input').prop('min')).toEqual(10);
       });
 
       it('should set a max as expected', () => {
-        expect(numberInput.props().max).toEqual(100);
+        expect(numberInput.prop('max')).toEqual(100);
         wrapper.setProps({ max: 10 });
-        expect(wrapper.find('input').props().min).toEqual(10);
+        expect(wrapper.find('input').prop('max')).toEqual(10);
       });
 
       it('should set step as expected', () => {
-        expect(numberInput.props().step).toEqual(1);
+        expect(numberInput.prop('step')).toEqual(1);
         wrapper.setProps({ step: 10 });
-        expect(wrapper.find('input').props().step).toEqual(10);
+        expect(wrapper.find('input').prop('step')).toEqual(10);
       });
 
       it('should set disabled as expected', () => {
-        expect(numberInput.props().disabled).toEqual(false);
+        expect(numberInput.prop('disabled')).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(wrapper.find('input').props().disabled).toEqual(true);
+        expect(wrapper.find('input').prop('disabled')).toEqual(true);
+      });
+
+      it('should set invalid as expected', () => {
+        expect(container.prop('data-invalid')).toEqual(undefined);
+        wrapper.setProps({ invalid: true });
+        expect(wrapper.find('.bx--number').prop('data-invalid')).toEqual(true);
+      });
+
+      it('should set invalidText as expected', () => {
+        expect(wrapper.find('.bx--form-requirement').length).toEqual(0);
+        wrapper.setProps({ invalid: true });
+        const invalidText = wrapper.find('.bx--form-requirement');
+        expect(invalidText.length).toEqual(1);
+        expect(invalidText.text()).toEqual('invalid text');
       });
 
       describe('initial rendering', () => {
@@ -78,53 +103,52 @@ describe('NumberInput', () => {
         it('should set value as expected when value > min', () => {
           const wrapper = getWrapper(-1, 100, 0);
           const numberInput = getNumberInput(wrapper);
-          expect(numberInput.props().value).toEqual(0);
+          expect(numberInput.prop('value')).toEqual(0);
         });
 
         it('should set value as expected when min === 0 and value > min', () => {
           const wrapper = getWrapper(0, 100, 1);
           const numberInput = getNumberInput(wrapper);
-          expect(numberInput.props().value).toEqual(1);
+          expect(numberInput.prop('value')).toEqual(1);
         });
 
         it('should set value to equal min when value < min', () => {
           let wrapper = getWrapper(5, 100, 0);
           let numberInput = wrapper.find('input');
-          expect(numberInput.props().value).toEqual(5);
+          expect(numberInput.prop('value')).toEqual(5);
         });
 
         it('should set value when min is undefined', () => {
           let wrapper = getWrapper(undefined, 100, 5);
           let numberInput = wrapper.find('input');
-          expect(numberInput.props().value).toEqual(5);
+          expect(numberInput.prop('value')).toEqual(5);
         });
       });
     });
 
     describe('Icon', () => {
-      const icons = wrapper.find(Icon);
       it('renders two Icon components', () => {
         expect(icons.length).toEqual(2);
       });
 
       it('has the expected default iconDescription', () => {
-        expect(wrapper.props().iconDescription).toEqual('choose a number');
+        expect(wrapper.prop('iconDescription')).toEqual('choose a number');
       });
 
       it('should use correct icons', () => {
-        expect(icons.at(0).props().name).toEqual('caret--up');
-        expect(icons.at(1).props().name).toEqual('caret--down');
+        expect(icons.at(0).prop('name')).toEqual('caret--up');
+        expect(icons.at(1).prop('name')).toEqual('caret--down');
       });
 
       it('adds new iconDescription when passed via props', () => {
         wrapper.setProps({ iconDescription: 'new description' });
-        expect(wrapper.props().iconDescription).toEqual('new description');
+        expect(wrapper.prop('iconDescription')).toEqual('new description');
       });
 
       it('should have iconDescription match Icon component description prop', () => {
         const iconUpText = wrapper.find('.up-icon title').text();
         const iconDownText = wrapper.find('.down-icon title').text();
-        const iconDescription = wrapper.props().iconDescription;
+        const iconDescription = wrapper.prop('iconDescription');
 
         const matches =
           iconDescription === iconUpText && iconDescription === iconDownText;

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -16,6 +16,8 @@ export default class NumberInput extends Component {
     onClick: PropTypes.func,
     step: PropTypes.number,
     value: PropTypes.number,
+    invalid: PropTypes.bool,
+    invalidText: PropTypes.string,
   };
 
   static defaultProps = {
@@ -26,6 +28,8 @@ export default class NumberInput extends Component {
     onClick: () => {},
     step: 1,
     value: 0,
+    invalid: false,
+    invalidText: 'Provide invalidText',
   };
 
   constructor(props) {
@@ -96,6 +100,8 @@ export default class NumberInput extends Component {
       max,
       min,
       step,
+      invalid,
+      invalidText,
       ...other
     } = this.props;
 
@@ -117,12 +123,19 @@ export default class NumberInput extends Component {
       className: 'bx--number__control-btn',
     };
 
+    const inputWrapperProps = {};
+    let error = null;
+    if (invalid) {
+      inputWrapperProps['data-invalid'] = true;
+      error = <div className="bx--form-requirement">{invalidText}</div>;
+    }
+
     return (
       <div className="bx--form-item">
         <label htmlFor={id} className="bx--label">
           {label}
         </label>
-        <div className={numberInputClasses}>
+        <div className={numberInputClasses} {...inputWrapperProps}>
           <input type="number" pattern="[0-9]*" {...other} {...props} />
           <div className="bx--number__controls">
             <button
@@ -147,6 +160,7 @@ export default class NumberInput extends Component {
             </button>
           </div>
         </div>
+        {error}
       </div>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,8 +1977,8 @@ caniuse-lite@^1.0.30000715, caniuse-lite@^1.0.30000744, caniuse-lite@^1.0.300007
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000749.tgz#2ff382865aead8cca35dacfbab04f58effa4c01c"
 
 carbon-components@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.1.3.tgz#3c89d34c6d71eac20ea6514ae68adb827cce050e"
+  version "8.1.13"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.1.13.tgz#addec6b8f15c7f21938c52e4d669b293c813289b"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"


### PR DESCRIPTION
Add support for the invalid flag and for invalidText

Fixes #373 

Blocked by Carbon core not properly supporting invalidText with NumberInput (styles are wrong)