### PR TITLE
fix(DataTable): handle sorting for different primitive types

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -34,26 +34,26 @@ const initialRows = [
   {
     name: 'Load Balancer 3',
     protocol: 'HTTP',
-    something: '80',
+    something: 80,
     rule: 'Round Robin',
     attached_groups: 'Kevins VM Groups',
-    status: 'Active',
+    status: true,
   },
   {
     name: 'Load Balancer 1',
     protocol: 'HTTP',
-    something: '80',
+    something: 79,
     rule: 'Round Robin',
     attached_groups: 'Maureens VM Groups',
-    status: 'Active',
+    status: false,
   },
   {
     name: 'Load Balancer 2',
     protocol: 'HTTP',
-    something: '80',
+    something: 42,
     rule: 'Round Robin',
     attached_groups: 'Andrews VM Groups',
-    status: 'Active',
+    status: true,
   },
 ];
 
@@ -270,7 +270,7 @@ class BasicDataTable extends Component {
                     {headers.map(header => (
                       <DataTableColumnHeader
                         key={header.key}
-                        sortable={true}
+                        sortable={header.key !== 'status'}
                         {...getHeaderProps(header)}>
                         {header.title}
                       </DataTableColumnHeader>
@@ -293,6 +293,13 @@ class BasicDataTable extends Component {
                           }
                         />
                         {Object.keys(row).map((rowData, j) => {
+                          if (rowData === 'status') {
+                            return (
+                              <DataTableData key={`rowdata${j}`}>
+                                {row[rowData] ? 'Active' : 'Inactive'}
+                              </DataTableData>
+                            );
+                          }
                           return (
                             <DataTableData key={`rowdata${j}`}>
                               {row[rowData]}

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -13,24 +13,23 @@ const toggleSortDirection = direction => {
   return 'DESC';
 };
 
-const sortRow = (key, direction) => (a, b) => {
-  if (typeof a[key] === 'string' && typeof b[key] === 'string') {
-    if (direction === 'DESC') {
-      return a[key].localeCompare(b[key]);
-    }
+const sortRow = (key, direction, locale = 'en') => (a, b) => {
+  const itemA = String(a[key]);
+  const itemB = String(b[key]);
 
-    return b[key].localeCompare(a[key]);
+  if (typeof a[key] === 'boolean' && typeof b[key] === 'boolean') {
+    return null;
   }
 
-  if (typeof a[key] === 'number' && typeof b[key] === 'number') {
-    if (direction === 'DESC') {
-      return a[key] > b[key];
-    }
-
-    return b[key] > a[key];
+  if (direction === 'DESC') {
+    return itemA.localeCompare(itemB, locale, {
+      numeric: true,
+    });
   }
 
-  return null;
+  return itemB.localeCompare(itemA, locale, {
+    numeric: true,
+  });
 };
 
 export class DataTable extends Component {

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -14,11 +14,23 @@ const toggleSortDirection = direction => {
 };
 
 const sortRow = (key, direction) => (a, b) => {
-  if (direction === 'DESC') {
-    return a[key].localeCompare(b[key]);
+  if (typeof a[key] === 'string' && typeof b[key] === 'string') {
+    if (direction === 'DESC') {
+      return a[key].localeCompare(b[key]);
+    }
+
+    return b[key].localeCompare(a[key]);
   }
 
-  return b[key].localeCompare(a[key]);
+  if (typeof a[key] === 'number' && typeof b[key] === 'number') {
+    if (direction === 'DESC') {
+      return a[key] > b[key];
+    }
+
+    return b[key] > a[key];
+  }
+
+  return null;
 };
 
 export class DataTable extends Component {


### PR DESCRIPTION
Hi guys! I've been working with the new DataTable and wanted to contribute this upstream. Currently, the sorting only works if the table data is a string. This just checks what the primitive type is and sorts it appropriately.

I didn't think it made sense to sort boolean values, but if you disagree, let me know.

#### Changelog

**New**

- N/A

**Changed**

- Fixed a bug where the v2 table couldn't sort non-string values.

**Removed**

- N/A
