### PR TITLE
fix(story): make sure DataTable is using small primary button

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -249,7 +249,7 @@ class BasicDataTable extends Component {
                 iconDescription="Settings"
                 onClick={action('Toolbar Action 1')}
               />
-              <Button onClick={action('Add new row')} kind="primary">
+              <Button onClick={action('Add new row')} small kind="primary">
                 Add new
               </Button>
             </DataTableToolbarContent>


### PR DESCRIPTION
This will ensure anyone who uses the `DataTable` story will use the correct `Button` type. Closes https://github.com/carbon-design-system/carbon-components-react/issues/554