### PR TITLE
[RFC] feat: support UMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 es
 lib
+umd
 storybook-static
 
 # Logs

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   ],
   "files": [
     "lib/**/*",
-    "es/**/*"
+    "es/**/*",
+    "umd/**/*"
   ],
   "contributors": [
     {
@@ -119,6 +120,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.38",
     "@babel/core": "^7.0.0-beta.38",
+    "@babel/plugin-external-helpers": "^7.0.0-beta.38",
     "@babel/plugin-proposal-class-properties": "^7.0.0-beta.38",
     "@babel/preset-env": "^7.0.0-beta.38",
     "@babel/preset-react": "^7.0.0-beta.38",
@@ -134,6 +136,8 @@
     "bowser": "^1.6.1",
     "carbon-components": "^8.7.1",
     "carbon-icons": "^6.1.0",
+    "chalk": "^2.3.0",
+    "cli-table": "^0.3.0",
     "commitizen": "^2.9.5",
     "css-loader": "^0.28.4",
     "cz-conventional-changelog-components": "^1.0.0",
@@ -144,6 +148,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "gh-pages": "1.0.0",
+    "gzip-size": "^4.1.0",
     "husky": "^0.14.3",
     "jest": "^22.1.0",
     "lcov2badge": "^0.1.0",
@@ -159,6 +164,13 @@
     "react-test-renderer": "^16.1.0",
     "requestanimationframe": "^0.0.23",
     "rimraf": "^2.6.1",
+    "rollup": "^0.55.0",
+    "rollup-plugin-babel": "^4.0.0-beta.1",
+    "rollup-plugin-commonjs": "^8.2.0",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-sizes": "^0.4.0",
+    "rollup-plugin-uglify": "^3.0.0",
     "sass-loader": "^6.0.5",
     "semantic-release": "^12.2.2",
     "storybook-addon-a11y": "^3.0.0",
@@ -259,5 +271,6 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]
-  }
+  },
+  "bundleSizeThreshold": 60000
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,9 @@ const rootDir = path.resolve(__dirname, '../');
 const babelPath = path
   .resolve(__dirname, '../node_modules/.bin/babel')
   .replace(/ /g, '\\ ');
+const rollupPath = path
+  .resolve(__dirname, '../node_modules/.bin/rollup')
+  .replace(/ /g, '\\ ');
 const rimrafAsync = promisify(rimraf);
 
 const exec = (command, extraEnv) =>
@@ -26,8 +29,13 @@ const ignoreGlobs = ['**/__tests__/*', '**/*-test.js', '**/*-story.js'].join(
   ','
 );
 
-console.log('Deleting old build folders...');
-Promise.all([rimrafAsync(`${rootDir}/lib`), rimrafAsync(`${rootDir}/es`)])
+console.log('Deleting old build folders...'); // eslint-disable-line no-console
+
+Promise.all([
+  rimrafAsync(`${rootDir}/cjs`),
+  rimrafAsync(`${rootDir}/es`),
+  rimrafAsync(`${rootDir}/umd`),
+])
   .then(() => {
     exec(`${babelPath} src -q -d es --ignore "${ignoreGlobs}"`, {
       BABEL_ENV: 'es',
@@ -35,7 +43,20 @@ Promise.all([rimrafAsync(`${rootDir}/lib`), rimrafAsync(`${rootDir}/es`)])
     exec(`${babelPath} src -q -d lib --ignore "${ignoreGlobs}"`, {
       BABEL_ENV: 'cjs',
     });
+    exec(
+      `${rollupPath} -c scripts/rollup.config.js -o umd/carbon-components-react.js`,
+      {
+        NODE_ENV: 'development',
+      }
+    );
+    exec(
+      `${rollupPath} -c scripts/rollup.config.js -o umd/carbon-components-react.min.js`,
+      {
+        NODE_ENV: 'production',
+      }
+    );
   })
   .catch(error => {
-    throw error;
+    console.error('One of the commands failed:', error.stack); // eslint-disable-line no-console
+    process.exit(1);
   });

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const chalk = require('chalk');
+const Table = require('cli-table');
+const gzip = require('gzip-size');
+
+const commonjs = require('rollup-plugin-commonjs');
+const resolve = require('rollup-plugin-node-resolve');
+const babel = require('rollup-plugin-babel');
+const replace = require('rollup-plugin-replace');
+const uglify = require('rollup-plugin-uglify');
+const sizes = require('rollup-plugin-sizes');
+
+const packageJson = require('../package.json');
+const peerDependencies = Object.keys(packageJson.peerDependencies || {}).concat(
+  ['classnames', 'prop-types']
+);
+
+const env = process.env.NODE_ENV || 'development';
+const prodSettings =
+  env === 'development'
+    ? []
+    : [
+        uglify(),
+        sizes({
+          report(details) {
+            const table = new Table({
+              head: [
+                chalk.gray.yellow('Dependency/app'),
+                chalk.gray.yellow('Size'),
+              ],
+              colAligns: ['left', 'right'],
+            });
+            details.totals
+              .map(item => [chalk.white.bold(item.name), item.size])
+              .forEach(item => {
+                table.push(item);
+              });
+            console.log(`Sizes of app/dependencies:\n${table}`); // eslint-disable-line no-console
+            console.log('Total size:', details.total); // eslint-disable-line no-console
+          },
+        }),
+        {
+          ongenerate(bundle, details) {
+            const gzipSize = gzip.sync(details.code);
+            const { bundleSizeThreshold } = packageJson;
+            console.log('Total size (gzipped):', gzipSize); // eslint-disable-line no-console
+            if (gzipSize > bundleSizeThreshold) {
+              throw new RangeError(
+                `Exceeded size threshold of ${bundleSizeThreshold} bytes (gzipped)!`
+              );
+            }
+          },
+        },
+      ];
+
+process.env.BABEL_ENV = 'es';
+
+module.exports = {
+  input: 'src/index.js',
+  plugins: [
+    resolve({
+      jsnext: true,
+      main: true,
+    }),
+    commonjs({
+      include: 'node_modules/**',
+      sourceMap: true,
+      namedExports: {
+        'node_modules/react/index.js': [
+          'Children',
+          'Component',
+          'PureComponent',
+          'Fragment',
+          'PropTypes',
+          'createElement',
+        ],
+        'node_modules/react-dom/index.js': ['render'],
+      },
+    }),
+    babel({
+      exclude: ['node_modules/**'], // only transpile our source code
+    }),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env),
+    }),
+    ...prodSettings,
+  ],
+  external: peerDependencies,
+  output: {
+    name: 'CarbonComponentsReact',
+    format: 'umd',
+    globals: {
+      classnames: 'classNames',
+      'prop-types': 'PropTypes',
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      'carbon-icons': 'CarbonIcons',
+    },
+  },
+};


### PR DESCRIPTION
This change supports UMD in the build in our `lib` directory. This allows consumers to get quick prototype with `carbon-components-react` without scaffolding the build tool-chain.

#### Changelog

**Changed**

- CJS build now support UMD, while keeping compatible as CJS.