### PR TITLE
fix: onRequestSubmit not triggering in ComposedModal component

### DIFF
--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -265,7 +265,7 @@ export class ModalFooter extends Component {
 
         {primaryButtonText && (
           <Button
-            onClick={this.onRequestSubmit}
+            onClick={onRequestSubmit}
             className={primaryClass}
             disabled={primaryButtonDisabled}
             kind="primary">


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#440

Fixed issue where `ModalFooter` wasn't triggering onRequestSubmit when primary button is clicked

#### Changelog

**Changed**

- Updated `ModalFooter` to call `onRequestSubmit` prop since there's no local method `this.onRequestSubmit`