### PR TITLE
Add `ListBox` component

### DIFF
--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -1,0 +1,66 @@
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import ListBoxField from './ListBoxField';
+import ListBoxMenu from './ListBoxMenu';
+import { ListBoxType } from './ListBoxPropTypes';
+import childrenOf from '../../prop-types/childrenOf';
+
+/**
+ * `ListBox` is a generic container component that handles creating the
+ * container class name in response to certain props.
+ */
+const ListBox = ({
+  children,
+  className: containerClassName,
+  disabled,
+  innerRef,
+  type,
+  ...rest
+}) => {
+  const className = cx({
+    [containerClassName]: !!containerClassName,
+    'bx--list-box': true,
+    'bx--list-box--inline': type === 'inline',
+    'bx--list-box--disabled': disabled,
+  });
+  return (
+    <div className={className} ref={innerRef} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+ListBox.propTypes = {
+  children: childrenOf([ListBoxField, ListBoxMenu]),
+
+  /**
+   * Specify a class name to be applied on the containing list box node
+   */
+  className: PropTypes.string,
+
+  /**
+   * `innerRef` hook used for libraries like Downshift that require a reference
+   * on a container node when it is not a native element
+   */
+  innerRef: PropTypes.func.isRequired,
+
+  /**
+   * Specify whether the ListBox is currently disabled
+   */
+  disabled: PropTypes.bool.isRequired,
+
+  /**
+   * Specify the "type" of the ListBox. Currently supports either `default` or
+   * `inline` as an option.
+   */
+  type: ListBoxType.isRequired,
+};
+
+ListBox.defaultProps = {
+  innerRef: () => {},
+  disabled: false,
+  type: 'default',
+};
+
+export default ListBox;

--- a/src/components/ListBox/ListBoxField.js
+++ b/src/components/ListBox/ListBoxField.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ListBoxMenuIcon from './ListBoxMenuIcon';
+import ListBoxSelection from './ListBoxSelection';
+import childrenOf from '../../prop-types/childrenOf';
+
+/**
+ * `ListBoxField` is responsible for creating the containing node for valid
+ * elements inside of a field. It also provides a11y-related attributes like
+ * `role` to make sure a user can focus the given field.
+ */
+const ListBoxField = ({ children, ...rest }) => (
+  <div role="button" className="bx--list-box__field" tabIndex="0" {...rest}>
+    {children}
+  </div>
+);
+
+ListBoxField.propTypes = {
+  children: childrenOf([ListBoxMenuIcon, ListBoxSelection]),
+};
+
+export default ListBoxField;

--- a/src/components/ListBox/ListBoxMenu.js
+++ b/src/components/ListBox/ListBoxMenu.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ListBoxMenuItem from './ListBoxMenuItem';
+import childrenOfType from '../../prop-types/childrenOfType';
+
+/**
+ * `ListBoxMenu` is a simple container node that isolates the `list-box__menu`
+ * class into a single component. It is also being used to validate given
+ * `children` components.
+ */
+const ListBoxMenu = ({ children, ...rest }) => {
+  return (
+    <div className="bx--list-box__menu" {...rest}>
+      {children}
+    </div>
+  );
+};
+
+ListBoxMenu.propTypes = {
+  children: childrenOfType(ListBoxMenuItem),
+};
+
+export default ListBoxMenu;

--- a/src/components/ListBox/ListBoxMenuIcon.js
+++ b/src/components/ListBox/ListBoxMenuIcon.js
@@ -1,0 +1,52 @@
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+
+export const translationIds = {
+  'close.menu': 'close.menu',
+  'open.menu': 'open.menu',
+};
+
+const defaultTranslations = {
+  [translationIds['close.menu']]: 'Close menu',
+  [translationIds['open.menu']]: 'Open menu',
+};
+
+/**
+ * `ListBoxMenuIcon` is used to orient the icon up or down depending on the
+ * state of the menu for a given `ListBox`
+ */
+const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
+  const className = cx({
+    'bx--list-box__menu-icon': true,
+    'bx--list-box__menu-icon--open': isOpen,
+  });
+  const description = isOpen ? t('close.menu') : t('open.menu');
+  return (
+    <div className={className}>
+      <Icon name="caret--down" description={description} />
+    </div>
+  );
+};
+
+ListBoxMenuIcon.propTypes = {
+  /**
+   * Specify whether the menu is currently open, which will influence the
+   * direction of the menu icon
+   */
+  isOpen: PropTypes.bool.isRequired,
+
+  /**
+   * i18n hook used to provide the appropriate description for the given menu
+   * icon. This function takes in an id defined in `translationIds` and should
+   * return a string message for that given message id.
+   */
+  translateWithId: PropTypes.func.isRequired,
+};
+
+ListBoxMenuIcon.defaultProps = {
+  translateWithId: id => defaultTranslations[id],
+};
+
+export default ListBoxMenuIcon;

--- a/src/components/ListBox/ListBoxMenuItem.js
+++ b/src/components/ListBox/ListBoxMenuItem.js
@@ -1,0 +1,46 @@
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * `ListBoxMenuItem` is a helper component for managing the container class
+ * name, alongside any classes for any corresponding states, for a generic list
+ * box menu item.
+ */
+const ListBoxMenuItem = ({ children, isActive, isHighlighted, ...rest }) => {
+  const className = cx({
+    'bx--list-box__menu-item': true,
+    'bx--list-box__menu-item--active': isActive,
+    'bx--list-box__menu-item--highlighted': isHighlighted,
+  });
+  return (
+    <div className={className} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+ListBoxMenuItem.propTypes = {
+  /**
+   * Specify any children nodes that hsould be rendered inside of the ListBox
+   * Menu Item
+   */
+  children: PropTypes.node,
+
+  /**
+   * Specify whether the current menu item is "active".
+   */
+  isActive: PropTypes.bool.isRequired,
+
+  /**
+   * Specify whether the current menu item is "highlighed".
+   */
+  isHighlighted: PropTypes.bool.isRequired,
+};
+
+ListBoxMenuItem.defaultProps = {
+  isActive: false,
+  isHighlighted: false,
+};
+
+export default ListBoxMenuItem;

--- a/src/components/ListBox/ListBoxPropTypes.js
+++ b/src/components/ListBox/ListBoxPropTypes.js
@@ -1,0 +1,3 @@
+import PropTypes from 'prop-types';
+
+export const ListBoxType = PropTypes.oneOf(['default', 'inline']);

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -1,0 +1,85 @@
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+
+/**
+ * `ListBoxSelection` is used to provide controls for clearing a selection, in
+ * addition to conditionally rendering a badge if the control has more than one
+ * selection.
+ */
+const ListBoxSelection = ({
+  clearSelection,
+  selectionCount,
+  translateWithId: t,
+}) => {
+  const className = cx({
+    'bx--list-box__selection': true,
+    'bx--list-box__selection--multi': selectionCount,
+  });
+  const handleOnClick = event => {
+    // If we have a mult-select badge, clicking it shouldn't open the menu back
+    // up. However, if we have a clear badge then we want the click to have this
+    // behavior.
+    if (selectionCount) {
+      event.stopPropagation();
+    }
+    clearSelection(event);
+  };
+  const handleOnKeyDown = event => {
+    // When a user hits ENTER, we'll clear the selection
+    if (event.keyCode === 13) {
+      clearSelection(event);
+    }
+  };
+  const description = selectionCount ? t('clear.all') : t('clear.selection');
+  return (
+    <div
+      role="button"
+      className={className}
+      tabIndex="0"
+      onClick={handleOnClick}
+      onKeyDown={handleOnKeyDown}
+      title={description}>
+      {selectionCount}
+      <Icon name="close" description={description} />
+    </div>
+  );
+};
+
+export const translationIds = {
+  'clear.all': 'clear.all',
+  'clear.selection': 'clear.selection',
+};
+
+const defaultTranslations = {
+  [translationIds['clear.all']]: 'Clear all selected items',
+  [translationIds['clear.selection']]: 'Clear selected item',
+};
+
+ListBoxSelection.propTypes = {
+  /**
+   * Specify a function to be invoked when a user interacts with the clear
+   * selection element.
+   */
+  clearSelection: PropTypes.func.isRequired,
+
+  /**
+   * Specify an optional `selectionCount` value that will be used to determine
+   * whether the selection should display a badge or a single clear icon.
+   */
+  selectionCount: PropTypes.number,
+
+  /**
+   * i18n hook used to provide the appropriate description for the given menu
+   * icon. This function takes in an id defined in `translationIds` and should
+   * return a string message for that given message id.
+   */
+  translateWithId: PropTypes.func.isRequired,
+};
+
+ListBoxSelection.defaultProps = {
+  translateWithId: id => defaultTranslations[id],
+};
+
+export default ListBoxSelection;

--- a/src/components/ListBox/README.md
+++ b/src/components/ListBox/README.md
@@ -1,0 +1,14 @@
+# `ListBox` component
+
+`ListBox` is responsible for powering a variety of dropdown-flavored components in Carbon. This list includes components like: Dropdown, Combobox, MultiSelect, and more!
+
+Currently, a `ListBox` is broken up into the following pieces:
+
+- `ListBox`: container component that wraps all `ListBox*`-related components
+  - `ListBoxField`: component used for handling input and displaying selections in components like Combobox and MultiSelect
+    - `ListBoxMenuIcon`: indicates the status of the menu, e.g. whether it is open or closed.
+    - `ListBoxSelection`: indicates the status of the selection for the control, works for both single selection and multi-selection components
+  - `ListBoxMenu`: container component for the menu of options available in a `ListBox`
+    - `ListBoxMenuItem`: container component for an option in a `ListBoxMenu`
+
+In addition, we have `ListBox`-specific `prop` types in `ListBoxPropTypes`.

--- a/src/components/ListBox/__tests__/ListBox-test.js
+++ b/src/components/ListBox/__tests__/ListBox-test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBox', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      type: 'default',
+      children: <span>Hello</span>,
+      className: 'bx--list-box__container',
+      disabled: false,
+      innerRef: jest.fn(),
+    };
+  });
+
+  it('should render', () => {
+    const wrapper = mount(<ListBox {...mockProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render an inline class if the type=`inline`', () => {
+    const wrapper = mount(<ListBox {...mockProps} type="inline" />);
+    expect(wrapper.find('.bx--list-box--inline').length).toBe(1);
+  });
+
+  it('should render a disabled class if disabled is true', () => {
+    const wrapper = mount(<ListBox {...mockProps} disabled />);
+    expect(wrapper.find('.bx--list-box--disabled').length).toBe(1);
+  });
+
+  it('should call the provided `innerRef` function with a ref to the node', () => {
+    mount(<ListBox {...mockProps} />);
+    expect(mockProps.innerRef).toHaveBeenCalled();
+  });
+
+  it('should add the provided `className` to the root node', () => {
+    const wrapper = mount(<ListBox {...mockProps} />);
+    expect(
+      wrapper
+        .children()
+        .prop('className')
+        .includes(mockProps.className)
+    ).toBe(true);
+  });
+});

