### PR TITLE
feat(components): add MultiSelect component

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,13 +101,14 @@
     }
   },
   "peerDependencies": {
-    "carbon-components": "^8.1.11",
+    "carbon-components": "^8.2.0",
     "carbon-icons": "^5.1.2 || ^6.0.0",
     "react": "^15.3.2 || ^16.1.0",
     "react-dom": "^15.3.2 || ^16.1.0"
   },
   "dependencies": {
     "classnames": "2.2.5",
+    "downshift": "^1.23.2",
     "flatpickr": "4.2.1",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
@@ -127,7 +128,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.16.0",
     "bowser": "^1.6.1",
-    "carbon-components": "^8.1.3",
+    "carbon-components": "^8.2.0",
     "carbon-icons": "^6.1.0",
     "commitizen": "^2.9.5",
     "css-loader": "^0.28.4",

--- a/src/components/ListBox/ListBoxField.js
+++ b/src/components/ListBox/ListBoxField.js
@@ -15,7 +15,7 @@ const ListBoxField = ({ children, ...rest }) => (
 );
 
 ListBoxField.propTypes = {
-  children: childrenOf([ListBoxMenuIcon, ListBoxSelection]),
+  children: childrenOf([ListBoxMenuIcon, ListBoxSelection, 'span']),
 };
 
 export default ListBoxField;

--- a/src/components/ListBox/test-helpers.js
+++ b/src/components/ListBox/test-helpers.js
@@ -1,0 +1,49 @@
+// Finding nodes in a ListBox
+export const findMenuNode = wrapper => wrapper.find('.bx--list-box__menu');
+export const findMenuItemNode = (wrapper, index) =>
+  wrapper.find('ListBoxMenuItem').at(index);
+export const findMenuIconNode = wrapper =>
+  wrapper.find('.bx--list-box__menu-icon');
+export const findFieldNode = wrapper => wrapper.find('.bx--list-box__field');
+
+// Actions
+export const openMenu = wrapper => findFieldNode(wrapper).simulate('click');
+
+// Common assertions, useful for validating a11y props are set when needed
+export const assertMenuOpen = (wrapper, mockProps) => {
+  expect(findMenuNode(wrapper).children().length).toBe(mockProps.items.length);
+  expect(findMenuIconNode(wrapper).prop('className')).toEqual(
+    expect.stringContaining('bx--list-box__menu-icon--open')
+  );
+  expect(findFieldNode(wrapper).props()).toEqual(
+    expect.objectContaining({
+      'aria-expanded': true,
+      'aria-haspopup': true,
+      'aria-label': 'close menu',
+    })
+  );
+};
+
+// `GenericItem` corresponds to an item in a collection that is passed to
+// MultiSelect that is in a predictable shape and works with the default
+// `itemTostring` out of the box.
+export const generateGenericItem = index => ({
+  id: `id-${index}`,
+  label: `Item ${index}`,
+  value: index,
+});
+
+// `CustomItem` corresponds to a potentially different item structure that
+// might be passed into MultiSelect that we would need to supply a custom
+// `itemToString` method for
+export const generateCustomItem = index => ({
+  field: `Item ${index}`,
+  value: `Custom value ${index}`,
+});
+
+export const generateItems = (amount, generator) =>
+  Array(amount)
+    .fill(null)
+    .map((_, i) => generator(i));
+
+export const customItemToString = ({ field }) => field;

--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { storiesOf, action } from '@storybook/react';
+import MultiSelect from '../MultiSelect';
+
+const items = [
+  {
+    id: 'option-1',
+    text: 'Option 1',
+  },
+  {
+    id: 'option-2',
+    text: 'Option 2',
+  },
+  {
+    id: 'option-3',
+    text: 'Option 3',
+  },
+  {
+    id: 'option-4',
+    text: 'Option 4',
+  },
+];
+
+storiesOf('MultiSelect', module)
+  .addWithInfo(
+    'default',
+    `
+    MultiSelect
+  `,
+    () => (
+      <div style={{ width: 300 }}>
+        <MultiSelect
+          label="Label"
+          items={items}
+          itemToString={item => (item ? item.text : '')}
+          onChange={action('onChange - MultiSelect')}
+        />
+      </div>
+    )
+  )
+  .addWithInfo(
+    'inline',
+    `
+      Inline variant of a MultiSelect
+    `,
+    () => (
+      <MultiSelect
+        type="inline"
+        label="Label"
+        items={items}
+        itemToString={item => (item ? item.text : '')}
+        onChange={action('onChange - Inline MultiSelect')}
+      />
+    )
+  )
+  .addWithInfo(
+    'disabled',
+    `
+      Disabled variant of a MultiSelect
+    `,
+    () => (
+      <div style={{ width: 300 }}>
+        <MultiSelect
+          label="Label"
+          items={items}
+          itemToString={item => (item ? item.text : '')}
+          onChange={action('onChange - Inline MultiSelect')}
+          disabled
+        />
+      </div>
+    )
+  )
+  .addWithInfo(
+    'disabled - inline',
+    `
+      Disabled, inline variant of a MultiSelect
+    `,
+    () => (
+      <MultiSelect
+        type="inline"
+        label="Label"
+        items={items}
+        itemToString={item => (item ? item.text : '')}
+        onChange={action('onChange - Inline MultiSelect')}
+        disabled
+      />
+    )
+  );

--- a/src/components/MultiSelect/MultiSelect-test.js
+++ b/src/components/MultiSelect/MultiSelect-test.js
@@ -1,0 +1,216 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import MultiSelect from '../MultiSelect';
+import {
+  openMenu,
+  generateItems,
+  generateGenericItem,
+} from '../ListBox/test-helpers';
+
+const mouseDownAndUp = node => {
+  node.dispatchEvent(new window.MouseEvent('mousedown', { bubbles: true }));
+  node.dispatchEvent(new window.MouseEvent('mouseup', { bubbles: true }));
+};
+
+describe('MultiSelect', () => {
+  it('should initialize with no selected items if no `initialSelectedItems` are given', () => {
+    const items = generateItems(5, generateGenericItem);
+    const wrapper = mount(<MultiSelect label="Field" items={items} />);
+    expect(wrapper.find('Selection').instance().state.selectedItems).toEqual(
+      []
+    );
+  });
+  it('should initialize with the menu not open', () => {
+    const items = generateItems(5, generateGenericItem);
+    const wrapper = mount(<MultiSelect label="Field" items={items} />);
+    expect(wrapper.state('isOpen')).toEqual(false);
+  });
+
+  describe('#handleOnToggleMenu', () => {
+    it('should toggle the boolean `isOpen` field', () => {
+      const items = generateItems(5, generateGenericItem);
+      const wrapper = mount(<MultiSelect label="Field" items={items} />);
+      expect(wrapper.state('isOpen')).toBe(false);
+      wrapper.instance().handleOnToggleMenu();
+      expect(wrapper.state('isOpen')).toBe(true);
+      wrapper.instance().handleOnToggleMenu();
+      expect(wrapper.state('isOpen')).toBe(false);
+    });
+  });
+
+  describe('when `initialSelectedItems` is given', () => {
+    it('should initialize `selectedItems` with the given initial selected items', () => {
+      const items = generateItems(5, generateGenericItem);
+      const wrapper = mount(
+        <MultiSelect
+          label="Field"
+          items={items}
+          initialSelectedItems={[items[0], items[1]]}
+        />
+      );
+      expect(wrapper.find('Selection').instance().state.selectedItems).toEqual([
+        items[0],
+        items[1],
+      ]);
+    });
+  });
+
+  describe('e2e', () => {
+    let mockProps;
+
+    beforeEach(() => {
+      mockProps = {
+        items: generateItems(5, generateGenericItem),
+        initialSelectedItems: [],
+        itemToString: ({ label }) => label,
+        onChange: jest.fn(),
+        label: 'Label',
+      };
+    });
+
+    it('should open the menu when a user clicks on the ListBox field', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      wrapper.find('.bx--list-box__field').simulate('click');
+      expect(wrapper.find('.bx--list-box__menu').length).toBe(1);
+      expect(wrapper.find('.bx--list-box__menu-item').length).toBe(
+        mockProps.items.length
+      );
+    });
+
+    it('should open the menu when a user focuses and hits space on the ListBox field', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      wrapper.find('.bx--list-box__field').simulate('keydown', {
+        key: ' ',
+      });
+      expect(wrapper.find('.bx--list-box__menu').length).toBe(1);
+      expect(wrapper.find('.bx--list-box__menu-item').length).toBe(
+        mockProps.items.length
+      );
+    });
+
+    it('should select an item when a user clicks on an item', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      openMenu(wrapper);
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .first()
+        .simulate('click');
+      expect(wrapper.find('Selection').instance().state.selectedItems).toEqual([
+        mockProps.items[0],
+      ]);
+    });
+
+    it('should allow a user to highlight items with the up and down arrow keys', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      wrapper.find('.bx--list-box__field').simulate('click');
+      const simulateArrowDown = () =>
+        wrapper.find('.bx--list-box__field').simulate('keydown', {
+          key: 'ArrowDown',
+        });
+      const simulateArrowUp = () =>
+        wrapper.find('.bx--list-box__field').simulate('keydown', {
+          key: 'ArrowUp',
+        });
+      const getHighlightedId = () =>
+        wrapper.find('.bx--list-box__menu-item--highlighted').prop('id');
+      simulateArrowDown();
+      expect(getHighlightedId()).toBe('downshift-1-item-0');
+      simulateArrowDown();
+      expect(getHighlightedId()).toBe('downshift-1-item-1');
+      // Simulate "wrap" behavior
+      simulateArrowDown();
+      simulateArrowDown();
+      simulateArrowDown();
+      simulateArrowDown();
+      expect(getHighlightedId()).toBe('downshift-1-item-0');
+      simulateArrowUp();
+      expect(getHighlightedId()).toBe('downshift-1-item-4');
+    });
+
+    it('should close the menu when a user clicks outside of the control', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      wrapper.find('.bx--list-box__field').simulate('click');
+      mouseDownAndUp(document.body);
+      expect(wrapper.state('isOpen')).toBe(false);
+    });
+
+    it('should show a badge that mirrors the number of selected items', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      openMenu(wrapper);
+      for (let i = 0; i < mockProps.items.length; i++) {
+        wrapper
+          .find('.bx--list-box__menu-item')
+          .at(i)
+          .simulate('click');
+        expect(wrapper.find('.bx--list-box__selection').text()).toEqual(
+          expect.stringContaining(`${i + 1}`)
+        );
+      }
+      expect(wrapper.find('Selection').instance().state.selectedItems).toEqual(
+        mockProps.items
+      );
+    });
+
+    it('should allow a user to de-select an item by clicking on a selected item', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      wrapper.find('.bx--list-box__field').simulate('click');
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .at(0)
+        .simulate('click');
+      expect(wrapper.find('.bx--list-box__menu-item--active').length).toBe(1);
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .at(0)
+        .simulate('click');
+      expect(wrapper.find('.bx--list-box__menu-item--active').length).toBe(0);
+    });
+
+    it('should allow a user to de-select an item by hitting enter on a selected item', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      const simulateArrowDown = wrapper =>
+        wrapper.find('.bx--list-box__field').simulate('keydown', {
+          key: 'ArrowDown',
+        });
+      openMenu(wrapper);
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .at(0)
+        .simulate('click');
+      expect(wrapper.find('.bx--list-box__menu-item--active').length).toBe(1);
+      simulateArrowDown(wrapper);
+      wrapper.find('.bx--list-box__field').simulate('keydown', {
+        key: 'Enter',
+      });
+      expect(wrapper.find('.bx--list-box__menu-item--active').length).toBe(0);
+    });
+
+    it('should allow a user to click on the clear icon to clear all selected items', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      openMenu(wrapper);
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .at(0)
+        .simulate('click');
+      wrapper.find('.bx--list-box__selection').simulate('click');
+      expect(wrapper.find('Selection').instance().state.selectedItems).toEqual(
+        []
+      );
+    });
+
+    it('should allow a user to focus the clear icon and hit enter to clear all selected items', () => {
+      const wrapper = mount(<MultiSelect {...mockProps} />);
+      openMenu(wrapper);
+      wrapper
+        .find('.bx--list-box__menu-item')
+        .at(0)
+        .simulate('click');
+      wrapper.find('.bx--list-box__selection').simulate('keydown', {
+        keyCode: 13,
+      });
+      expect(wrapper.find('Selection').instance().state.selectedItems).toEqual(
+        []
+      );
+    });
+  });
+});

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -1,0 +1,185 @@
+import cx from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Downshift from 'downshift';
+import ListBox from '../ListBox';
+import Checkbox from '../Checkbox';
+import Selection from '../../internal/Selection';
+
+export default class MultiSelect extends React.Component {
+  static propTypes = {
+    /**
+     * Disable the control
+     */
+    disabled: PropTypes.bool,
+
+    /**
+     * We try to stay as generic as possible here to allow individuals to pass
+     * in a collection of whatever kind of data structure they prefer
+     */
+    items: PropTypes.array.isRequired,
+
+    /**
+     * Allow users to pass in arbitrary items from their collection that are
+     * pre-selected
+     */
+    initialSelectedItems: PropTypes.array,
+
+    /**
+     * Helper function passed to downshift that allows the library to render a
+     * given item to a string label. By default, it extracts the `label` field
+     * from a given item to serve as the item label in the list.
+     */
+    itemToString: PropTypes.func,
+
+    /**
+     * `onChange` is a utility for this controlled component to communicate to a
+     * consuming component what kind of internal state changes are occuring.
+     */
+    onChange: PropTypes.func,
+
+    /**
+     * Generic `label` that will be used as the textual representation of what
+     * this field is for
+     */
+    label: PropTypes.node.isRequired,
+  };
+
+  static defaultProps = {
+    disabled: false,
+    type: 'default',
+    itemToString: item => (item ? item.label : ''),
+    initialSelectedItems: [],
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      highlightedIndex: null,
+      isOpen: false,
+    };
+  }
+
+  handleOnChange = changes => {
+    if (this.props.onChange) {
+      this.props.onChange(changes);
+    }
+  };
+
+  handleOnToggleMenu = () => {
+    this.setState(state => ({
+      isOpen: !state.isOpen,
+    }));
+  };
+
+  handleOnOuterClick = () => {
+    this.setState({
+      isOpen: false,
+    });
+  };
+
+  handleOnStateChange = changes => {
+    const { type } = changes;
+    switch (type) {
+      case Downshift.stateChangeTypes.keyDownArrowDown:
+      case Downshift.stateChangeTypes.keyDownArrowUp:
+      case Downshift.stateChangeTypes.itemMouseEnter:
+        this.setState({ highlightedIndex: changes.highlightedIndex });
+        break;
+      case Downshift.stateChangeTypes.keyDownEscape:
+      case Downshift.stateChangeTypes.mouseUp:
+        this.setState({ isOpen: false });
+        break;
+      // Opt-in to some cases where we should be toggling the menu based on
+      // a given key press or mouse handler
+      // Reference: https://github.com/paypal/downshift/issues/206
+      case Downshift.stateChangeTypes.clickButton:
+      case Downshift.stateChangeTypes.keyDownSpaceButton:
+        this.handleOnToggleMenu();
+        break;
+    }
+  };
+
+  render() {
+    const { highlightedIndex, isOpen } = this.state;
+    const {
+      className: containerClassName,
+      items,
+      itemToString,
+      label,
+      type,
+      disabled,
+      initialSelectedItems,
+    } = this.props;
+    const className = cx('bx--multi-select', containerClassName);
+    return (
+      <Selection
+        onChange={this.handleOnChange}
+        initialSelectedItems={initialSelectedItems}
+        render={({ selectedItems, onItemChange, clearSelection }) => (
+          <Downshift
+            highlightedIndex={highlightedIndex}
+            isOpen={isOpen}
+            itemToString={itemToString}
+            onChange={onItemChange}
+            onStateChange={this.handleOnStateChange}
+            onOuterClick={this.handleOnOuterClick}
+            selectedItem={selectedItems}
+            render={({
+              getRootProps,
+              selectedItem,
+              isOpen,
+              itemToString,
+              highlightedIndex,
+              getItemProps,
+              getButtonProps,
+            }) => (
+              <ListBox
+                type={type}
+                className={className}
+                disabled={disabled}
+                {...getRootProps({ refKey: 'innerRef' })}>
+                <ListBox.Field {...getButtonProps({ disabled })}>
+                  {selectedItem.length > 0 && (
+                    <ListBox.Selection
+                      clearSelection={clearSelection}
+                      selectionCount={selectedItem.length}
+                    />
+                  )}
+                  <span className="bx--list-box__label">{label}</span>
+                  <ListBox.MenuIcon isOpen={isOpen} />
+                </ListBox.Field>
+                {isOpen && (
+                  <ListBox.Menu>
+                    {items.map((item, index) => {
+                      const itemProps = getItemProps({ item, index });
+                      const itemText = itemToString(item);
+                      const isChecked = selectedItem.indexOf(item) !== -1;
+                      return (
+                        <ListBox.MenuItem
+                          key={itemProps.id}
+                          isActive={selectedItem.indexOf(item) !== -1}
+                          isHighlighted={highlightedIndex === index}
+                          {...itemProps}>
+                          <Checkbox
+                            id={itemProps.id}
+                            name={itemText}
+                            checked={isChecked}
+                            readOnly={true}
+                            tabIndex="-1"
+                            labelText={itemText}
+                            iconDescription="Select this item"
+                          />
+                        </ListBox.MenuItem>
+                      );
+                    })}
+                  </ListBox.Menu>
+                )}
+              </ListBox>
+            )}
+          />
+        )}
+      />
+    );
+  }
+}

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -151,28 +151,30 @@ export default class MultiSelect extends React.Component {
                 </ListBox.Field>
                 {isOpen && (
                   <ListBox.Menu>
-                    {items.map((item, index) => {
-                      const itemProps = getItemProps({ item, index });
-                      const itemText = itemToString(item);
-                      const isChecked = selectedItem.indexOf(item) !== -1;
-                      return (
-                        <ListBox.MenuItem
-                          key={itemProps.id}
-                          isActive={selectedItem.indexOf(item) !== -1}
-                          isHighlighted={highlightedIndex === index}
-                          {...itemProps}>
-                          <Checkbox
-                            id={itemProps.id}
-                            name={itemText}
-                            checked={isChecked}
-                            readOnly={true}
-                            tabIndex="-1"
-                            labelText={itemText}
-                            iconDescription="Select this item"
-                          />
-                        </ListBox.MenuItem>
-                      );
-                    })}
+                    {items
+                      .sort(sortSelectedItems(selectedItems, itemToString))
+                      .map((item, index) => {
+                        const itemProps = getItemProps({ item });
+                        const itemText = itemToString(item);
+                        const isChecked = selectedItem.indexOf(item) !== -1;
+                        return (
+                          <ListBox.MenuItem
+                            key={itemProps.id}
+                            isActive={selectedItem.indexOf(item) !== -1}
+                            isHighlighted={highlightedIndex === index}
+                            {...itemProps}>
+                            <Checkbox
+                              id={itemProps.id}
+                              name={itemText}
+                              checked={isChecked}
+                              readOnly={true}
+                              tabIndex="-1"
+                              labelText={itemText}
+                              iconDescription="Select this item"
+                            />
+                          </ListBox.MenuItem>
+                        );
+                      })}
                   </ListBox.Menu>
                 )}
               </ListBox>
@@ -183,3 +185,21 @@ export default class MultiSelect extends React.Component {
     );
   }
 }
