### PR TITLE
fix(TextArea): match casing everywhere

### DIFF
--- a/src/components/Form/Form-story.js
+++ b/src/components/Form/Form-story.js
@@ -12,7 +12,7 @@ import Button from '../Button';
 import Search from '../Search';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
-import Textarea from '../TextArea';
+import TextArea from '../TextArea';
 import TextInput from '../TextInput';
 import Toggle from '../Toggle';
 
@@ -215,7 +215,7 @@ storiesOf('Form', module).addWithInfo(
         {...InvalidPasswordProps}
       />
 
-      <Textarea {...textareaProps} />
+      <TextArea {...textareaProps} />
 
       <Button type="submit" className="some-class" {...buttonEvents}>
         Submit

--- a/src/components/TextArea/TextArea-test.js
+++ b/src/components/TextArea/TextArea-test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import Textarea from '../TextArea';
+import TextArea from '../TextArea';
 
 describe('TextArea', () => {
   describe('should render as expected', () => {
-    const wrapper = mount(<Textarea id="testing" className="extra-class" />);
+    const wrapper = mount(<TextArea id="testing" className="extra-class" />);
 
     const textarea = () => wrapper.find('textarea');
 
@@ -80,7 +80,7 @@ describe('TextArea', () => {
       const onChange = jest.fn();
 
       const wrapper = shallow(
-        <Textarea id="test" onClick={onClick} onChange={onChange} disabled />
+        <TextArea id="test" onClick={onClick} onChange={onChange} disabled />
       );
 
       const textarea = wrapper.find('textarea');
@@ -104,7 +104,7 @@ describe('TextArea', () => {
       };
 
       const wrapper = shallow(
-        <Textarea id="test" onClick={onClick} onChange={onChange} />
+        <TextArea id="test" onClick={onClick} onChange={onChange} />
       );
 
       const textarea = wrapper.find('textarea');

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const Textarea = ({
+const TextArea = ({
   className,
   id,
   labelText,
@@ -57,7 +57,7 @@ const Textarea = ({
   );
 };
 
-Textarea.propTypes = {
+TextArea.propTypes = {
   className: PropTypes.string,
   cols: PropTypes.number,
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -73,7 +73,7 @@ Textarea.propTypes = {
   invalidText: PropTypes.string,
 };
 
-Textarea.defaultProps = {
+TextArea.defaultProps = {
   disabled: false,
   onChange: () => {},
   onClick: () => {},
@@ -85,4 +85,4 @@ Textarea.defaultProps = {
   invalidText: 'Provide invalidText',
 };
 
-export default Textarea;
+export default TextArea;

--- a/src/components/TextArea/Textarea-story.js
+++ b/src/components/TextArea/Textarea-story.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import Textarea from '../TextArea';
+import TextArea from '../TextArea';
 
-const textareaProps = {
+const TextAreaProps = {
   labelText: 'Text Area label',
   className: 'some-class',
   onChange: action('onChange'),
@@ -22,7 +22,7 @@ storiesOf('TextArea', module)
       anticipate the user to input more than 1 sentence. The example belows shows an enabled
       Text Area component.
     `,
-    () => <Textarea {...textareaProps} />
+    () => <TextArea {...TextAreaProps} />
   )
   .addWithInfo(
     'disabled',
@@ -31,5 +31,5 @@ storiesOf('TextArea', module)
       anticipate the user to input more than 1 sentence. The example belows shows an disabled
       Text Area component.
     `,
-    () => <Textarea disabled {...textareaProps} placeholder={'Disabled'} />
+    () => <TextArea disabled {...TextAreaProps} placeholder={'Disabled'} />
   );


### PR DESCRIPTION
The export for TextArea was set to camelcase. Other places used all
lower case, specifically the stories. If the story was copy and pasted,
the resulting code was wrong