### PR TITLE
chore: add valid version field for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "carbon-components-react",
+  "version": "5.5.1",
   "description": "A React wrapper for carbon-components",
   "license": "Apache-2",
   "main": "lib/index.js",


### PR DESCRIPTION
Add `version` field for new `semantic-release` dependency. In order to publish, it needs the version field apparently 😅 

#### Changelog

**New**

**Changed**

- `package.json` now has a `version` field 

**Removed**

  