### PR TITLE
Update Dropdown Role to Listbox

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -123,7 +123,7 @@ export default class Dropdown extends PureComponent {
           value={this.state.value}
           className={dropdownClasses}
           tabIndex={tabIndex}
-          role="presentation">
+          role="listbox">
           <li className="bx--dropdown-text">{this.state.selectedText}</li>
           <li>
             <Icon


### PR DESCRIPTION
The role presentation attached to dropdown isn't considered a form element. Therefore when partnered with a <label> we get an accessibility error:
```
The id "identifier" referenced by the 'for' attribute of a label element is not a valid form input element or an element with id "identifier" is either null or does not exist.
```

Changing the role to Listbox makes the dropdown act as if it is a select. However each child will need to also have the role option so screen readers know which children are selectable. See #545

References:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_listbox_role
https://www.w3.org/TR/wai-aria/roles#listbox