--- a/src/components/ListBox/__tests__/ListBox-test.js
+++ b/src/components/ListBox/__tests__/ListBox-test.js
@@ -8,7 +8,7 @@ describe('ListBox', () => {
   beforeEach(() => {
     mockProps = {
       type: 'default',
-      children: <span>Hello</span>,
+      children: <ListBox.Field />,
       className: 'bx--list-box__container',
       disabled: false,
       innerRef: jest.fn(),

--- a/src/components/ListBox/__tests__/ListBoxField-test.js
+++ b/src/components/ListBox/__tests__/ListBoxField-test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBoxField', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      <ListBox.Field>
+        <span>Hello</span>
+      </ListBox.Field>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should be focusable', () => {
+    const wrapper = mount(
+      <ListBox.Field>
+        <span>Hello</span>
+      </ListBox.Field>
+    );
+    expect(wrapper.children().prop('tabIndex')).toBe('0');
+  });
+});

--- a/src/components/ListBox/__tests__/ListBoxField-test.js
+++ b/src/components/ListBox/__tests__/ListBoxField-test.js
@@ -6,7 +6,7 @@ describe('ListBoxField', () => {
   it('should render', () => {
     const wrapper = mount(
       <ListBox.Field>
-        <span>Hello</span>
+        <ListBox.Selection clearSelection={jest.fn()} />
       </ListBox.Field>
     );
     expect(wrapper).toMatchSnapshot();
@@ -15,7 +15,7 @@ describe('ListBoxField', () => {
   it('should be focusable', () => {
     const wrapper = mount(
       <ListBox.Field>
-        <span>Hello</span>
+        <ListBox.Selection clearSelection={jest.fn()} />
       </ListBox.Field>
     );
     expect(wrapper.children().prop('tabIndex')).toBe('0');

--- a/src/components/ListBox/__tests__/ListBoxMenu-test.js
+++ b/src/components/ListBox/__tests__/ListBoxMenu-test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBoxMenu', () => {
+  it('should render', () => {
+    const wrapper = mount(
+      <ListBox.Menu>
+        <ListBox.MenuItem>Hello</ListBox.MenuItem>
+      </ListBox.Menu>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/ListBox/__tests__/ListBoxMenuIcon-test.js
+++ b/src/components/ListBox/__tests__/ListBoxMenuIcon-test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBoxMenuIcon', () => {
+  it('should render', () => {
+    const openWrapper = mount(<ListBox.MenuIcon isOpen={true} />);
+    const closedWrapper = mount(<ListBox.MenuIcon isOpen={false} />);
+    expect(openWrapper).toMatchSnapshot();
+    expect(closedWrapper).toMatchSnapshot();
+  });
+
+  it('should call `translateWithId` to determine the description', () => {
+    const translateWithId = jest.fn(() => 'message');
+    mount(<ListBox.MenuIcon isOpen={true} translateWithId={translateWithId} />);
+    expect(translateWithId).toHaveBeenCalledWith('close.menu');
+
+    translateWithId.mockClear();
+
+    mount(
+      <ListBox.MenuIcon isOpen={false} translateWithId={translateWithId} />
+    );
+    expect(translateWithId).toHaveBeenCalledWith('open.menu');
+  });
+});

--- a/src/components/ListBox/__tests__/ListBoxMenuItem-test.js
+++ b/src/components/ListBox/__tests__/ListBoxMenuItem-test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBoxMenuItem', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      isActive: false,
+      isHighlighted: false,
+      children: <span>ListBox.MenuItem</span>,
+    };
+  });
+
+  it('should render', () => {
+    const wrapper = mount(<ListBox.MenuItem {...mockProps} />);
+    const activeWrapper = mount(
+      <ListBox.MenuItem {...mockProps} isActive={true} />
+    );
+    const highlightedWrapper = mount(
+      <ListBox.MenuItem {...mockProps} isHighlighted={true} />
+    );
+    expect(wrapper).toMatchSnapshot();
+    expect(activeWrapper).toMatchSnapshot();
+    expect(highlightedWrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/ListBox/__tests__/ListBoxSelection-test.js
+++ b/src/components/ListBox/__tests__/ListBoxSelection-test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ListBox from '../';
+
+describe('ListBoxSelection', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      clearSelection: jest.fn(),
+      translateWithId: jest.fn(() => 'translation'),
+    };
+  });
+
+  it('should render', () => {
+    const singleSelectionWrapper = mount(<ListBox.Selection {...mockProps} />);
+    const multiSelectionWrapper = mount(
+      <ListBox.Selection selectionCount={3} {...mockProps} />
+    );
+    expect(singleSelectionWrapper).toMatchSnapshot();
+    expect(multiSelectionWrapper).toMatchSnapshot();
+  });
+
+  it('should call `translateWithId` with the id strings needed to translate', () => {
+    mount(<ListBox.Selection {...mockProps} />);
+    expect(mockProps.translateWithId).toHaveBeenCalledWith('clear.selection');
+
+    mockProps.translateWithId.mockClear();
+
+    mount(<ListBox.Selection {...mockProps} selectionCount={3} />);
+    expect(mockProps.translateWithId).toHaveBeenCalledWith('clear.all');
+  });
+});

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBox should render 1`] = `
+<ListBox
+  className="bx--list-box__container"
+  disabled={false}
+  innerRef={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          <div
+            class="bx--list-box__container bx--list-box"
+          >
+            <span>
+              Hello
+            </span>
+          </div>,
+        ],
+      ],
+    }
+  }
+  type="default"
+>
+  <div
+    className="bx--list-box__container bx--list-box"
+  >
+    <span>
+      Hello
+    </span>
+  </div>
+</ListBox>
+`;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -11,9 +11,11 @@ exports[`ListBox should render 1`] = `
           <div
             class="bx--list-box__container bx--list-box"
           >
-            <span>
-              Hello
-            </span>
+            <div
+              class="bx--list-box__field"
+              role="button"
+              tabindex="0"
+            />
           </div>,
         ],
       ],
@@ -24,9 +26,13 @@ exports[`ListBox should render 1`] = `
   <div
     className="bx--list-box__container bx--list-box"
   >
-    <span>
-      Hello
-    </span>
+    <ListBoxField>
+      <div
+        className="bx--list-box__field"
+        role="button"
+        tabIndex="0"
+      />
+    </ListBoxField>
   </div>
 </ListBox>
 `;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -7,9 +7,47 @@ exports[`ListBoxField should render 1`] = `
     role="button"
     tabIndex="0"
   >
-    <span>
-      Hello
-    </span>
+    <ListBoxSelection
+      clearSelection={[MockFunction]}
+      translateWithId={[Function]}
+    >
+      <div
+        className="bx--list-box__selection"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex="0"
+        title="Clear selected item"
+      >
+        <Icon
+          description="Clear selected item"
+          fillRule="evenodd"
+          name="close"
+          role="img"
+        >
+          <svg
+            aria-label="Clear selected item"
+            className={undefined}
+            fill={undefined}
+            fillRule="evenodd"
+            height="10"
+            name="close"
+            role="img"
+            style={undefined}
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <title>
+              Clear selected item
+            </title>
+            <path
+              d="M9.8 8.6L8.4 10 5 6.4 1.4 10 0 8.6 3.6 5 .1 1.4 1.5 0 5 3.6 8.6 0 10 1.4 6.4 5z"
+              key="key0"
+            />
+          </svg>
+        </Icon>
+      </div>
+    </ListBoxSelection>
   </div>
 </ListBoxField>
 `;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBoxField should render 1`] = `
+<ListBoxField>
+  <div
+    className="bx--list-box__field"
+    role="button"
+    tabIndex="0"
+  >
+    <span>
+      Hello
+    </span>
+  </div>
+</ListBoxField>
+`;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenu-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenu-test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBoxMenu should render 1`] = `
+<ListBoxMenu>
+  <div
+    className="bx--list-box__menu"
+  >
+    <ListBoxMenuItem
+      isActive={false}
+      isHighlighted={false}
+    >
+      <div
+        className="bx--list-box__menu-item"
+      >
+        Hello
+      </div>
+    </ListBoxMenuItem>
+  </div>
+</ListBoxMenu>
+`;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuIcon-test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBoxMenuIcon should render 1`] = `
+<ListBoxMenuIcon
+  isOpen={true}
+  translateWithId={[Function]}
+>
+  <div
+    className="bx--list-box__menu-icon bx--list-box__menu-icon--open"
+  >
+    <Icon
+      description="Close menu"
+      fillRule="evenodd"
+      name="caret--down"
+      role="img"
+    >
+      <svg
+        aria-label="Close menu"
+        className={undefined}
+        fill={undefined}
+        fillRule="evenodd"
+        height="5"
+        name="caret--down"
+        role="img"
+        style={undefined}
+        viewBox="0 0 10 5"
+        width="10"
+      >
+        <title>
+          Close menu
+        </title>
+        <path
+          d="M10 0L5 5 0 0z"
+          key="key0"
+        />
+      </svg>
+    </Icon>
+  </div>
+</ListBoxMenuIcon>
+`;
+
+exports[`ListBoxMenuIcon should render 2`] = `
+<ListBoxMenuIcon
+  isOpen={false}
+  translateWithId={[Function]}
+>
+  <div
+    className="bx--list-box__menu-icon"
+  >
+    <Icon
+      description="Open menu"
+      fillRule="evenodd"
+      name="caret--down"
+      role="img"
+    >
+      <svg
+        aria-label="Open menu"
+        className={undefined}
+        fill={undefined}
+        fillRule="evenodd"
+        height="5"
+        name="caret--down"
+        role="img"
+        style={undefined}
+        viewBox="0 0 10 5"
+        width="10"
+      >
+        <title>
+          Open menu
+        </title>
+        <path
+          d="M10 0L5 5 0 0z"
+          key="key0"
+        />
+      </svg>
+    </Icon>
+  </div>
+</ListBoxMenuIcon>
+`;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuItem-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxMenuItem-test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBoxMenuItem should render 1`] = `
+<ListBoxMenuItem
+  isActive={false}
+  isHighlighted={false}
+>
+  <div
+    className="bx--list-box__menu-item"
+  >
+    <span>
+      ListBox.MenuItem
+    </span>
+  </div>
+</ListBoxMenuItem>
+`;
+
+exports[`ListBoxMenuItem should render 2`] = `
+<ListBoxMenuItem
+  isActive={true}
+  isHighlighted={false}
+>
+  <div
+    className="bx--list-box__menu-item bx--list-box__menu-item--active"
+  >
+    <span>
+      ListBox.MenuItem
+    </span>
+  </div>
+</ListBoxMenuItem>
+`;
+
+exports[`ListBoxMenuItem should render 3`] = `
+<ListBoxMenuItem
+  isActive={false}
+  isHighlighted={true}
+>
+  <div
+    className="bx--list-box__menu-item bx--list-box__menu-item--highlighted"
+  >
+    <span>
+      ListBox.MenuItem
+    </span>
+  </div>
+</ListBoxMenuItem>
+`;

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListBoxSelection should render 1`] = `
+<ListBoxSelection
+  clearSelection={[MockFunction]}
+  translateWithId={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "clear.selection",
+        ],
+        Array [
+          "clear.all",
+        ],
+      ],
+    }
+  }
+>
+  <div
+    className="bx--list-box__selection"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+    title="translation"
+  >
+    <Icon
+      description="translation"
+      fillRule="evenodd"
+      name="close"
+      role="img"
+    >
+      <svg
+        aria-label="translation"
+        className={undefined}
+        fill={undefined}
+        fillRule="evenodd"
+        height="10"
+        name="close"
+        role="img"
+        style={undefined}
+        viewBox="0 0 10 10"
+        width="10"
+      >
+        <title>
+          translation
+        </title>
+        <path
+          d="M9.8 8.6L8.4 10 5 6.4 1.4 10 0 8.6 3.6 5 .1 1.4 1.5 0 5 3.6 8.6 0 10 1.4 6.4 5z"
+          key="key0"
+        />
+      </svg>
+    </Icon>
+  </div>
+</ListBoxSelection>
+`;
+
+exports[`ListBoxSelection should render 2`] = `
+<ListBoxSelection
+  clearSelection={[MockFunction]}
+  selectionCount={3}
+  translateWithId={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "clear.selection",
+        ],
+        Array [
+          "clear.all",
+        ],
+      ],
+    }
+  }
+>
+  <div
+    className="bx--list-box__selection bx--list-box__selection--multi"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex="0"
+    title="translation"
+  >
+    3
+    <Icon
+      description="translation"
+      fillRule="evenodd"
+      name="close"
+      role="img"
+    >
+      <svg
+        aria-label="translation"
+        className={undefined}
+        fill={undefined}
+        fillRule="evenodd"
+        height="10"
+        name="close"
+        role="img"
+        style={undefined}
+        viewBox="0 0 10 10"
+        width="10"
+      >
+        <title>
+          translation
+        </title>
+        <path
+          d="M9.8 8.6L8.4 10 5 6.4 1.4 10 0 8.6 3.6 5 .1 1.4 1.5 0 5 3.6 8.6 0 10 1.4 6.4 5z"
+          key="key0"
+        />
+      </svg>
+    </Icon>
+  </div>
+</ListBoxSelection>
+`;

--- a/src/components/ListBox/index.js
+++ b/src/components/ListBox/index.js
@@ -1,0 +1,15 @@
+import ListBox from './ListBox';
+import ListBoxField from './ListBoxField';
+import ListBoxMenu from './ListBoxMenu';
+import ListBoxMenuIcon from './ListBoxMenuIcon';
+import ListBoxMenuItem from './ListBoxMenuItem';
+import ListBoxSelection from './ListBoxSelection';
+
+ListBox.Field = ListBoxField;
+ListBox.Menu = ListBoxMenu;
+ListBox.MenuIcon = ListBoxMenuIcon;
+ListBox.MenuItem = ListBoxMenuItem;
+ListBox.Selection = ListBoxSelection;
+
+export default ListBox;
+export * as PropTypes from './ListBoxPropTypes';

--- a/src/prop-types/__tests__/childrenOf-test.js
+++ b/src/prop-types/__tests__/childrenOf-test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import childrenOf from '../childrenOf';
+
+const StatelessComponent = () => <div />;
+class ClassComponent extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
+// Note: when testing here, each component that passes children should have a
+// unique name. Otherwise, React will not report all invalid prop types because
+// it believes the name has already reported an issue in an earlier test.
+describe('childrenOf', () => {
+  let spy;
+
+  beforeEach(() => {
+    // We create a spy on `console.error` here since this is the vehicle React
+    // uses to communicate invalid prop types. Tests should make sure to assert
+    // on the number of times this is called to make sure we aren't swallowing
+    // any errors unexpectedly.
+    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('should validate children of a given enum of types', () => {
+    const ChildEnumValid = ({ children }) => <div>{children}</div>;
+    ChildEnumValid.propTypes = {
+      children: childrenOf([StatelessComponent, ClassComponent]),
+    };
+    <ChildEnumValid>
+      <StatelessComponent />
+      <ClassComponent />
+    </ChildEnumValid>;
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should warn with an invalid prop type for an invalid type', () => {
+    const ChildEnumInvalid = ({ children }) => <div>{children}</div>;
+    ChildEnumInvalid.propTypes = {
+      children: childrenOf([StatelessComponent, ClassComponent]),
+    };
+    <ChildEnumInvalid>
+      <div />
+      <StatelessComponent />
+      <ClassComponent />
+    </ChildEnumInvalid>;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Invalid prop `children` of type `div` supplied to ' +
+          '`ChildEnumInvalid`, expected each child to be one of: ' +
+          '`[StatelessComponent, ClassComponent]`.'
+      )
+    );
+  });
+
+  it('should work with `isRequired`', () => {
+    const RequiredChildrenOfTest = ({ children }) => <div>{children}</div>;
+    RequiredChildrenOfTest.propTypes = {
+      children: childrenOf([StatelessComponent, ClassComponent]).isRequired,
+    };
+    <RequiredChildrenOfTest />;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The prop `children` is marked as required in ' +
+          'RequiredChildrenOfTest, but its value is `undefined`.'
+      )
+    );
+  });
+});

--- a/src/prop-types/__tests__/childrenOfType-test.js
+++ b/src/prop-types/__tests__/childrenOfType-test.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import childrenOfType from '../childrenOfType';
+
+const Element = <span />;
+const StatelessComponent = () => <div />;
+class ClassComponent extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
+// Note: when testing here, each component that passes children should have a
+// unique name. Otherwise, React will not report all invalid prop types because
+// it believes the name has already reported an issue in an earlier test.
+describe('childrenOfType', () => {
+  let spy;
+
+  beforeEach(() => {
+    // We create a spy on `console.error` here since this is the vehicle React
+    // uses to communicate invalid prop types. Tests should make sure to assert
+    // on the number of times this is called to make sure we aren't swallowing
+    // any errors unexpectedly.
+    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('should validate children of a given element type', () => {
+    const ChildElementValidTest = ({ children }) => <div>{children}</div>;
+    ChildElementValidTest.propTypes = {
+      children: childrenOfType(Element),
+    };
+    <ChildElementValidTest>
+      <span />
+      <span />
+      <span />
+    </ChildElementValidTest>;
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should warn with an invalid prop type for an invalid element child type', () => {
+    const ChildElementInvalidTest = ({ children }) => <div>{children}</div>;
+    ChildElementInvalidTest.propTypes = {
+      children: childrenOfType(Element),
+    };
+    <ChildElementInvalidTest>
+      <div />
+      <span />
+      <span />
+    </ChildElementInvalidTest>;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Invalid prop `children` of type `div` supplied to ' +
+          '`ChildElementInvalidTest`, expected each child to be a ' +
+          '`span` component.'
+      )
+    );
+  });
+
+  it('should validate children of a given stateless functional component type', () => {
+    const ChildSFCValidTest = ({ children }) => <div>{children}</div>;
+    ChildSFCValidTest.propTypes = {
+      children: childrenOfType(StatelessComponent),
+    };
+    <ChildSFCValidTest>
+      <StatelessComponent />
+      <StatelessComponent />
+      <StatelessComponent />
+    </ChildSFCValidTest>;
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should warn with an invalid prop type for an invalid SFC child type', () => {
+    const BadStatelessComponent = () => <div />;
+    const ChildSFCInvalidTest = ({ children }) => <div>{children}</div>;
+    ChildSFCInvalidTest.propTypes = {
+      children: childrenOfType(StatelessComponent),
+    };
+    <ChildSFCInvalidTest>
+      <BadStatelessComponent />
+      <StatelessComponent />
+      <StatelessComponent />
+      <StatelessComponent />
+    </ChildSFCInvalidTest>;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Invalid prop `children` of type `BadStatelessComponent` supplied to ' +
+          '`ChildSFCInvalidTest`, expected each child to be a ' +
+          '`StatelessComponent` component.'
+      )
+    );
+  });
+
+  it('should validate children of a given class component type', () => {
+    const ChildClassValidTest = ({ children }) => <div>{children}</div>;
+    ChildClassValidTest.propTypes = {
+      children: childrenOfType(ClassComponent),
+    };
+    <ChildClassValidTest>
+      <ClassComponent />
+      <ClassComponent />
+      <ClassComponent />
+    </ChildClassValidTest>;
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should warn with an invalid prop type for an invalid class component child type', () => {
+    class BadClassComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+    const ChildClassInvalidTest = ({ children }) => <div>{children}</div>;
+    ChildClassInvalidTest.propTypes = {
+      children: childrenOfType(ClassComponent),
+    };
+    <ChildClassInvalidTest>
+      <BadClassComponent />
+      <ClassComponent />
+      <ClassComponent />
+    </ChildClassInvalidTest>;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Invalid prop `children` of type `BadClassComponent` supplied to ' +
+          '`ChildClassInvalidTest`, expected each child to be a ' +
+          '`ClassComponent` component.'
+      )
+    );
+  });
+
+  it('should work with `isRequired`', () => {
+    const RequiredTest = ({ children }) => <div>{children}</div>;
+    RequiredTest.propTypes = {
+      children: childrenOfType(StatelessComponent).isRequired,
+    };
+    <RequiredTest />;
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The prop `children` is marked as required in RequiredTest, but its ' +
+          'value is `undefined`.'
+      )
+    );
+  });
+});

--- a/src/prop-types/childrenOf.js
+++ b/src/prop-types/childrenOf.js
@@ -1,0 +1,34 @@
+import { Children } from 'react';
+import createChainableTypeChecker from './tools/createChainableTypeChecker';
+import getDisplayName from './tools/getDisplayName';
+
+/**
+ * `childrenOf` is used for asserting that the children of a given React
+ * component are of a given set of types. Currently, this will work with types
+ * that are Stateless Functional and Class-based components
+ *
+ * This prop validator also supports chaining through `isRequired`
+ */
+const childrenOf = expectedChildTypes => {
+  // Support both React elements and components by using `type` if it exists
+  const expectedDisplayNames = expectedChildTypes
+    .map(child => getDisplayName(child.type || child))
+    .join(', ');
+
+  const validate = (props, propName, componentName) => {
+    Children.forEach(props[propName], child => {
+      const childDisplayName = getDisplayName(child.type || child);
+      if (!expectedChildTypes.includes(child.type)) {
+        throw new Error(
+          `Invalid prop \`children\` of type \`${childDisplayName}\` ` +
+            `supplied to \`${componentName}\`, expected each child to be one ` +
+            `of: \`[${expectedDisplayNames}]\`.`
+        );
+      }
+    });
+  };
+
+  return createChainableTypeChecker(validate);
+};
+
+export default childrenOf;

