### PR TITLE
fix(textInput): Add aria-invalid and aria-described by to invalid textInput

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -127,13 +127,13 @@ export default class DatePicker extends Component {
     calendarContainer
       .querySelector('.flatpickr-days')
       .classList.add('bx--date-picker__days');
-    [
-      ...calendarContainer.querySelectorAll('.flatpickr-weekday'),
-    ].forEach(item => {
-      const currentItem = item;
-      currentItem.innerHTML = currentItem.innerHTML.replace(/\s+/g, '');
-      currentItem.classList.add('bx--date-picker__weekday');
-    });
+    [...calendarContainer.querySelectorAll('.flatpickr-weekday')].forEach(
+      item => {
+        const currentItem = item;
+        currentItem.innerHTML = currentItem.innerHTML.replace(/\s+/g, '');
+        currentItem.classList.add('bx--date-picker__weekday');
+      }
+    );
     [...daysContainer.querySelectorAll('.flatpickr-day')].forEach(item => {
       item.classList.add('bx--date-picker__day');
       if (

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -31,6 +31,7 @@ const TextInput = ({
     type,
   };
 
+  const errorId = id + 'errormsg';
   const textInputClasses = classNames('bx--text-input', className);
   const labelClasses = classNames('bx--label', {
     'bx--visually-hidden': hideLabel,
@@ -43,7 +44,9 @@ const TextInput = ({
   ) : null;
 
   const error = invalid ? (
-    <div className="bx--form-requirement">{invalidText}</div>
+    <div className="bx--form-requirement" id={errorId}>
+      {invalidText}
+    </div>
   ) : null;
 
   const input = invalid ? (
@@ -51,6 +54,8 @@ const TextInput = ({
       {...other}
       {...textInputProps}
       data-invalid
+      aria-invalid
+      aria-describedBy={errorId}
       className={textInputClasses}
     />
   ) : (


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#424

Adds `aria-invalid` to invalid textInput and `aria-describedBy` to the error message associated with the text field. 
  