### PR TITLE
feat(Toggle): support onChange event

### DIFF
--- a/src/components/Toggle/Toggle-test.js
+++ b/src/components/Toggle/Toggle-test.js
@@ -60,6 +60,24 @@ describe('Toggle', () => {
   });
 
   describe('events', () => {
+    it('passes along onChange to <input>', () => {
+      const onChange = jest.fn();
+      const id = 'test-input';
+      const wrapper = mount(<Toggle id={id} onChange={onChange} />);
+
+      const input = wrapper.find('input');
+      const inputElement = input.instance();
+
+      inputElement.checked = true;
+      wrapper.find('input').simulate('change');
+
+      expect(
+        onChange.mock.calls.map(call =>
+          call.map((arg, i) => (i > 0 ? arg : arg.target))
+        )
+      ).toEqual([[inputElement]]);
+    });
+
     it('should invoke onToggle with expected arguments', () => {
       const onToggle = jest.fn();
       const id = 'test-input';

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -6,6 +6,7 @@ const Toggle = ({
   className,
   defaultToggled,
   toggled,
+  onChange,
   onToggle,
   id,
   labelA,
@@ -35,6 +36,7 @@ const Toggle = ({
         id={id}
         className="bx--toggle"
         onChange={evt => {
+          onChange && onChange(evt);
           onToggle(input.checked, id, evt);
         }}
         ref={el => {


### PR DESCRIPTION
Resolves #510.

#### Changelog

**New**

- `onChange` prop to `Toggle` - It works as if the handler attached directly to `<input>`.