### PR TITLE
fix(OverflowMenu): reposition menu upon change in open state

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -85,6 +85,7 @@ describe('OverflowMenu', () => {
 
       expect(menuOptions.hasClass(openClass)).not.toEqual(true);
       rootWrapper.setState({ open: true });
+      rootWrapper.update();
       expect(rootWrapper.find('ul').hasClass(openClass)).not.toEqual(false);
     });
 

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -44,6 +44,16 @@ export default class OverflowMenu extends Component {
     open: this.props.open,
   };
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (nextState.open && !this.state.open) {
+      requestAnimationFrame(() => {
+        this.getMenuPosition();
+      });
+      return false; // Let `.getMenuPosition()` cause render
+    }
+    return true;
+  }
+
   componentDidMount() {
     requestAnimationFrame(() => {
       this.getMenuPosition();


### PR DESCRIPTION
Fixes #433.

#### Changelog

**New**

Code to recalculate the position of the trigger button, upon opening overflow menu.