### PR TITLE
chore(Prettier): Upgrade Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "node-sass": "4.6.0",
     "object-assign": "^4.1.1",
     "postcss-loader": "^2.0.5",
-    "prettier": "^1.7.4",
+    "prettier": "^1.10.0",
     "promise": "^8.0.1",
     "prop-types": "^15.5.8",
     "react": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6859,7 +6859,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.4:
+prettier@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 


### PR DESCRIPTION
Prettier changes DatePicker.js upon pre-commit hook. This change is for prevent that from happening.