### PR TITLE
fix(FileUploader): use an alternate way to hide pseudo <input>

### DIFF
--- a/src/components/FileUploader/FileUploader-test.js
+++ b/src/components/FileUploader/FileUploader-test.js
@@ -48,8 +48,8 @@ describe('FileUploaderButton', () => {
       expect(mountWrapper.props().disableLabelChanges).toEqual(false);
     });
 
-    it('renders with default role', () => {
-      expect(mountWrapper.props().role).toEqual('button');
+    it('does not have default role', () => {
+      expect(mountWrapper.props().role).not.toBeTruthy();
     });
   });
 
@@ -103,7 +103,9 @@ describe('FileUploader', () => {
       ).toEqual(true);
     });
     it('renders input with hidden prop', () => {
-      expect(mountWrapper.find('input').props().hidden).toEqual(true);
+      expect(mountWrapper.find('input').props().className).toEqual(
+        'bx--visually-hidden'
+      );
     });
     it('renders with empty div.bx--file-container by default', () => {
       expect(mountWrapper.find('div.bx--file-container').text()).toEqual('');

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -27,7 +27,6 @@ export class FileUploaderButton extends Component {
     multiple: false,
     onChange: () => {},
     onClick: () => {},
-    role: 'button',
   };
   state = {
     labelText: this.props.labelText,
@@ -88,7 +87,7 @@ export class FileUploaderButton extends Component {
           {this.state.labelText}
         </label>
         <input
-          hidden
+          className="bx--visually-hidden"
           ref={input => (this.input = input)}
           id={this.uid}
           type="file"


### PR DESCRIPTION
Fixes #431.

#### Changelog

**Changed**

Use `bx--visually-hidden` CSS class instead of `hidden` attribute for the pseudo `<input>`.