### PR TITLE
Fix(dropdown): handle null children

### DIFF
--- a/src/components/Dropdown/Dropdown-test.js
+++ b/src/components/Dropdown/Dropdown-test.js
@@ -45,6 +45,17 @@ describe('Dropdown', () => {
       expect(dropdown.find('.test-child').length).toEqual(2);
     });
 
+    it('should handle null children', () => {
+      const dropdown = shallow(
+        <Dropdown>
+          {null}
+          <div className="test-child" />
+          {null}
+        </Dropdown>
+      );
+      expect(dropdown.find('.test-child').length).toEqual(1);
+    });
+
     it('should use correct icon', () => {
       const icon = mounted.find(Icon);
       expect(icon.props().name).toEqual('caret--down');

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -42,8 +42,8 @@ export default class Dropdown extends PureComponent {
     let matchingChild;
     React.Children.forEach(children, child => {
       if (
-        child.props.itemText === selectedText ||
-        child.props.value === value
+        child &&
+        (child.props.itemText === selectedText || child.props.value === value)
       ) {
         matchingChild = child;
       }
@@ -96,14 +96,17 @@ export default class Dropdown extends PureComponent {
       ...other
     } = this.props;
 
-    const children = React.Children.map(this.props.children, child =>
-      React.cloneElement(child, {
-        onClick: (...args) => {
-          child.props.onClick && child.props.onClick(...args);
-          this.handleItemClick(...args);
-        },
-      })
-    );
+    const children = React.Children
+      .toArray(this.props.children)
+      .filter(child => child)
+      .map(child =>
+        React.cloneElement(child, {
+          onClick: (...args) => {
+            child.props.onClick && child.props.onClick(...args);
+            this.handleItemClick(...args);
+          },
+        })
+      );
 
     const dropdownClasses = classNames({
       'bx--dropdown': true,

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -98,7 +98,7 @@ export default class Dropdown extends PureComponent {
 
     const children = React.Children
       .toArray(this.props.children)
-      .filter(child => child)
+      .filter(Boolean)
       .map(child =>
         React.cloneElement(child, {
           onClick: (...args) => {

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -96,8 +96,7 @@ export default class Dropdown extends PureComponent {
       ...other
     } = this.props;
 
-    const children = React.Children
-      .toArray(this.props.children)
+    const children = React.Children.toArray(this.props.children)
       .filter(Boolean)
       .map(child =>
         React.cloneElement(child, {


### PR DESCRIPTION
If the `Dropdown` is given `null` children, it breaks on rendering. You can see this behavior by editing the `story` for `Dropdown`:

```javascript
.addWithInfo(
    'with default text',
    `
      The Dropdown component is used for navigating or filtering existing content.
      Create Dropdown Item components for each option in the dropdown menu.
    `,
    () => (
      <Dropdown
        {...dropdownEvents}
        onChange={action('onChange')}
        defaultText="Dropdown label">
        <DropdownItem itemText="Option 1" value="option1" />
        <DropdownItem itemText="Option 2" value="option2" />
        {null}
        <DropdownItem itemText="Option 3" value="option3" />
        <DropdownItem itemText="Option 4" value="option4" />
        <DropdownItem itemText="Option 5" value="option5" />
      </Dropdown>
    )
  )
```

Results in this error:
![image](https://user-images.githubusercontent.com/20052710/35247680-f995a538-ff90-11e7-8d8d-5cbd064bf106.png)

The `React.Children` methods don't verify whether the child actually exists, so we added this safety net to make sure first. We ran into this because of some Dropdowns we had that were being populated with both synchronous & asynchronous information, and the `map` for the async data was temporarily returning `null`. 