+
+const sortSelectedItems = (selectedItems, itemToString) => (itemA, itemB) => {
+  const hasItemA = selectedItems.includes(itemA);
+  const hasItemB = selectedItems.includes(itemB);
+
+  // Prefer whichever item is in the `selectedItems` array first
+  if (hasItemA && !hasItemB) {
+    return -1;
+  }
+
+  if (hasItemB && !hasItemA) {
+    return 1;
+  }
+
+  // Otherwise, we either have two selected items, or two un-selected items, so
+  // we just do a string comparison to see which comes first.
+  return itemToString(itemA).localeCompare(itemToString(itemB));
+};

--- a/src/components/MultiSelect/index.js
+++ b/src/components/MultiSelect/index.js
@@ -1,0 +1,1 @@
+export default from './MultiSelect';

--- a/src/internal/Selection.js
+++ b/src/internal/Selection.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class Selection extends React.Component {
+  static propTypes = {
+    initialSelectedItems: PropTypes.array.isRequired,
+  };
+
+  static defaultProps = {
+    initialSelectedItems: [],
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedItems: props.initialSelectedItems,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { selectedItems } = this.state;
+    const itemsToAdd = nextProps.initialSelectedItems.filter(item => {
+      return selectedItems.indexOf(item) === -1;
+    });
+
+    if (itemsToAdd.length > 0) {
+      this.setState(state => ({
+        selectedItems: state.selectedItems.concat(itemsToAdd),
+      }));
+    }
+  }
+
+  internalSetState = (stateToSet, callback) =>
+    this.setState(stateToSet, () => {
+      if (callback) {
+        callback();
+      }
+      if (this.props.onChange) {
+        this.props.onChange(this.state);
+      }
+    });
+
+  handleClearSelection = () => {
+    this.internalSetState({
+      selectedItems: [],
+    });
+  };
+
+  handleSelectItem = item => {
+    this.internalSetState(state => ({
+      selectedItems: state.selectedItems.concat(item),
+    }));
+  };
+
+  handleRemoveItem = index => {
+    this.internalSetState(state => ({
+      selectedItems: removeAtIndex(state.selectedItems, index),
+    }));
+  };
+
+  handleOnItemChange = item => {
+    const { selectedItems } = this.state;
+    const selectedIndex = selectedItems.indexOf(item);
+
+    if (selectedIndex === -1) {
+      this.handleSelectItem(item);
+      return;
+    }
+    this.handleRemoveItem(selectedIndex);
+  };
+
+  render() {
+    const { children, render } = this.props;
+    const { selectedItems } = this.state;
+    const renderProps = {
+      selectedItems,
+      onItemChange: this.handleOnItemChange,
+      clearSelection: this.handleClearSelection,
+    };
+
+    if (render !== undefined) {
+      return render(renderProps);
+    }
+
+    if (children !== undefined) {
+      return children(renderProps);
+    }
+
+    return null;
+  }
+}
+
+// Generic utility for safely removing an element at a given index from an
+// array.
+const removeAtIndex = (array, index) => {
+  const result = array.slice();
+  result.splice(index, 1);
+  return result;
+};