--- a/src/prop-types/childrenOfType.js
+++ b/src/prop-types/childrenOfType.js
@@ -1,0 +1,36 @@
+import { Children } from 'react';
+import createChainableTypeChecker from './tools/createChainableTypeChecker';
+import getDisplayName from './tools/getDisplayName';
+
+/**
+ * `childrenOfType` is used for asserting that children of a given React
+ * component are only of a given type. Currently, this supports React elements,
+ * Stateless Functional Components, and Class-based components.
+ *
+ * This prop validator also supports chaining through `isRequired`
+ */
+const childrenOfType = expectedChildType => {
+  const expectedDisplayName = getDisplayName(
+    // Support both React elements and components by using `type` if it exists
+    expectedChildType.type || expectedChildType
+  );
+  const validate = (props, propName, componentName) => {
+    Children.forEach(props[propName], child => {
+      const childDisplayName = getDisplayName(child.type);
+      if (
+        child.type !== expectedChildType.type &&
+        child.type !== expectedChildType
+      ) {
+        throw new Error(
+          `Invalid prop \`children\` of type \`${childDisplayName}\` ` +
+            `supplied to \`${componentName}\`, expected each child to be a ` +
+            `\`${expectedDisplayName}\` component.`
+        );
+      }
+    });
+  };
+
+  return createChainableTypeChecker(validate);
+};
+
+export default childrenOfType;

