### PR TITLE
Update DropDownItem role to option

### DIFF
--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -9,6 +9,7 @@ const DropdownItem = ({
   onClick,
   onKeyPress,
   href,
+  selected,
   ...other
 }) => {
   const dropdownItemClasses = classNames({
@@ -40,6 +41,7 @@ const DropdownItem = ({
       onClick={handleClick}
       onKeyPress={handleKeypress}
       tabIndex={-1}
+      aria-selected={selected}
       role="option">
       <a
         href={href}
@@ -58,12 +60,14 @@ DropdownItem.propTypes = {
   onClick: PropTypes.func,
   onKeyPress: PropTypes.func,
   href: PropTypes.string,
+  selected: PropTypes.bool,
 };
 
 DropdownItem.defaultProps = {
   onClick: /* istanbul ignore next */ () => {},
   onKeyPress: /* istanbul ignore next */ () => {},
   href: '',
+  selected: false,
 };
 
 export default DropdownItem;

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -40,7 +40,7 @@ const DropdownItem = ({
       onClick={handleClick}
       onKeyPress={handleKeypress}
       tabIndex={-1}
-      role="menuitem">
+      role="option">
       <a
         href={href}
         onClick={/* istanbul ignore next */ evt => evt.preventDefault()}


### PR DESCRIPTION
The role menuitem attached to DropDownItem is usually used as a child under [menu or menubar](https://www.w3.org/TR/wai-aria/roles#menuitem).

With the change to the role to listbox, #544 , the children will need to have the role option.

References:
https://www.w3.org/TR/wai-aria/roles#option
