### PR TITLE
test: add test-coverage step

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "yarn storybook",
     "storybook": "start-storybook -p 9000",
     "test": "jest",
+    "test-coverage": "jest --coverage",
     "test-ssr": "yarn build && node ssr-tests/*.js"
   },
   "keywords": [
@@ -221,7 +222,13 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "components/**/*.js"
+      "src/components/**/*.js",
+      "!src/components/**/*-story.js"
+    ],
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "html"
     ],
     "setupFiles": [
       "<rootDir>/config/jest/setup.js"


### PR DESCRIPTION
'npm test-coverage' generates coverage report in the 'coverage' folder, excluding storybooks.