### PR TITLE
fix(InteriorLeftNav): allow arbitraty child node types

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -32,6 +32,7 @@ describe('InteriorLeftNav', () => {
             className="test-child">
             <a href="http://www.carbondesignsystem.com">test-title</a>
           </InteriorLeftNavItem>
+          <div data-child-div>foo</div>
         </InteriorLeftNav>
       );
       expect(interiorLeftNav.find('.left-nav-list').length).toEqual(2);
@@ -39,6 +40,11 @@ describe('InteriorLeftNav', () => {
       expect(
         interiorLeftNav.find('.bx--interior-left-nav-collapse').length
       ).toEqual(1);
+      expect(
+        interiorLeftNav
+          .find('[data-child-div]')
+          .matchesElement(<div data-child-div>foo</div>)
+      ).toBe(true);
     });
   });
 

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -97,14 +97,12 @@ export default class InteriorLeftNav extends Component {
     } = this.props;
 
     const newChildren = React.Children.map(children, (child, index) => {
-      let newChild;
       if (child.type === InteriorLeftNavList) {
-        newChild = this.buildNewListChild(child, index);
-      } else {
-        newChild = this.buildNewItemChild(child, index);
+        return this.buildNewListChild(child, index);
+      } else if (child.type === InteriorLeftNavItem) {
+        return this.buildNewItemChild(child, index);
       }
-
-      return newChild;
+      return child;
     });
 
     const classNames = classnames(


### PR DESCRIPTION
Fixes #534.

#### Changelog

**New**

- Support for arbitrary types of child nodes under `<InteriorLeftNav>`.