### PR TITLE
All images, or role=img, including SVGs need to have an alt tag

### DIFF
--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -105,7 +105,7 @@ const Icon = ({
   const svgContent = icon ? svgShapes(icon.svgData) : '';
 
   return (
-    <svg {...props} aria-label={description}>
+    <svg {...props} aria-label={description} alt={description}>
       <title>{description}</title>
       {svgContent}
     </svg>

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -26,6 +26,7 @@ exports[`ListBoxField should render 1`] = `
           role="img"
         >
           <svg
+            alt="Clear selected item"
             aria-label="Clear selected item"
             fillRule="evenodd"
             height="10"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -31,6 +31,7 @@ exports[`ListBoxSelection should render 1`] = `
       role="img"
     >
       <svg
+        alt="translation"
         aria-label="translation"
         fillRule="evenodd"
         height="10"
@@ -85,6 +86,7 @@ exports[`ListBoxSelection should render 2`] = `
       role="img"
     >
       <svg
+        alt="translation"
         aria-label="translation"
         fillRule="evenodd"
         height="10"

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -87,6 +87,7 @@ exports[`ModalWrapper should render 1`] = `
                 role="img"
               >
                 <svg
+                  alt="close the modal"
                   aria-label="close the modal"
                   className="bx--modal-close__icon"
                   fillRule="evenodd"


### PR DESCRIPTION
Although I disagree with this one because the title element is used by screen readers as the descriptor of svg's according to w3

```In order for elements with a role of img be perceivable, authors MUST provide alternative text or a label determined by the accessible name calculation.```

https://www.w3.org/TR/wai-aria/roles#img