### PR TITLE
feat(tooltip): add menuoffset prop

### DIFF
--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -34,7 +34,10 @@ storiesOf('Tooltip', module)
     `,
     () => (
       <div style={{ marginTop: '2rem' }}>
-        <Tooltip triggerText="Tooltip - top" direction="top">
+        <Tooltip
+          triggerText="Tooltip - right"
+          direction="right"
+          menuOffset={{ left: 10, top: 15 }}>
           <p className="bx--tooltip__label">Tooltip subtitle</p>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -30,7 +30,11 @@ describe('Tooltip', () => {
 
   describe('Renders as expected with specified properties', () => {
     const wrapper = mount(
-      <Tooltip triggerText="Tooltip" direction="bottom" showIcon={false}>
+      <Tooltip
+        triggerText="Tooltip"
+        direction="bottom"
+        menuOffset={{ left: 10, top: 15 }}
+        showIcon={false}>
         <p className="bx--tooltip__label">Tooltip label</p>
         <p>Lorem ipsum dolor sit amet</p>
       </Tooltip>
@@ -43,7 +47,9 @@ describe('Tooltip', () => {
       it("sets the tooltip's position", () => {
         expect(floatingMenu.prop('menuDirection')).toEqual('bottom');
       });
-
+      it("sets the tooltip's offset", () => {
+        expect(floatingMenu.prop('menuOffset')).toEqual({ left: 10, top: 15 });
+      });
       it('does not render info icon', () => {
         const icon = trigger.find(Icon);
         expect(icon.exists()).toBe(false);

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -9,7 +9,8 @@ export default class Tooltip extends Component {
     open: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
-    direction: PropTypes.oneOf(['bottom', 'top']),
+    direction: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
+    menuOffset: PropTypes.obj,
     triggerText: PropTypes.string,
     showIcon: PropTypes.bool,
     iconName: PropTypes.string,
@@ -23,6 +24,10 @@ export default class Tooltip extends Component {
     iconName: 'info--glyph',
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
+    menuOffset: {
+      left: 5,
+      top: 10,
+    },
   };
 
   state = {
@@ -58,6 +63,7 @@ export default class Tooltip extends Component {
       showIcon,
       iconName,
       iconDescription,
+      menuOffset,
       ...other
     } = this.props;
 
@@ -66,8 +72,6 @@ export default class Tooltip extends Component {
       { 'bx--tooltip--shown': this.state.open },
       className
     );
-
-    const menuOffset = { left: 5, top: 10 };
 
     return (
       <div>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -10,7 +10,7 @@ export default class Tooltip extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     direction: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
-    menuOffset: PropTypes.obj,
+    menuOffset: PropTypes.object,
     triggerText: PropTypes.string,
     showIcon: PropTypes.bool,
     iconName: PropTypes.string,


### PR DESCRIPTION
### Small changes to Tooltip

- Changes `direction` proptypes to `PropTypes.oneOf(['bottom', 'top', 'left', 'right'])`
- Adds in `menuOffset` prop to ensure Tooltip is always positioned correctly. Usage is as follows:

```jsx
<Tooltip triggerText="Tooltip - no icon" menuOffset={{left: 10, top: 30}}>
```

Related to https://github.com/carbon-design-system/carbon-components-react/issues/390#issuecomment-349335529