### PR TITLE
feat(Card): support custom icon

### DIFF
--- a/src/components/CardContent/CardContent-test.js
+++ b/src/components/CardContent/CardContent-test.js
@@ -94,4 +94,53 @@ describe('CardContent', () => {
       });
     });
   });
+
+  describe('Supporting custom icon', () => {
+    it('supports rendering the given icon as-is', () => {
+      const props = {
+        cardIcon: (
+          <svg>
+            <title>foo</title>
+          </svg>
+        ),
+      };
+      const wrapper = shallow(<CardContent {...props} />);
+      expect(
+        wrapper.contains(
+          <svg>
+            <title>foo</title>
+          </svg>
+        )
+      ).toBe(true);
+    });
+
+    it('warns if icon description is given along with a custom icon', () => {
+      const spyWarn = jest.spyOn(console, 'warn');
+      try {
+        const props = {
+          cardIcon: (
+            <svg>
+              <title>foo</title>
+            </svg>
+          ),
+          iconDescription: 'icon-desc-foo',
+        };
+        const wrapper = shallow(<CardContent {...props} />);
+        expect(
+          wrapper.contains(
+            <svg>
+              <title>foo</title>
+            </svg>
+          )
+        ).toBe(true);
+        const message = [
+          'Specified a custom icon while the icon description is provided.',
+          "It'll be ignored as an icon description is only used for carbon-icons sprite.",
+        ].join('\n');
+        expect(spyWarn.mock.calls).toEqual([[message]]);
+      } finally {
+        spyWarn.mockRestore();
+      }
+    });
+  });
 });

--- a/src/components/CardContent/CardContent-test.js
+++ b/src/components/CardContent/CardContent-test.js
@@ -1,7 +1,10 @@
+import warning from 'warning';
 import React from 'react';
 import CardContent from '../CardContent';
 import Icon from '../Icon';
 import { shallow } from 'enzyme';
+
+jest.mock('warning', () => jest.fn());
 
 describe('CardContent', () => {
   describe('Renders as expected', () => {
@@ -115,32 +118,31 @@ describe('CardContent', () => {
     });
 
     it('warns if icon description is given along with a custom icon', () => {
-      const spyWarn = jest.spyOn(console, 'warn');
-      try {
-        const props = {
-          cardIcon: (
-            <svg>
-              <title>foo</title>
-            </svg>
-          ),
-          iconDescription: 'icon-desc-foo',
-        };
-        const wrapper = shallow(<CardContent {...props} />);
-        expect(
-          wrapper.contains(
-            <svg>
-              <title>foo</title>
-            </svg>
-          )
-        ).toBe(true);
-        const message = [
-          'Specified a custom icon while the icon description is provided.',
-          "It'll be ignored as an icon description is only used for carbon-icons sprite.",
-        ].join('\n');
-        expect(spyWarn.mock.calls).toEqual([[message]]);
-      } finally {
-        spyWarn.mockRestore();
-      }
+      const props = {
+        cardIcon: (
+          <svg>
+            <title>foo</title>
+          </svg>
+        ),
+        iconDescription: 'icon-desc-foo',
+      };
+      const wrapper = shallow(<CardContent {...props} />);
+      expect(
+        wrapper.contains(
+          <svg>
+            <title>foo</title>
+          </svg>
+        )
+      ).toBe(true);
+      const message = [
+        'Specified a custom icon while the icon description is provided.',
+        "It'll be ignored as an icon description is only used for carbon-icons sprite.",
+      ].join('\n');
+      expect(warning.mock.calls).toEqual([[false, message]]);
     });
+  });
+
+  afterEach(() => {
+    warning.mockReset();
   });
 });

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -1,3 +1,4 @@
+import warning from 'warning';
 import PropTypes from 'prop-types';
 import React, { isValidElement } from 'react';
 import classNames from 'classnames';
@@ -37,18 +38,11 @@ const CardContent = ({
   const cardLinkContentArray = Object.keys(cardLinkContent);
   const cardInfoContentArray = Object.keys(cardInfoContent);
 
-  if (
-    isValidElement(cardIcon) &&
-    iconDescription !== CardContent.defaultProps.iconDescription
-  ) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      [
-        'Specified a custom icon while the icon description is provided.',
-        "It'll be ignored as an icon description is only used for carbon-icons sprite.",
-      ].join('\n')
-    );
-  }
+  warning(
+    !isValidElement(cardIcon) ||
+      iconDescription === CardContent.defaultProps.iconDescription,
+    "Specified a custom icon while the icon description is provided.\nIt'll be ignored as an icon description is only used for carbon-icons sprite."
+  );
 
   return (
     <div {...other} className={cardContentClasses}>

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { isValidElement } from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 
@@ -37,17 +37,36 @@ const CardContent = ({
   const cardLinkContentArray = Object.keys(cardLinkContent);
   const cardInfoContentArray = Object.keys(cardInfoContent);
 
+  if (
+    isValidElement(cardIcon) &&
+    iconDescription !== CardContent.defaultProps.iconDescription
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      [
+        'Specified a custom icon while the icon description is provided.',
+        "It'll be ignored as an icon description is only used for carbon-icons sprite.",
+      ].join('\n')
+    );
+  }
+
   return (
     <div {...other} className={cardContentClasses}>
       {children}
       <div className="bx--card-overview__about">
-        <div className="bx--about__icon">
-          <Icon
-            className="bx--about__icon--img"
-            name={cardIcon}
-            description={iconDescription}
-          />
-        </div>
+        {cardIcon && (
+          <div className="bx--about__icon">
+            {isValidElement(cardIcon) ? (
+              cardIcon
+            ) : (
+              <Icon
+                className="bx--about__icon--img"
+                name={cardIcon}
+                description={iconDescription}
+              />
+            )}
+          </div>
+        )}
         <div className="bx--about__title">
           <p id="card-app-title" className="bx--about__title--name">
             {cardTitle}
@@ -61,12 +80,39 @@ const CardContent = ({
 };
 
 CardContent.propTypes = {
+  /**
+   * The child nodes.
+   */
   children: PropTypes.node,
-  cardIcon: PropTypes.string,
+
+  /**
+   * The name of icon sprite, or icon itself.
+   */
+  cardIcon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+  /**
+   * The title of the card.
+   */
   cardTitle: PropTypes.string,
+
+  /**
+   * A link to put in the card.
+   */
   cardLink: PropTypes.node,
+
+  /**
+   * Additional info to put in the card.
+   */
   cardInfo: PropTypes.array,
+
+  /**
+   * The CSS class names.
+   */
   className: PropTypes.string,
+
+  /**
+   * The description of the icon.
+   */
   iconDescription: PropTypes.string,
 };
 


### PR DESCRIPTION
Resolves #515.

#### Changelog

**New**

- `cardIcon` prop in `CardContent` now supports `PropTypes.node` - A custom icon (instead of `carbon-icons` sprite) in such case.