--- a/src/prop-types/tools/__tests__/getDisplayName-test.js
+++ b/src/prop-types/tools/__tests__/getDisplayName-test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import getDisplayName from '../getDisplayName';
+
+describe('getDisplayName', () => {
+  it('should get the name from a React element', () => {
+    const element = <span />;
+    expect(getDisplayName(element.type)).toBe('span');
+  });
+
+  it('should get the name from a Stateless Functional Component', () => {
+    const Child = () => <div />;
+    expect(getDisplayName(React.createElement(Child).type)).toBe('Child');
+  });
+
+  it('should get the displayName from a class Component', () => {
+    class Child extends React.Component {
+      static displayName = 'ChildDisplayName';
+      render() {
+        return null;
+      }
+    }
+    expect(getDisplayName(React.createElement(Child).type)).toBe(
+      Child.displayName
+    );
+  });
+});

--- a/src/prop-types/tools/createChainableTypeChecker.js
+++ b/src/prop-types/tools/createChainableTypeChecker.js
@@ -1,0 +1,36 @@
+/**
+ * `createChainableTypeChecker` is used inside of our custom prop validators to
+ * add in chaining `isRequired` on a given prop validator.
+ */
+const createChainableTypeChecker = validate => {
+  // `checkType` is borrowed heavily from the `prop-types` package
+  const checkType = (isRequired, props, propName, componentName, location) => {
+    if (props[propName] == null) {
+      if (isRequired) {
+        if (props[propName] === null) {
+          return new Error(
+            `The ${location} \`${propName}\` is marked as required in ` +
+              `${componentName}, but its value is \`null\`.`
+          );
+        }
+        return new Error(
+          `The ${location} \`${propName}\` is marked as required in ` +
+            `${componentName}, but its value is \`undefined\`.`
+        );
+      }
+      return null;
+    } else {
+      return validate(props, propName, componentName, location);
+    }
+  };
+
+  // By default, the validator will have `isRequired` set to false. However, we
+  // also define the `isRequired` property on the validtor so that consumers can
+  // chain their prop validator and assert that the property is required.
+  let chainedCheckType = checkType.bind(null, false);
+  chainedCheckType.isRequired = checkType.bind(null, true);
+
+  return chainedCheckType;
+};
+
+export default createChainableTypeChecker;