--- a/src/internal/__tests__/Selection-test.js
+++ b/src/internal/__tests__/Selection-test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import Selection from '../Selection';
+import { mount } from 'enzyme';
+
+describe('Selection', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      initialSelectedItems: [],
+      render: jest.fn(() => <div />),
+    };
+  });
+
+  it('should render', () => {
+    const wrapper = mount(<Selection {...mockProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should be able to add or remove an item from the callback props', () => {
+    const wrapper = mount(
+      <Selection
+        {...mockProps}
+        render={({ onItemChange }) => (
+          <button onClick={() => onItemChange(1)} />
+        )}
+      />
+    );
+    expect(wrapper.state('selectedItems').length).toBe(0);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state('selectedItems').length).toBe(1);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state('selectedItems').length).toBe(0);
+  });
+
+  it('should give a list of all selected items from the callback props', () => {
+    const wrapper = mount(
+      <Selection
+        {...mockProps}
+        render={({ selectedItems, onItemChange }) => (
+          <div>
+            <button onClick={() => onItemChange(1)} />
+            <ul>
+              {selectedItems.map((item, index) => <li key={index}>{item}</li>)}
+            </ul>
+          </div>
+        )}
+      />
+    );
+    expect(wrapper.find('li').length).toBe(0);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('li').length).toBe(1);
+  });
+
+  it('should be able to clear the selection from the callback props', () => {
+    const wrapper = mount(
+      <Selection
+        {...mockProps}
+        render={({ onItemChange, clearSelection }) => (
+          <div>
+            <button id="add-item" onClick={() => onItemChange(1)} />
+            <button id="clear-selection" onClick={clearSelection} />
+          </div>
+        )}
+      />
+    );
+    expect(wrapper.state('selectedItems')).toEqual([]);
+    wrapper.find('#add-item').simulate('click');
+    expect(wrapper.state('selectedItems')).toEqual([1]);
+    wrapper.find('#clear-selection').simulate('click');
+    expect(wrapper.state('selectedItems')).toEqual([]);
+  });
+});

