### PR TITLE
fix(DataTable): remove hard-coded ID for <Search>

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -230,6 +230,7 @@ class BasicDataTable extends Component {
               </DataTableActionList>
             </DataTableBatchActions>
             <DataTableSearch
+              id="id-search"
               onInput={this.searchTable}
               onChange={this.searchTable}
             />

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -346,7 +346,6 @@ export const DataTableSearch = props => {
         className={className}
         {...other}
         small
-        id="search-2"
         labelText="Filter table"
         placeHolderText="Search"
         onChange={onChange}

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -117,7 +117,11 @@ export default class Search extends Component {
     const {
       className,
       type,
-      id,
+      id = (this._inputId =
+        this._inputId ||
+        `search__input__id_${Math.random()
+          .toString(36)
+          .substr(2)}`),
       placeHolderText,
       labelText,
       small,


### PR DESCRIPTION
Also made a change to `<Search>` to make `id` prop fully optional.
Fixes #552.

#### Changelog

**New**

- ID auto-gen feature for `<Search>`

**Removed**

- Hard-coded ID in `<DataTableSearch>`