### PR TITLE
Update `ClickListener` and introduce `InnerClickListener`

### DIFF
--- a/src/internal/ClickListener.js
+++ b/src/internal/ClickListener.js
@@ -1,13 +1,24 @@
 import PropTypes from 'prop-types';
-/* global document */
-
 import React from 'react';
 
-class ClickListener extends React.Component {
+/**
+ * Generic component used for reacting to a click event happening outside of a
+ * given `children` element.
+ */
+export default class ClickListener extends React.Component {
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.element.isRequired,
     onClickOutside: PropTypes.func.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+    // We manually bind handlers in this Component, versus using class
+    // properties, so that we can properly test the `handleRef` handler with
+    // enzyme.
+    this.handleRef = this.handleRef.bind(this);
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+  }
 
   componentDidMount() {
     document.addEventListener('click', this.handleDocumentClick);
@@ -17,24 +28,35 @@ class ClickListener extends React.Component {
     document.removeEventListener('click', this.handleDocumentClick);
   }
 
-  handleDocumentClick = evt => {
+  handleDocumentClick(evt) {
     if (this.element) {
-      if (!this.element.contains(evt.target)) {
+      if (this.element.contains && !this.element.contains(evt.target)) {
         this.props.onClickOutside(evt);
       }
     }
-  };
+  }
+
+  handleRef(el) {
+    const { children } = this.props;
+    this.element = el;
+
+    /**
+     * One important note, `children.ref` corresponds to a `ref` prop passed in
+     * directly to the child, not necessarily a `ref` defined in the component.
+     * This means that here we target the following `ref` location:
+     *
+     * <ClickListener onClickOutside={() => {}}>
+     *   <Child ref={targetedRefHere} />
+     * </ClickListener>
+     */
+    if (children.ref && typeof children.ref === 'function') {
+      children.ref(el);
+    }
+  }
 
   render() {
-    return (
-      <div
-        ref={el => {
-          this.element = el;
-        }}>
-        {this.props.children}
-      </div>
-    );
+    return React.cloneElement(this.props.children, {
+      ref: this.handleRef,
+    });
   }
 }
-
-export default ClickListener;

--- a/src/internal/InnerClickListener.js
+++ b/src/internal/InnerClickListener.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Generic component used for reacting to a click event happening outside of a
+ * given child component that used the forwarded `handleRef` function through
+ * the `refKey` prop.
+ */
+export default class InnerClickListener extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    refKey: PropTypes.string.isRequired,
+    onClickOutside: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    // We manually bind handlers in this Component, versus using class
+    // properties, so that we can properly test the `handleRef` handler with
+    // enzyme.
+    this.handleRef = this.handleRef.bind(this);
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleDocumentClick);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleDocumentClick);
+  }
+
+  handleDocumentClick(event) {
+    if (this.element) {
+      if (this.element.contains && !this.element.contains(event.target)) {
+        this.props.onClickOutside(event);
+      }
+    }
+  }
+
+  handleRef(el) {
+    this.element = el;
+  }
+
+  render() {
+    const { refKey, children } = this.props;
+    return React.cloneElement(children, {
+      [refKey]: this.handleRef,
+    });
+  }
+}

