### PR TITLE
refactor(FloatingMenu): improved position calculation logic

### DIFF
--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -85,6 +85,7 @@ const Icon = ({
   role,
   style,
   width,
+  iconRef,
   ...other
 }) => {
   const icon = isPrefixed(name) ? findIcon(name) : findIcon(`icon--${name}`);
@@ -99,6 +100,7 @@ const Icon = ({
     style,
     viewBox: icon.viewBox,
     width: width || icon.width,
+    ref: iconRef,
     ...other,
   };
 
@@ -113,16 +115,60 @@ const Icon = ({
 };
 
 Icon.propTypes = {
+  /**
+   * The CSS class name.
+   */
   className: PropTypes.string,
+
+  /**
+   * The icon description.
+   */
   description: PropTypes.string.isRequired,
+
+  /**
+   * The `<svg>` `fill` attribute.
+   */
   fill: PropTypes.string,
+
+  /**
+   * The `<svg>` `fillRule` attribute.
+   */
   fillRule: PropTypes.string,
+
+  /**
+   * The `<svg>` `height` attribute.
+   */
   height: PropTypes.string,
+
+  /**
+   * The name in the sprite.
+   */
   name: PropTypes.string.isRequired,
+
+  /**
+   * The `role` attribute.
+   */
   role: PropTypes.string,
+
+  /**
+   * The CSS styles.
+   */
   style: PropTypes.object,
+
+  /**
+   * The `<svg>` `viewbox` attribute.
+   */
   viewBox: PropTypes.string,
+
+  /**
+   * The `<svg>` `width` attribute.
+   */
   width: PropTypes.string,
+
+  /**
+   * The `ref` callback for the icon.
+   */
+  iconRef: PropTypes.func,
 };
 
 Icon.defaultProps = {

--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -157,8 +157,7 @@ storiesOf('Tooltip', module)
         <Tooltip
           triggerText="Tooltip - no icon - left"
           direction="left"
-          showIcon={false}
-          menuOffset={{ left: 8 }}>
+          showIcon={false}>
           >
           <p className="bx--tooltip__label">Tooltip subtitle</p>
           <p>

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -36,7 +36,8 @@ describe('Tooltip', () => {
         triggerText="Tooltip"
         direction="bottom"
         menuOffset={{ left: 10, top: 15 }}
-        showIcon={false}>
+        showIcon={false}
+        open={true}>
         {' '}
         <p className="bx--tooltip__label">Tooltip label</p>
         <p>Lorem ipsum dolor sit amet</p>
@@ -63,7 +64,7 @@ describe('Tooltip', () => {
             .find('[data-floating-menu-direction]')
             .first()
             .prop('className')
-        ).toBe('bx--tooltip tooltip--class');
+        ).toBe('bx--tooltip bx--tooltip--shown tooltip--class');
       });
       it('sets the trigger class', () => {
         expect(trigger.prop('className')).toBe(


### PR DESCRIPTION
Did the following noted in the changelog. These would make us easier to make future enhancement to `<FloatingMenu>`, easing the complexity introduced to support code paths of with/without React portal API.

#### Changelog

**New**

* Enhanced `menuOffset` prop in `<FloatingMenu>` to support a callback to return the offset, e.g. to give `<OverflowMenu>` a chance to calculate the adjustment of non-centered menu arrow
* Enhanced `<Icon>` so that `<svg>` in it can be grabbed, to allow calculating tooltip position based on that, and the padding in the outer container doesnot affect the positioning

**Changed**

* Some changes to calculate the position in the right phase in the component lifecycle
* Hoisted several logic as non-class functions so that they are independent of class state
* Hidden tooltips are now removed from DOM

**Removed**

* Several hard-coded geometries to accomodate future style changes