--- a/src/prop-types/tools/getDisplayName.js
+++ b/src/prop-types/tools/getDisplayName.js
@@ -1,0 +1,31 @@
+const cachedDisplayNames = new WeakMap();
+
+/**
+ * `getDisplayName` is a utility function for getting a name from a given
+ * component type. It supports names from React elements, Stateless Functional
+ * Components, and Class-based Components
+ */
+const getDisplayName = type => {
+  if (typeof type === 'string') {
+    return type;
+  }
+
+  if (cachedDisplayNames.has(type)) {
+    return cachedDisplayNames.get(type);
+  }
+
+  let displayName;
+
+  if (typeof type.displayName === 'string') {
+    displayName = type.displayName;
+  }
+  if (!displayName) {
+    displayName = type.name || 'Unknown';
+  }
+
+  cachedDisplayNames.set(type, displayName);
+
+  return displayName;
+};
+
+export default getDisplayName;


### PR DESCRIPTION
Extracted `ListBox` and other relevant bits from #332 for a simpler diff.

#### Changelog

**New**

- `ListBox`: see [`README.md`](https://github.com/carbon-design-system/carbon-components-react/pull/435/files#diff-8d1d10a4d2221059c29d4000987f7dfb)
- `prop-types`
  - `childrenOf` `prop` validator for children of a given set of types
  - `childrenOfType` `prop` validator for children of a singletype
  - `tools`
    - `createChainableTypeChecker`: chaining required for supporting `isRequired`
    - `getDisplayName`: get name for a given React element or component

**Changed**

**Removed**
