### PR TITLE
fix(FloatingMenu): remove parens

### DIFF
--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -140,12 +140,11 @@ class FloatingMenu extends React.Component {
       }),
       top: () => ({
         left: refCenterHorizontal - this.menuWidth / 2 + menuOffset.left,
-        top: refTop - (this.menuHeight + scroll) - menuOffset.top,
+        top: refTop - this.menuHeight + scroll - menuOffset.top,
       }),
       right: () => ({
         left: refRight + menuOffset.left,
-        top:
-          refCenterVertical - (this.menuHeight / 2 + scroll) + menuOffset.top,
+        top: refCenterVertical - this.menuHeight / 2 + scroll + menuOffset.top,
       }),
       bottom: () => ({
         left: refCenterHorizontal - this.menuWidth / 2 + menuOffset.left,


### PR DESCRIPTION
Closes #410 

Details are in the issue, but there's an easier way to test. 

## Steps to Reproduce:

1. In Tooltip.js add `<h1>XXX</h1>` at the beginning and end of the render method, just inside the enclosing `<div>`, so that you have enough content to scroll. About 15 at the beginning and end should be enough. 
2. Open existing Storybook with `npm run storybook`
3. Click [this link](http://localhost:9000/?selectedKind=Tooltip&selectedStory=position%20-%20right&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel) in your local environment to go directly to **_Tooltip: Position Right_** 
  - Note: Left and Bottom are not broken! Test with the **_right_** side!
4. hover over tooltip, everything is okay
5. Scroll down a smidge, just a little, and hover again. Tooltip is too high.
6. Scroll a little more and Tooltip is off the screen completely.

