### PR TITLE
fix(Search): allow arbitrary React nodes for label

### DIFF
--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -10,7 +10,7 @@ export default class Search extends Component {
     type: PropTypes.string,
     small: PropTypes.bool,
     placeHolderText: PropTypes.string,
-    labelText: PropTypes.string.isRequired,
+    labelText: PropTypes.node.isRequired,
     id: PropTypes.string,
     searchButtonLabelText: PropTypes.string,
     layoutButtonLabelText: PropTypes.string,


### PR DESCRIPTION
Fixes #530.

#### Changelog

**New**

- Support for arbitrary React nodes for `labelText` property in `<Search>`.