### PR TITLE
fix(AccordionItem): add explicit `type` attribute

### DIFF
--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -74,6 +74,7 @@ export default class AccordionItem extends Component {
         role="presentation"
         {...other}>
         <button
+          type="button"
           className="bx--accordion__heading"
           role="tab"
           onClick={this.handleHeadingClick}>


### PR DESCRIPTION
By default, `<button>` in a form will submit the form if it's interacted with. Adding `type="button"` here will cause this not to be the default behavior.

#### Changelog

**New**

**Changed**

- `<AccordionItem>`

**Removed**
