### PR TITLE
Tooltip: Add Even Better Positioning!

### DIFF
--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -4,7 +4,7 @@ import Tooltip from '../Tooltip';
 
 storiesOf('Tooltip', module)
   .addWithInfo(
-    'default',
+    'default (bottom)',
     `
       Tooltips are used to supply additional information to an element when hovering over it. By default,
       the tooltip will render above the element. The example below shows the default scenario.
@@ -27,11 +27,11 @@ storiesOf('Tooltip', module)
     )
   )
   .addWithInfo(
-    'position',
+    'position - top',
     `
-      Tooltips are used to supply additional information to an element when hovering over it. By default,
-      the tooltip will render above the element. The example below shows specifying the position (supports 'bottom' and 'top')
-    `,
+        Tooltips are used to supply additional information to an element when hovering over it. By default,
+        the tooltip will render above the element. The example below shows specifying the position (supports 'bottom' and 'top')
+      `,
     () => (
       <div style={{ marginTop: '2rem' }}>
         <Tooltip triggerText="Tooltip - top" direction="top">
@@ -50,14 +50,116 @@ storiesOf('Tooltip', module)
     )
   )
   .addWithInfo(
-    'no icon',
+    'position - right',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render above the element. The example below shows specifying the position (supports 'bottom' and 'top')
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip triggerText="Tooltip - right" direction="right">
+          <p className="bx--tooltip__label">Tooltip subtitle</p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'position - left',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render above the element. The example below shows specifying the position (supports 'bottom' and 'top')
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip triggerText="Tooltip - left" direction="left">
+          <p className="bx--tooltip__label">Tooltip subtitle</p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'no icon - bottom (default)',
     `
       Tooltips are used to supply additional information to an element when hovering over it. By default,
       the tooltip will render with an information Icon. The example below shows the option to exclude the Icon.
     `,
     () => (
       <div style={{ marginTop: '2rem' }}>
-        <Tooltip triggerText="Tooltip - no icon" showIcon={false}>
+        <Tooltip
+          triggerText="Tooltip - no icon - bottom (default)"
+          showIcon={false}>
+          <p className="bx--tooltip__label">Tooltip subtitle</p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'no icon - right',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render with an information Icon. The example below shows the option to exclude the Icon.
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip
+          triggerText="Tooltip - no icon - right"
+          direction="right"
+          showIcon={false}>
+          <p className="bx--tooltip__label">Tooltip subtitle</p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'no icon - left',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render with an information Icon. The example below shows the option to exclude the Icon.
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip
+          triggerText="Tooltip - no icon - left"
+          direction="left"
+          showIcon={false}
+          menuOffset={{ left: 8 }}>
+          >
           <p className="bx--tooltip__label">Tooltip subtitle</p>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -30,7 +30,12 @@ describe('Tooltip', () => {
 
   describe('Renders as expected with specified properties', () => {
     const wrapper = mount(
-      <Tooltip triggerText="Tooltip" direction="bottom" showIcon={false}>
+      <Tooltip
+        triggerText="Tooltip"
+        direction="bottom"
+        menuOffset={{ left: 10, top: 15 }}
+        showIcon={false}>
+        {' '}
         <p className="bx--tooltip__label">Tooltip label</p>
         <p>Lorem ipsum dolor sit amet</p>
       </Tooltip>
@@ -43,7 +48,9 @@ describe('Tooltip', () => {
       it("sets the tooltip's position", () => {
         expect(floatingMenu.prop('menuDirection')).toEqual('bottom');
       });
-
+      it("sets the tooltip's offset", () => {
+        expect(floatingMenu.prop('menuOffset')).toEqual({ left: 10, top: 15 });
+      });
       it('does not render info icon', () => {
         const icon = trigger.find(Icon);
         expect(icon.exists()).toBe(false);

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -9,7 +9,8 @@ export default class Tooltip extends Component {
     open: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
-    direction: PropTypes.oneOf(['bottom', 'top']),
+    direction: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
+    menuOffset: PropTypes.object,
     triggerText: PropTypes.string,
     showIcon: PropTypes.bool,
     iconName: PropTypes.string,
@@ -23,6 +24,7 @@ export default class Tooltip extends Component {
     iconName: 'info--glyph',
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
+    menuOffset: {},
   };
 
   state = {
@@ -58,6 +60,7 @@ export default class Tooltip extends Component {
       showIcon,
       iconName,
       iconDescription,
+      menuOffset,
       ...other
     } = this.props;
 
@@ -66,8 +69,6 @@ export default class Tooltip extends Component {
       { 'bx--tooltip--shown': this.state.open },
       className
     );
-
-    const menuOffset = { left: 5, top: 10 };
 
     return (
       <div>

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -184,12 +184,10 @@ class FloatingMenu extends React.Component {
       top: 10,
     };
     const adjustedOffsets = Object.assign({}, defaultOffsets);
-    if (newOffsets.left) {
-      adjustedOffsets.left += newOffsets.left;
-    }
-    if (newOffsets.top) {
-      adjustedOffsets.top += newOffsets.top;
-    }
+
+    adjustedOffsets.left += newOffsets.left || 0;
+    adjustedOffsets.top += newOffsets.top || 0;
+
     switch (menuDirection) {
       case 'left':
         adjustedOffsets.top += 4;

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -184,23 +184,19 @@ class FloatingMenu extends React.Component {
       top: 10,
     };
     const adjustedOffsets = Object.assign({}, defaultOffsets);
-
     adjustedOffsets.left += newOffsets.left || 0;
     adjustedOffsets.top += newOffsets.top || 0;
-
     switch (menuDirection) {
+      case 'right':
+        adjustedOffsets.left += 8;
+        adjustedOffsets.top += 4;
+        break;
       case 'left':
         adjustedOffsets.top += 4;
-        return adjustedOffsets;
-
-      case 'right':
-        adjustedOffsets.top += 4;
-        adjustedOffsets.left += 8;
-        return adjustedOffsets;
-
-      default:
-        return adjustedOffsets;
+        break;
     }
+
+    return adjustedOffsets;
   }
 
   renderLayer = () => {

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -5,7 +5,7 @@ import window from 'window-or-global';
 
 class FloatingMenu extends React.Component {
   static propTypes = {
-    children: PropTypes.any,
+    children: PropTypes.object,
     menuPosition: PropTypes.object.isRequired,
     menuDirection: PropTypes.oneOf(['left', 'top', 'right', 'bottom'])
       .isRequired,
@@ -20,7 +20,22 @@ class FloatingMenu extends React.Component {
 
   constructor() {
     super();
-    this.state = {};
+    this.state = {
+      menuOffset: {
+        left: 0,
+        top: 0,
+      },
+    };
+  }
+
+  componentWillMount() {
+    const adjustedOffsets = this.adjustOffsets(
+      this.props.menuOffset,
+      this.props.menuDirection
+    );
+    this.setState({
+      menuOffset: adjustedOffsets,
+    });
   }
 
   onNewMenuRef = menu => {
@@ -65,6 +80,13 @@ class FloatingMenu extends React.Component {
         props.menuDirection !== this.props.menuDirection ||
         props.menuOffset !== this.props.menuOffset;
       if (hasChange) {
+        const adjustedOffsets = this.adjustOffsets(
+          this.props.menuOffset,
+          this.props.menuDirection
+        );
+        this.setState({
+          menuOffset: adjustedOffsets,
+        });
         requestAnimationFrame(() => {
           if (this.menuWidth !== undefined && this.menuHeight !== undefined) {
             this.setState({ floatingPosition: this.positionFloatingMenu() });
@@ -97,7 +119,7 @@ class FloatingMenu extends React.Component {
   };
 
   positionFloatingMenu = () => {
-    const menuOffset = this.props.menuOffset;
+    const menuOffset = this.state.menuOffset;
 
     const scroll = window.scrollY || 0;
 
@@ -118,11 +140,12 @@ class FloatingMenu extends React.Component {
       }),
       top: () => ({
         left: refCenterHorizontal - this.menuWidth / 2 + menuOffset.left,
-        top: refTop - this.menuHeight + scroll - menuOffset.top,
+        top: refTop - (this.menuHeight + scroll) - menuOffset.top,
       }),
       right: () => ({
         left: refRight + menuOffset.left,
-        top: refCenterVertical - this.menuHeight / 2 + scroll + menuOffset.top,
+        top:
+          refCenterVertical - (this.menuHeight / 2 + scroll) + menuOffset.top,
       }),
       bottom: () => ({
         left: refCenterHorizontal - this.menuWidth / 2 + menuOffset.left,
@@ -148,6 +171,39 @@ class FloatingMenu extends React.Component {
       style,
     });
   };
+
+  adjustOffsets(newOffsets, menuDirection) {
+    /**
+     * we have default offsets to center the positions.
+     * right and left positions need further adjustment as follows:
+     * right: top += 3, left += 6
+     * left: top += 3
+     */
+    const defaultOffsets = {
+      left: 5,
+      top: 10,
+    };
+    const adjustedOffsets = Object.assign({}, defaultOffsets);
+    if (newOffsets.left) {
+      adjustedOffsets.left += newOffsets.left;
+    }
+    if (newOffsets.top) {
+      adjustedOffsets.top += newOffsets.top;
+    }
+    switch (menuDirection) {
+      case 'left':
+        adjustedOffsets.top += 4;
+        return adjustedOffsets;
+
+      case 'right':
+        adjustedOffsets.top += 4;
+        adjustedOffsets.left += 8;
+        return adjustedOffsets;
+
+      default:
+        return adjustedOffsets;
+    }
+  }
 
   renderLayer = () => {
     ReactDOM.render(this.getChildrenWithProps(), this.menu);


### PR DESCRIPTION
## Add Direction Functionality to Tooltip
This PR is an update to @tw15egan 's very good [#392](https://github.com/carbon-design-system/carbon-components-react/pull/392).

- Changes direction proptypes to PropTypes.oneOf(['bottom', 'top', 'left', 'right'])
- Adds in menuOffset prop (optional) to ensure Tooltip is always positioned correctly. Usage is as follows:
```
<Tooltip triggerText="Hover Info Here">
```
or
```
<Tooltip triggerText="Hover Info Here" menuOffset={{left: 10, top: 30}}>
```
Replaces PR [#392](https://github.com/carbon-design-system/carbon-components-react/pull/392)
Fixes Issue [#390](https://github.com/carbon-design-system/carbon-components-react/issues/390).  