### PR TITLE
fix: add guard to triggerEl ref

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -38,8 +38,10 @@ export default class Tooltip extends Component {
   }
 
   getTriggerPosition = () => {
-    const triggerPosition = this.triggerEl.getBoundingClientRect();
-    this.setState({ triggerPosition });
+    if (this.triggerEl) {
+      const triggerPosition = this.triggerEl.getBoundingClientRect();
+      this.setState({ triggerPosition });
+    }
   };
 
   handleMouse = direction => {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#384

#### Changelog

**New**

**Changed**

- `Tooltip`
  - Added check to `getTriggerPosition` to make sure `ref` is non-`null`

**Removed**
