### PR TITLE
fix(Module): fix wrong re-export in Module/index.js

### DIFF
--- a/src/components/Module/index.js
+++ b/src/components/Module/index.js
@@ -1,2 +1,1 @@
 export * from './Module';
-export default from './Module';


### PR DESCRIPTION
Fixes #423.

Removed the re-exporting line of the default export in `Module/index.js`, since it does not exist actually.