### PR TITLE
fix(breadcrumb): refactored so it accepts react router links

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb-story.js
+++ b/src/components/Breadcrumb/Breadcrumb-story.js
@@ -19,8 +19,10 @@ storiesOf('Breadcrumb', module).addWithInfo(
     `,
   () => (
     <Breadcrumb {...additionalProps}>
-      <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
-      <BreadcrumbItem href="w#">Breadcrumb 2</BreadcrumbItem>
+      <BreadcrumbItem>
+        <a href="/#">Breadcrumb 1</a>
+      </BreadcrumbItem>
+      <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
       <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
     </Breadcrumb>
   )

--- a/src/components/BreadcrumbItem/BreadcrumbItem.js
+++ b/src/components/BreadcrumbItem/BreadcrumbItem.js
@@ -3,11 +3,21 @@ import React from 'react';
 import classnames from 'classnames';
 import Link from '../Link';
 
+const newChild = (children, href) => {
+  if (typeof children === 'string' && !(href === undefined)) {
+    return <Link href={href}>{children}</Link>;
+  } else {
+    return React.cloneElement(React.Children.only(children), {
+      className: 'bx--link',
+    });
+  }
+};
+
 const BreadcrumbItem = ({ children, className, href, ...other }) => {
   const classNames = classnames('bx--breadcrumb-item', className);
   return (
     <div className={classNames} {...other}>
-      <Link href={href}>{children}</Link>
+      {newChild(children, href)}
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4487,7 +4487,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@2.x.x, invariant@^2.2.0, invariant@^2.2.2:
+invariant@2.x.x, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:


### PR DESCRIPTION
Closes #279 

Refactored BreadcrumbItem to accept `react-router` links without showing a warning. 

#### Changelog

**Changed**

- `BreadcrumbItem`
