### PR TITLE
fix(date-picker): reset calendar when inputs are cleared

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -106,7 +106,7 @@ export default class DatePicker extends Component {
       this.toInputField.addEventListener('blur', () => {
         this.cal.close();
       });
-      this.toInputField.addEventListener('input', () => {
+      this.toInputField.addEventListener('change', () => {
         if (
           this.toInputField.value === '' &&
           cal.selectedDates.length > 0 &&

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -88,7 +88,17 @@ export default class DatePicker extends Component {
     ) {
       this.cal.destroy();
     }
+    this.inputField.removeEventListener(this.onChange);
+    if (this.toInputField) {
+      this.toInputField.removeEventListener(this.onChange);
+    }
   }
+
+  onChange = e => {
+    if (e.target.value === '' && this.cal.selectedDates.length > 0) {
+      this.cal.clear();
+    }
+  };
 
   addKeyboardEvents = cal => {
     const input = this.inputField;
@@ -97,24 +107,12 @@ export default class DatePicker extends Component {
         cal.calendarContainer.focus();
       }
     });
-    input.addEventListener('change', () => {
-      if (input.value === '' && cal.selectedDates.length > 0) {
-        cal.clear();
-      }
-    });
+    input.addEventListener('change', this.onChange);
     if (this.toInputField) {
       this.toInputField.addEventListener('blur', () => {
         this.cal.close();
       });
-      this.toInputField.addEventListener('change', () => {
-        if (
-          this.toInputField.value === '' &&
-          cal.selectedDates.length > 0 &&
-          !(input.value === '')
-        ) {
-          cal.clear();
-        }
-      });
+      this.toInputField.addEventListener('change', this.onChange);
     }
   };
 

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -97,11 +97,6 @@ export default class DatePicker extends Component {
         cal.calendarContainer.focus();
       }
     });
-    // input.addEventListener('input', () => {
-    //   if (input.value === '') {
-    //     cal.clear();
-    //   }
-    // });
     input.addEventListener('change', () => {
       if (input.value === '' && cal.selectedDates.length > 0) {
         cal.clear();

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -97,9 +97,28 @@ export default class DatePicker extends Component {
         cal.calendarContainer.focus();
       }
     });
+    // input.addEventListener('input', () => {
+    //   if (input.value === '') {
+    //     cal.clear();
+    //   }
+    // });
+    input.addEventListener('change', () => {
+      if (input.value === '' && cal.selectedDates.length > 0) {
+        cal.clear();
+      }
+    });
     if (this.toInputField) {
       this.toInputField.addEventListener('blur', () => {
         this.cal.close();
+      });
+      this.toInputField.addEventListener('input', () => {
+        if (
+          this.toInputField.value === '' &&
+          cal.selectedDates.length > 0 &&
+          !(input.value === '')
+        ) {
+          cal.clear();
+        }
       });
     }
   };


### PR DESCRIPTION
Closes #402 

Fixed DatePicker so when the inputs are cleared, the calendar gets reset.

#### Changelog

**Changed**

- `DatePicker.js`
