### PR TITLE
fix(interior-left-nav): refactored so it accepts react router links

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,6 @@
     "flatpickr": "4.2.2",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
-    "react-router": "^4.2.0",
-    "react-router-dom": "^4.2.2",
     "warning": "3.0.0",
     "window-or-global": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
     "flatpickr": "4.2.2",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
+    "react-router": "^4.2.0",
+    "react-router-dom": "^4.2.2",
     "warning": "3.0.0",
     "window-or-global": "^1.0.1"
   },

--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -4,6 +4,9 @@ import InteriorLeftNav from '../InteriorLeftNav';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 
+// For demo purposes
+import { BrowserRouter, Link } from 'react-router-dom';
+
 storiesOf('InteriorLeftNav', module).addWithInfo(
   'Default',
   `
@@ -12,34 +15,44 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
       breadth of content and tasks users expect to see.
     `,
   () => (
-    <InteriorLeftNav>
-      <InteriorLeftNavList title="Example Item 1">
-        <InteriorLeftNavItem href="#example-item-1A">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
+    <BrowserRouter>
+      <InteriorLeftNav>
+        <InteriorLeftNavList title="Example Item 1">
+          <InteriorLeftNavItem>
+            <Link target="_blank" to="http://www.carbondesignsystem.com">
+              Link Child
+            </Link>
+          </InteriorLeftNavItem>
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+        </InteriorLeftNavList>
+        <InteriorLeftNavList title="Example Item 2">
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+          <InteriorLeftNavItem>
+            <a href="http://www.carbondesignsystem.com">Link Child</a>
+          </InteriorLeftNavItem>
+        </InteriorLeftNavList>
+        <InteriorLeftNavItem>
+          <a href="#example-1">Link label</a>
         </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-1B">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com" target="_blank">
+            Link label 2
+          </a>
         </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-1C">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
-        </InteriorLeftNavItem>
-      </InteriorLeftNavList>
-      <InteriorLeftNavList title="Example Item 2">
-        <InteriorLeftNavItem href="#example-item-2A">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
-        </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-2B">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
-        </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-2C">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
-        </InteriorLeftNavItem>
-        <InteriorLeftNavItem href="#example-item-2D">
-          <a href="http://www.carbondesignsystem.com">Link Child</a>
-        </InteriorLeftNavItem>
-      </InteriorLeftNavList>
-      <InteriorLeftNavItem href="#example-item-3" label="Link Label" />
-      <InteriorLeftNavItem href="#example-item-4" label="Link Label" />
-    </InteriorLeftNav>
+      </InteriorLeftNav>
+    </BrowserRouter>
   )
 );

