### PR TITLE
feat(Icon): Add support for Custom icons

### DIFF
--- a/src/components/Icon/Icon-story.js
+++ b/src/components/Icon/Icon-story.js
@@ -11,16 +11,47 @@ const props = {
   className: 'extra-class',
 };
 
-storiesOf('Icon', module).addWithInfo(
-  'Default',
-  `
-    Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see carbondesignsystem.com/style/iconography/library
-  `,
-  () => (
-    <div>
-      <Icon name="icon--add" {...props} />
-      <Icon name="add--glyph" {...props} />
-      <Icon name="add--outline" {...props} />
-    </div>
+storiesOf('Icon', module)
+  .addWithInfo(
+    'Default',
+    `
+      Icons are used in the product to present common actions and commands. Modify the fill property to change the color of the icon. The name property defines which icon to display. For accessibility, provide a context-rich description with the description prop. For a full list of icon names, see carbondesignsystem.com/style/iconography/library
+    `,
+    () => (
+      <div>
+        <Icon name="icon--add" {...props} />
+        <Icon name="add--glyph" {...props} />
+        <Icon name="add--outline" {...props} />
+      </div>
+    )
   )
-);
+  .addWithInfo(
+    'custom icon',
+    `
+      To use a custom icon, define an SVG symbol with a given ID somewhere in your HTML (either manually or using a tool such as 'svg-sprite-loader') and then pass that ID name to the Icon component using the special prefix of 'xlink--'. Custom icons can be used with other components that take a icon prop, such as Button.
+    `,
+    () => (
+      <div>
+        <svg style={{ position: 'absolute', width: 0, height: 0 }}>
+          <symbol viewBox="0 0 48 48" id="mycustomicon">
+            <g>
+              <polygon
+                fill="#3d70b2"
+                points="11.2968 16.0997 11.0268 16.2197 10.7558 16.0997 4.1938 13.3407 -0.0002 15.0797 4.4648 16.9397 11.0268 19.7597 17.5888 16.9397 22.0528 15.0807 22.0528 15.0797 17.8588 13.3407"
+              />
+              <polygon
+                fill="#41d6c3"
+                points="0 4.6796 4.194 6.4206 4.465 6.5396 4.6 6.6006 5.006 6.7806 9.132 8.5196 9.538 8.6996 9.944 8.8796 11.027 9.3596 12.109 8.8796 12.514 8.6996 12.92 8.5196 17.048 6.7806 17.453 6.6006 17.589 6.5396 17.859 6.4206 22.053 4.6796 22.053 4.6796 11.027 0.0006"
+              />
+              <polygon
+                fill="#5596e6"
+                points="11.2968 10.8698 11.0268 10.9908 10.7558 10.8698 4.1938 8.1108 -0.0002 9.8498 4.4648 11.7108 11.0268 14.5298 17.5888 11.7108 22.0528 9.8508 22.0528 9.8498 17.8588 8.1108"
+              />
+            </g>
+          </symbol>
+        </svg>
+
+        <Icon name="xlink--mycustomicon" {...props} />
+      </div>
+    )
+  );

--- a/src/components/Icon/Icon-test.js
+++ b/src/components/Icon/Icon-test.js
@@ -5,6 +5,7 @@ import Icon, {
   getSvgData,
   icons,
   isPrefixed,
+  isXlink,
 } from '../Icon';
 import { mount } from 'enzyme';
 
@@ -49,6 +50,23 @@ describe('Icon', () => {
 
     it('should recieve style props', () => {
       expect(wrapper.props().style).toEqual({ transition: '2s' });
+    });
+  });
+
+  describe('Renders custom icon as expected', () => {
+    const props = {
+      name: 'xlink--search--glyph',
+    };
+
+    const wrapper = mount(<Icon {...props} />);
+
+    it('should have expected <use> inside <svg>', () => {
+      expect(
+        wrapper
+          .find('svg')
+          .find('use')
+          .props().xlinkHref
+      ).toEqual('#search--glyph');
     });
   });
 
@@ -110,6 +128,18 @@ describe('Icon', () => {
 
     it('returns false when given a name without icon-- prefix', () => {
       const prefixed = isPrefixed('search--glyph');
+      expect(prefixed).toBe(false);
+    });
+  });
+
+  describe('isXlink', () => {
+    it('returns true when given a name with xlink-- prefix', () => {
+      const prefixed = isXlink('xlink--search--glyph');
+      expect(prefixed).toBe(true);
+    });
+
+    it('returns false when given a name without xlink-- prefix', () => {
+      const prefixed = isXlink('search--glyph');
       expect(prefixed).toBe(false);
     });
   });

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -75,6 +75,10 @@ export function isPrefixed(name) {
   return name.split('--')[0] === 'icon';
 }
 
+export function isXlink(name) {
+  return name.split('--')[0] === 'xlink';
+}
+
 const Icon = ({
   className,
   description,
@@ -102,7 +106,13 @@ const Icon = ({
     ...other,
   };
 
-  const svgContent = icon ? svgShapes(icon.svgData) : '';
+  const svgContent = icon ? (
+    svgShapes(icon.svgData)
+  ) : isXlink(name) ? (
+    <use xlinkHref={'#' + name.substring('xlink--'.length)} />
+  ) : (
+    ''
+  );
 
   return (
     <svg {...props} aria-label={description}>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#515

Add support for custom icons using an 'xlink' prefix in the icon name

#### Changelog

**New**

- Add support for custom icons using an 'xlink' prefix in the icon name
