### PR TITLE
fix(OverflowMenu): clobber DOM for closed overflow menu

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -28,19 +28,17 @@ describe('OverflowMenu', () => {
       expect(menu.hasClass('bx--overflow-menu--open')).not.toBe(true);
     });
 
-    it('should render a ul with the appropriate class', () => {
+    it('should not render a ul unless menu is open', () => {
       const list = menu.find('ul');
-
-      expect(list.length).toEqual(1);
-      expect(list.hasClass('bx--overflow-menu-options')).toEqual(true);
+      expect(list.length).toEqual(0);
     });
 
     it('should add extra classes that are passed via className', () => {
       expect(menu.hasClass('extra-class')).toEqual(true);
     });
 
-    it('should render children as expected', () => {
-      expect(menu.find('.test-child').length).toEqual(2);
+    it('should not render children unless the menu is open', () => {
+      expect(menu.find('.test-child').length).toEqual(0);
     });
 
     it('should set tabIndex if one is passed via props', () => {
@@ -78,12 +76,36 @@ describe('OverflowMenu', () => {
       expect(rootWrapper.props().open).toEqual(false);
     });
 
+    it('should render a ul with the appropriate class', () => {
+      const rootWrapper = mount(
+        <OverflowMenu>
+          <div className="test-child" />
+          <div className="test-child" />
+        </OverflowMenu>
+      );
+      rootWrapper.setState({ open: true });
+      rootWrapper.update();
+      const list = rootWrapper.find('ul');
+      expect(list.length).toEqual(1);
+      expect(list.hasClass('bx--overflow-menu-options')).toEqual(true);
+    });
+
+    it('should render children as expected', () => {
+      const rootWrapper = mount(
+        <OverflowMenu>
+          <div className="test-child" />
+          <div className="test-child" />
+        </OverflowMenu>
+      );
+      rootWrapper.setState({ open: true });
+      rootWrapper.update();
+      expect(rootWrapper.find('.test-child').length).toEqual(2);
+    });
+
     it('should set expected class when state is open', () => {
       const rootWrapper = mount(<OverflowMenu />);
-      const menuOptions = rootWrapper.find('ul');
       const openClass = 'bx--overflow-menu-options--open';
-
-      expect(menuOptions.hasClass(openClass)).not.toEqual(true);
+      expect(rootWrapper.find('ul').length).toEqual(0);
       rootWrapper.setState({ open: true });
       rootWrapper.update();
       expect(rootWrapper.find('ul').hasClass(openClass)).not.toEqual(false);

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -122,17 +122,19 @@ export default class OverflowMenu extends Component {
       ...other
     } = this.props;
 
+    const { open } = this.state;
+
     const overflowMenuClasses = classNames(
       this.props.className,
       'bx--overflow-menu',
       {
-        'bx--overflow-menu--open': this.state.open,
+        'bx--overflow-menu--open': open,
       }
     );
 
     const overflowMenuOptionsClasses = classNames('bx--overflow-menu-options', {
       'bx--overflow-menu--flip': this.props.flipped,
-      'bx--overflow-menu-options--open': this.state.open,
+      'bx--overflow-menu-options--open': open,
     });
 
     const overflowMenuIconClasses = classNames(
@@ -164,7 +166,7 @@ export default class OverflowMenu extends Component {
             description={iconDescription}
             style={{ width: '100%' }}
           />
-          {floatingMenu ? (
+          {!open ? null : floatingMenu ? (
             <FloatingMenu
               menuPosition={this.state.menuPosition}
               menuDirection="bottom"

--- a/src/components/Toolbar/Toolbar-test.js
+++ b/src/components/Toolbar/Toolbar-test.js
@@ -77,7 +77,7 @@ describe('Toolbar', () => {
     describe('with ToolbarTitle ', () => {
       const withToolbarTitle = mount(
         <ToolbarItem>
-          <OverflowMenu>
+          <OverflowMenu open={true}>
             <ToolbarTitle title="Test title" />
           </OverflowMenu>
         </ToolbarItem>
@@ -99,7 +99,7 @@ describe('Toolbar', () => {
     describe('with ToolbarOption ', () => {
       const withToolbarOption = mount(
         <ToolbarItem>
-          <OverflowMenu>
+          <OverflowMenu open={true}>
             <ToolbarOption>
               <div>Test child</div>
             </ToolbarOption>
@@ -123,7 +123,7 @@ describe('Toolbar', () => {
     describe('with ToolbarDivider ', () => {
       const withToolbarDivider = mount(
         <ToolbarItem>
-          <OverflowMenu>
+          <OverflowMenu open={true}>
             <ToolbarDivider />
           </OverflowMenu>
         </ToolbarItem>


### PR DESCRIPTION
Fixes #420. Wanted to see if this kind of change makes sense.

#### Changelog

**Changed**

With this change, the DOM for overflow menu is not rendered until it's open.