### PR TITLE
chore(devenv): load polyfill into Storybook env

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import './polyfills';
 import './_container.scss';
 
 export default class Container extends Component {

--- a/.storybook/polyfills.js
+++ b/.storybook/polyfills.js
@@ -1,0 +1,4 @@
+import 'core-js/modules/es7.array.includes';
+import 'core-js/modules/es6.array.fill';
+import 'core-js/modules/es6.string.includes';
+import 'core-js/modules/es6.string.trim';

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install -S carbon-components-react carbon-components carbon-icons
 
 2. Components do not import any of the styles themselves, use the scss or css from `carbon-components` to bring in styling. You can also use the `unpkg` cdn to bring in the styles wholesale - `unpkg.com/carbon-components/css/carbon-components.css` aliases the latest css file.
 
+3. For older browsers (e.g. IE11), polyfills listed in [`carbon-components-react/.storybook/polyfills.js` file](./.storybook/polyfills.js) is required.
+
 ## Development
 
 Please refer to the [Contribution Guidelines](CONTRIBUTING.md) before starting any work.


### PR DESCRIPTION
Refs #533.

#### Changelog

**New**

- `.storybook/polyfills.js`, which let you run Storybook on IE11 as well as works as the list of required polyfills.