### PR TITLE
fix(textInput): Add aria-invalid and aria-describedBy to invalid textInput

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -31,6 +31,7 @@ const TextInput = ({
     type,
   };
 
+  const errorId = id + 'errormsg';
   const textInputClasses = classNames('bx--text-input', className);
   const labelClasses = classNames('bx--label', {
     'bx--visually-hidden': hideLabel,
@@ -43,7 +44,9 @@ const TextInput = ({
   ) : null;
 
   const error = invalid ? (
-    <div className="bx--form-requirement">{invalidText}</div>
+    <div className="bx--form-requirement" id={errorId}>
+      {invalidText}
+    </div>
   ) : null;
 
   const input = invalid ? (
@@ -51,6 +54,8 @@ const TextInput = ({
       {...other}
       {...textInputProps}
       data-invalid
+      aria-invalid
+      aria-describedBy={errorId}
       className={textInputClasses}
     />
   ) : (

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -31,7 +31,7 @@ const TextInput = ({
     type,
   };
 
-  const errorId = id + 'errormsg';
+  const errorId = id + '-error-msg';
   const textInputClasses = classNames('bx--text-input', className);
   const labelClasses = classNames('bx--label', {
     'bx--visually-hidden': hideLabel,


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#424

Adds `aria-invalid` to invalid textInput and `aria-describedBy` to the error message associated with the text field. 