### PR TITLE
fix(ModalWrapper): update trigger prop to follow camelCase

### DIFF
--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -170,17 +170,17 @@ describe('Modal Wrapper', () => {
     });
 
     it('should render ghost button when ghost is passed', () => {
-      wrapper.setProps({ triggerButtonkind: 'ghost' });
+      wrapper.setProps({ triggerButtonKind: 'ghost' });
       expect(wrapper.find('.bx--btn--ghost').length).toEqual(1);
     });
 
     it('should render danger button when danger is passed', () => {
-      wrapper.setProps({ triggerButtonkind: 'danger' });
+      wrapper.setProps({ triggerButtonKind: 'danger' });
       expect(wrapper.find('.bx--btn--danger').length).toEqual(1);
     });
 
     it('should render secondary button when secondary is passed', () => {
-      wrapper.setProps({ triggerButtonkind: 'secondary' });
+      wrapper.setProps({ triggerButtonKind: 'secondary' });
       expect(wrapper.find('.bx--btn--secondary').length).toEqual(2);
     });
   });

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -20,7 +20,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
     disabled: PropTypes.bool,
-    triggerButtonkind: PropTypes.oneOf([
+    triggerButtonKind: PropTypes.oneOf([
       'primary',
       'secondary',
       'danger',
@@ -31,7 +31,7 @@ export default class ModalWrapper extends React.Component {
   static defaultProps = {
     primaryButtonText: 'Save',
     secondaryButtonText: 'Cancel',
-    triggerButtonkind: 'primary',
+    triggerButtonKind: 'primary',
     disabled: false,
   };
 
@@ -55,7 +55,7 @@ export default class ModalWrapper extends React.Component {
     const {
       id,
       buttonTriggerText,
-      triggerButtonkind,
+      triggerButtonKind,
       modalLabel,
       modalHeading,
       passiveModal,
@@ -89,7 +89,7 @@ export default class ModalWrapper extends React.Component {
         }}>
         <Button
           disabled={disabled}
-          kind={triggerButtonkind}
+          kind={triggerButtonKind}
           onClick={this.handleOpen}>
           {buttonTriggerText}
         </Button>


### PR DESCRIPTION
Closes #356

Updates prop to follow camelCase naming convention.

#### Changelog

**New**

**Changed**

- `ModalWrapper`
  - `triggerButtonkind` -> `triggerButtonKind`

**Removed**
