### PR TITLE
fix(a11y): update jsx-a11y to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,21 +14,15 @@
     "prepublish": "yarn build",
     "prettier": "prettier --write \"**/*.{scss,css,js}\"",
     "prettier:diff": "prettier --list-different \"**/*.{scss,css,js}\"",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release":
+      "semantic-release pre && npm publish && semantic-release post",
     "start": "yarn storybook",
     "storybook": "start-storybook -p 9000",
     "test": "jest",
     "test-ssr": "yarn build && node ssr-tests/*.js"
   },
-  "keywords": [
-    "react",
-    "carbon",
-    "carbon-components"
-  ],
-  "files": [
-    "lib/**/*",
-    "es/**/*"
-  ],
+  "keywords": ["react", "carbon", "carbon-components"],
+  "files": ["lib/**/*", "es/**/*"],
   "contributors": [
     {
       "name": "Brian Han",
@@ -57,14 +51,8 @@
   ],
   "eslintConfig": {
     "parser": "babel-eslint",
-    "extends": [
-      "eslint:recommended",
-      "plugin:jsx-a11y/recommended"
-    ],
-    "plugins": [
-      "react",
-      "jsx-a11y"
-    ],
+    "extends": ["eslint:recommended", "plugin:jsx-a11y/recommended"],
+    "plugins": ["react", "jsx-a11y"],
     "rules": {
       "react/jsx-uses-vars": 1,
       "react/jsx-uses-react": 1,
@@ -72,8 +60,16 @@
       "jsx-a11y/no-static-element-interactions": 1,
       "jsx-a11y/no-noninteractive-element-interactions": 1,
       "jsx-a11y/click-events-have-key-events": 1,
-      "jsx-a11y/href-no-hash": 1,
-      "jsx-a11y/interactive-supports-focus": 1
+      "jsx-a11y/anchor-is-valid": 1,
+      "jsx-a11y/interactive-supports-focus": 1,
+      "jsx-a11y/label-has-for": [
+        1,
+        {
+          "components": ["Label"],
+          "required": { "some": ["nesting", "id"] },
+          "allowChildren": false
+        }
+      ]
     },
     "env": {
       "node": true,
@@ -118,7 +114,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.1.2",
     "eslint": "^4.11.0",
-    "eslint-plugin-jsx-a11y": "^5.0.0",
+    "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-react": "^7.4.0",
     "gh-pages": "1.0.0",
     "husky": "^0.14.3",
@@ -144,14 +140,8 @@
     "whatwg-fetch": "^2.0.3"
   },
   "babel": {
-    "presets": [
-      "./scripts/env",
-      "react",
-      "stage-1"
-    ],
-    "plugins": [
-      "transform-object-assign"
-    ]
+    "presets": ["./scripts/env", "react", "stage-1"],
+    "plugins": ["transform-object-assign"]
   },
   "prettier": {
     "jsxBracketSameLine": true,
@@ -160,15 +150,8 @@
     "trailingComma": "es5"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier",
-      "lint",
-      "git add"
-    ],
-    "*.{css,scss}": [
-      "prettier",
-      "git add"
-    ]
+    "*.js": ["prettier", "lint", "git add"],
+    "*.{css,scss}": ["prettier", "git add"]
   },
   "config": {
     "validate-commit-msg": {
@@ -197,12 +180,8 @@
     "url": "https://github.com/carbon-design-system/carbon-components-react.git"
   },
   "jest": {
-    "collectCoverageFrom": [
-      "components/**/*.js"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
+    "collectCoverageFrom": ["components/**/*.js"],
+    "setupFiles": ["<rootDir>/config/jest/setup.js"],
     "testMatch": [
       "<rootDir>/**/__tests__/**/*.js?(x)",
       "<rootDir>/**/?(*-)(spec|test).js?(x)"
@@ -220,15 +199,8 @@
       "/es/",
       "/cjs/"
     ],
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+    "moduleFileExtensions": ["js", "json"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }

--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -15,27 +15,27 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
     <InteriorLeftNav>
       <InteriorLeftNavList title="Example Item 1">
         <InteriorLeftNavItem href="#example-item-1A">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1B">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-1C">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavList title="Example Item 2">
         <InteriorLeftNavItem href="#example-item-2A">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2B">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2C">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="#example-item-2D">
-          <a href="">Link Child</a>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
       <InteriorLeftNavItem href="#example-item-3" label="Link Label" />

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -30,7 +30,7 @@ describe('InteriorLeftNav', () => {
             href=""
             title="test-title"
             className="test-child">
-            <a href="">test-title</a>
+            <a href="http://www.carbondesignsystem.com">test-title</a>
           </InteriorLeftNavItem>
         </InteriorLeftNav>
       );

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -136,13 +136,11 @@ export default class InteriorLeftNav extends Component {
           className="bx--interior-left-nav-collapse"
           onClick={this.toggle}
           style={buttonStyles}>
-          <a className="bx--interior-left-nav-collapse__link">
-            <Icon
-              name="chevron--left"
-              description="close/open iln"
-              className="bx--interior-left-nav-collapse__arrow"
-            />
-          </a>
+          <Icon
+            name="chevron--left"
+            description="close/open iln"
+            className="bx--interior-left-nav-collapse__arrow"
+          />
         </button>
       </nav>
     );

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
@@ -68,7 +68,7 @@ describe('InteriorLeftNavItem', () => {
 
     const wrapper = shallow(
       <InteriorLeftNavItem onClick={onClick} href="">
-        <a href="">test-title</a>
+        <a href="http://www.carbondesignsystem.com">test-title</a>
       </InteriorLeftNavItem>
     );
 

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList-test.js
@@ -9,7 +9,7 @@ describe('InteriorLeftNavList', () => {
     const openList = shallow(
       <InteriorLeftNavList className="extra-class" title="test-title" open>
         <InteriorLeftNavItem href="">
-          <a href="">test-title</a>
+          <a href="http://www.carbondesignsystem.com">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
@@ -17,7 +17,7 @@ describe('InteriorLeftNavList', () => {
     const closedList = shallow(
       <InteriorLeftNavList>
         <InteriorLeftNavItem href="">
-          <a href="">test-title</a>
+          <a href="http://www.carbondesignsystem.com">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
@@ -25,10 +25,10 @@ describe('InteriorLeftNavList', () => {
     const expectedChildrenList = shallow(
       <InteriorLeftNavList>
         <InteriorLeftNavItem href="" className="test-child">
-          <a href="">test-title</a>
+          <a href="http://www.carbondesignsystem.com">test-title</a>
         </InteriorLeftNavItem>
         <InteriorLeftNavItem href="" className="test-child">
-          <a href="">test-title</a>
+          <a href="http://www.carbondesignsystem.com">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );
@@ -102,7 +102,7 @@ describe('InteriorLeftNavList', () => {
     const list = mount(
       <InteriorLeftNavList title="test-title">
         <InteriorLeftNavItem href="">
-          <a href="">test-title</a>
+          <a href="http://www.carbondesignsystem.com">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNavList>
     );

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -92,7 +92,7 @@ export default class InteriorLeftNavList extends Component {
         onClick={this.toggle}
         onKeyPress={this.toggle}
         role="menuitem">
-        <a className="left-nav-list__item-link">
+        <div className="left-nav-list__item-link">
           {title}
           <div className="left-nav-list__item-icon">
             <Icon
@@ -101,7 +101,7 @@ export default class InteriorLeftNavList extends Component {
               className="left-nav-list__item-icon bx--interior-left-nav__icon"
             />
           </div>
-        </a>
+        </div>
         <ul
           role="menu"
           className="left-nav-list left-nav-list--nested"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,9 +3117,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-jsx-a11y@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
+eslint-plugin-jsx-a11y@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
   dependencies:
     aria-query "^0.7.0"
     array-includes "^3.0.3"


### PR DESCRIPTION
Updates `eslint-plugin-jsx-a11y` to `v6`

- Changed empty `href` to actual links
- Changed `left-nav-list__item-link` from `a` to `div` since it was not being used to navigate