--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -4,9 +4,6 @@ import InteriorLeftNav from '../InteriorLeftNav';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 
-// For demo purposes
-import { BrowserRouter, Link } from 'react-router-dom';
-
 storiesOf('InteriorLeftNav', module).addWithInfo(
   'Default',
   `
@@ -15,44 +12,42 @@ storiesOf('InteriorLeftNav', module).addWithInfo(
       breadth of content and tasks users expect to see.
     `,
   () => (
-    <BrowserRouter>
-      <InteriorLeftNav>
-        <InteriorLeftNavList title="Example Item 1">
-          <InteriorLeftNavItem>
-            <Link target="_blank" to="http://www.carbondesignsystem.com">
-              Link Child
-            </Link>
-          </InteriorLeftNavItem>
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-        </InteriorLeftNavList>
-        <InteriorLeftNavList title="Example Item 2">
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-          <InteriorLeftNavItem>
-            <a href="http://www.carbondesignsystem.com">Link Child</a>
-          </InteriorLeftNavItem>
-        </InteriorLeftNavList>
+    <InteriorLeftNav>
+      <InteriorLeftNavList title="Example Item 1">
         <InteriorLeftNavItem>
-          <a href="#example-1">Link label</a>
-        </InteriorLeftNavItem>
-        <InteriorLeftNavItem>
-          <a href="http://www.carbondesignsystem.com" target="_blank">
-            Link label 2
+          <a target="_blank" href="http://www.carbondesignsystem.com">
+            Link Child
           </a>
         </InteriorLeftNavItem>
-      </InteriorLeftNav>
-    </BrowserRouter>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+      </InteriorLeftNavList>
+      <InteriorLeftNavList title="Example Item 2">
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+        <InteriorLeftNavItem>
+          <a href="http://www.carbondesignsystem.com">Link Child</a>
+        </InteriorLeftNavItem>
+      </InteriorLeftNavList>
+      <InteriorLeftNavItem>
+        <a href="#example-1">Link label</a>
+      </InteriorLeftNavItem>
+      <InteriorLeftNavItem>
+        <a href="http://www.carbondesignsystem.com" target="_blank">
+          Link label 2
+        </a>
+      </InteriorLeftNavItem>
+    </InteriorLeftNav>
   )
 );

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -63,7 +63,7 @@ describe('InteriorLeftNav', () => {
     const interiorLeftNav = mount(
       <InteriorLeftNav>
         <InteriorLeftNavList />
-        <InteriorLeftNavItem href="#first">
+        <InteriorLeftNavItem>
           <a href="#first">test-title</a>
         </InteriorLeftNavItem>
       </InteriorLeftNav>

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
@@ -12,13 +12,6 @@ describe('InteriorLeftNavItem', () => {
         <a href="test-href">link</a>
       </InteriorLeftNavItem>
     );
-    const wrapperNoChild = mount(
-      <InteriorLeftNavItem
-        className="extra-class"
-        href="test-href"
-        activeHref="test-href"
-      />
-    );
 
     it('renders a interior left nav item', () => {
       expect(wrapper.length).toEqual(1);
@@ -49,16 +42,6 @@ describe('InteriorLeftNavItem', () => {
     it('has an anchor with the expected class', () => {
       expect(wrapper.find('a').hasClass('left-nav-list__item-link')).toEqual(
         true
-      );
-    });
-
-    it('can render without a child ', () => {
-      expect(wrapperNoChild.length).toEqual(1);
-    });
-
-    it('has an anchor that matches label when no child is given', () => {
-      expect(wrapperNoChild.find('a').text()).toEqual(
-        wrapperNoChild.props().label
       );
     });
   });

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -16,10 +16,13 @@ const InteriorLeftNavItem = ({
   children,
   onClick,
   onKeyPress,
+  activeHref,
   ...other
 }) => {
+  const childHref =
+    children.props.href === undefined ? children.props.to : children.props.href;
   const classNames = classnames('left-nav-list__item', className, {
-    'left-nav-list__item--active': false,
+    'left-nav-list__item--active': activeHref === childHref,
   });
 
   return (

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -21,8 +21,10 @@ const InteriorLeftNavItem = ({
 }) => {
   const childHref =
     children.props.href === undefined ? children.props.to : children.props.href;
+  const activePath =
+    window.location && window.location.hash ? window.location.hash : activeHref;
   const classNames = classnames('left-nav-list__item', className, {
-    'left-nav-list__item--active': activeHref === childHref,
+    'left-nav-list__item--active': activePath === childHref,
   });
 
   return (

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -15,7 +15,6 @@ const InteriorLeftNavItem = ({
   tabIndex,
   children,
   onClick,
-  onKeyPress,
   activeHref,
   ...other
 }) => {
@@ -32,8 +31,8 @@ const InteriorLeftNavItem = ({
       tabIndex={children ? -1 : tabIndex}
       role="menuitem"
       className={classNames}
-      onClick={evt => onClick(evt)}
-      onKeyPress={evt => onKeyPress(evt)}
+      onClick={evt => onClick(evt, childHref)}
+      onKeyPress={evt => onClick(evt, childHref)}
       {...other}>
       {newChild(children, tabIndex)}
     </li>

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -12,16 +12,14 @@ const newChild = (children, tabIndex) => {
 
 const InteriorLeftNavItem = ({
   className,
-  href,
-  activeHref,
-  onClick,
   tabIndex,
   children,
-  label,
+  onClick,
+  onKeyPress,
   ...other
 }) => {
   const classNames = classnames('left-nav-list__item', className, {
-    'left-nav-list__item--active': activeHref === href,
+    'left-nav-list__item--active': false,
   });
 
   return (
@@ -29,36 +27,23 @@ const InteriorLeftNavItem = ({
       tabIndex={children ? -1 : tabIndex}
       role="menuitem"
       className={classNames}
-      onClick={evt => onClick(evt, href)}
-      onKeyPress={evt => onClick(evt, href)}
+      onClick={evt => onClick(evt)}
+      onKeyPress={evt => onKeyPress(evt)}
       {...other}>
-      {children ? (
-        newChild(children, tabIndex)
-      ) : (
-        <a
-          className="left-nav-list__item-link"
-          href={href}
-          tabIndex={children ? tabIndex : -1}>
-          {label}
-        </a>
-      )}
+      {newChild(children, tabIndex)}
     </li>
   );
 };
 
 InteriorLeftNavItem.propTypes = {
   className: PropTypes.string,
-  href: PropTypes.string.isRequired,
-  activeHref: PropTypes.string,
   tabIndex: PropTypes.number,
   onClick: PropTypes.func,
-  blankTarget: PropTypes.bool,
+  onKeyPress: PropTypes.func,
   children: PropTypes.node,
-  label: PropTypes.string.isRequired,
 };
 
 InteriorLeftNavItem.defaultProps = {
-  activeHref: '#',
   tabIndex: 0,
   label: 'InteriorLeftNavItem Label',
   onClick: /* istanbul ignore next */ () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,6 +4188,16 @@ he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4207,6 +4217,10 @@ hoek@4.x.x:
 hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4706,6 +4720,10 @@ is-utf8@^0.2.0:
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -5535,7 +5553,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -6379,6 +6397,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -7083,6 +7107,29 @@ react-modal@^2.4.1:
     exenv "^1.2.0"
     prop-types "^15.5.10"
 
+react-router-dom@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+  dependencies:
+    history "^4.7.2"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.4"
+    react-router "^4.2.0"
+    warning "^3.0.0"
+
+react-router@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.3.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
+
 react-simple-di@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-simple-di/-/react-simple-di-1.2.0.tgz#dde0e5bf689f391ef2ab02c9043b213fe239c6d0"
@@ -7467,6 +7514,10 @@ resolve-from@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -8469,6 +8520,10 @@ validate-npm-package-name@^3.0.0:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
   dependencies:
     builtins "^1.0.3"
+
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-react/issues/169

Refactored `InteriorLeftNavItem` to have more customizable children and to accept both normal links and react-router links.

### Changelog

**Changed**

- The parent does not handle the `href` anymore
- The child can be either an anchor link or a react-router Link