--- a/src/internal/__tests__/ClickListener-test.js
+++ b/src/internal/__tests__/ClickListener-test.js
@@ -3,26 +3,62 @@ import ClickListener from '../ClickListener';
 import { shallow, mount } from 'enzyme';
 
 describe('ClickListener', () => {
-  it('renders children as expected', () => {
-    const onClickOutside = jest.fn();
+  let onClickOutside;
+  let handleRefSpy;
 
+  beforeEach(() => {
+    onClickOutside = jest.fn();
+    handleRefSpy = jest.spyOn(ClickListener.prototype, 'handleRef');
+  });
+
+  afterEach(() => {
+    handleRefSpy.mockRestore();
+  });
+
+  it('should render', () => {
     const wrapper = shallow(
+      <ClickListener onClickOutside={onClickOutside}>
+        <div>
+          <div className="child">Test</div>
+          <div className="child">Test</div>
+        </div>
+      </ClickListener>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should throw a PropType validation error if passed multiple children', () => {
+    // We need to make assertions on `console.error` that come from React, so let's
+    // disable the `no-console` eslint rules on certain lines.
+    // eslint-disable-next-line no-console
+    const originalConsoleError = console.error;
+    const mockConsoleError = jest.fn();
+    // eslint-disable-next-line no-console
+    console.error = mockConsoleError;
+
+    shallow(
       <ClickListener onClickOutside={onClickOutside}>
         <div className="child">Test</div>
         <div className="child">Test</div>
       </ClickListener>
     );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Warning: Failed prop type: Invalid prop `children` of type `array`'
+      )
+    );
 
-    expect(wrapper.find('.child').length).toBe(2);
+    // eslint-disable-next-line no-console
+    console.error = originalConsoleError;
   });
 
   it('should invoke onClickOutside if click is outside of the component', () => {
-    const onClickOutside = jest.fn();
-
     mount(
       <ClickListener onClickOutside={onClickOutside}>
-        <div className="child">Test</div>
-        <div className="child">Test</div>
+        <div>
+          <div className="child">Test</div>
+          <div className="child">Test</div>
+        </div>
       </ClickListener>
     );
 
@@ -30,5 +66,37 @@ describe('ClickListener', () => {
     document.dispatchEvent(evt);
 
     expect(onClickOutside).toBeCalled();
+  });
+
+  it('should not overwrite any children function refs', () => {
+    const mockRef = jest.fn();
+    class Child extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+    mount(
+      <ClickListener onClickOutside={onClickOutside}>
+        <Child ref={mockRef} />
+      </ClickListener>
+    );
+    expect(handleRefSpy).toHaveBeenCalledTimes(1);
+    expect(mockRef).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call any string refs on children', () => {
+    class Child extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+    expect(() => {
+      mount(
+        <ClickListener onClickOutside={onClickOutside}>
+          <Child ref="hi" />
+        </ClickListener>
+      );
+      expect(handleRefSpy).toHaveBeenCalledTimes(1);
+    }).not.toThrow();
   });
 });

--- a/src/internal/__tests__/InnerClickListener-test.js
+++ b/src/internal/__tests__/InnerClickListener-test.js
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { mount } from 'enzyme';
+import InnerClickListener from '../InnerClickListener';
+
+describe('InnerClickListener', () => {
+  let onClickOutside;
+  let handleRefSpy;
+  let InnerChild;
+
+  beforeEach(() => {
+    onClickOutside = jest.fn();
+    handleRefSpy = jest.spyOn(InnerClickListener.prototype, 'handleRef');
+    InnerChild = class InnerChild extends React.Component {
+      static propTypes = {
+        innerRef: PropTypes.func.isRequired,
+      };
+      static defaultProps = {
+        innerRef: () => {},
+      };
+      render() {
+        return (
+          <div>
+            <div id="1">1</div>
+            <div id="2" ref={this.props.innerRef}>
+              2
+            </div>
+          </div>
+        );
+      }
+    };
+  });
+
+  afterEach(() => {
+    handleRefSpy.mockRestore();
+  });
+
+  it('should render', () => {
+    const wrapper = mount(
+      <InnerClickListener refKey="innerRef" onClickOutside={onClickOutside}>
+        <InnerChild />
+      </InnerClickListener>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call `handleRef` when mounting', () => {
+    mount(
+      <InnerClickListener refKey="innerRef" onClickOutside={onClickOutside}>
+        <InnerChild />
+      </InnerClickListener>
+    );
+    expect(handleRefSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `onClickOutside` when clicked outside the node that has the ref', () => {
+    const rootNode = document.createElement('div');
+    rootNode.setAttribute('id', 'root');
+
+    document.body.appendChild(rootNode);
+
+    mount(
+      <InnerClickListener refKey="innerRef" onClickOutside={onClickOutside}>
+        <InnerChild />
+      </InnerClickListener>,
+      {
+        attachTo: rootNode,
+      }
+    );
+
+    document.getElementById('2').click();
+    expect(onClickOutside).not.toHaveBeenCalled();
+
+    document.getElementById('1').click();
+    expect(onClickOutside).toHaveBeenCalledTimes(1);
+
+    document.dispatchEvent(new MouseEvent('click'));
+    expect(onClickOutside).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/internal/__tests__/__snapshots__/ClickListener-test.js.snap
+++ b/src/internal/__tests__/__snapshots__/ClickListener-test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClickListener should render 1`] = `
+<div>
+  <div
+    className="child"
+  >
+    Test
+  </div>
+  <div
+    className="child"
+  >
+    Test
+  </div>
+</div>
+`;

--- a/src/internal/__tests__/__snapshots__/InnerClickListener-test.js.snap
+++ b/src/internal/__tests__/__snapshots__/InnerClickListener-test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InnerClickListener should render 1`] = `
+<InnerClickListener
+  onClickOutside={[MockFunction]}
+  refKey="innerRef"
+>
+  <InnerChild
+    innerRef={[Function]}
+  >
+    <div>
+      <div
+        id="1"
+      >
+        1
+      </div>
+      <div
+        id="2"
+      >
+        2
+      </div>
+    </div>
+  </InnerChild>
+</InnerClickListener>
+`;


### PR DESCRIPTION
Closes #425, Closes #344

Update `ClickListener` and introduce `InnerClickListener`.

#### Changelog

**New**

- `InnerClickListener`
  - Adds ability to listen to nodes inside of a component rather than the top-level node

**Changed**

- `ClickListener`
  - removes wrapping `div` node and adds ref directly to child component

**Removed**

  