--- a/src/internal/__tests__/__snapshots__/Selection-test.js.snap
+++ b/src/internal/__tests__/__snapshots__/Selection-test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Selection should render 1`] = `
+<Selection
+  initialSelectedItems={Array []}
+  render={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "clearSelection": [Function],
+            "onItemChange": [Function],
+            "selectedItems": Array [],
+          },
+        ],
+      ],
+    }
+  }
+>
+  <div />
+</Selection>
+`;

--- a/src/prop-types/childrenOf.js
+++ b/src/prop-types/childrenOf.js
@@ -17,6 +17,9 @@ const childrenOf = expectedChildTypes => {
 
   const validate = (props, propName, componentName) => {
     Children.forEach(props[propName], child => {
+      if (!child) {
+        return;
+      }
       const childDisplayName = getDisplayName(child.type || child);
       if (!expectedChildTypes.includes(child.type)) {
         throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,6 +623,12 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
+async@^2.0.0-rc.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^2.1.2, async@^2.1.4, async@^2.1.5:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
@@ -1768,12 +1774,6 @@ bindings@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
-bl@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
-  dependencies:
-    readable-stream "~2.0.5"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -2040,9 +2040,9 @@ caniuse-lite@^1.0.30000715, caniuse-lite@^1.0.30000744, caniuse-lite@^1.0.300007
   version "1.0.30000749"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000749.tgz#2ff382865aead8cca35dacfbab04f58effa4c01c"
 
-carbon-components@^8.1.3:
-  version "8.1.13"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.1.13.tgz#addec6b8f15c7f21938c52e4d669b293c813289b"
+carbon-components@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.2.0.tgz#716d655d61397423fff89b905c0570f6d2dd868c"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"
@@ -2976,6 +2976,10 @@ dot@^1.0.3:
 dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
+downshift@^1.23.2:
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.23.2.tgz#457435fc461eaaf51df6e81e8920aabca6bb8c33"
 
 duplexer2@~0.1.0:
   version "0.1.4"
@@ -6220,6 +6224,10 @@ output-file-sync@^1.1.2:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+p-cancelable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -6313,6 +6321,13 @@ parse-json@^4.0.0:
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
+parse-url@^1.3.0:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-1.3.11.tgz#57c15428ab8a892b1f43869645c711d0e144b554"
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
 
 parse5@^3.0.1:
   version "3.0.2"
@@ -7607,7 +7622,7 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-semantic-release@11.0.2:
+semantic-release@^11.0.2:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-11.0.2.tgz#2a09baa33a0e41926ac3290c8b110d22a5ba2a48"
   dependencies:


### PR DESCRIPTION
Adds MultiSelect to the project

#### Changelog

**New**

- `internal/Selection` for handling selections across dropdowns
- `components/MultiSelect/*` for MultiSelect

**Changed**

- Update `package.json` to bring in newer `carbon-components` and `downshift`
- `childrenOf` `prop-type` should ignore no children.

**Removed**
