### PR TITLE
fix: resolves #409 by honoring selected attribute when selectedIndex is not set

### DIFF
--- a/src/components/ContentSwitcher/ContentSwitcher-test.js
+++ b/src/components/ContentSwitcher/ContentSwitcher-test.js
@@ -8,7 +8,7 @@ describe('ContentSwitcher', () => {
     const wrapper = shallow(
       <ContentSwitcher onChange={() => {}} className="extra-class">
         <Switch kind="anchor" text="one" />
-        <Switch kind="anchor" text="two" />
+        <Switch kind="anchor" text="two" selected />
       </ContentSwitcher>
     );
 
@@ -22,13 +22,32 @@ describe('ContentSwitcher', () => {
       expect(children.length).toEqual(2);
     });
 
-    it('should default "selected" property to true on first child', () => {
-      expect(children.first().props().selected).toEqual(true);
-      expect(children.last().props().selected).toEqual(false);
+    it('should honor selected property on selected child when selectedIndex is unspecified', () => {
+      expect(children.first().props().selected).toEqual(false);
+      expect(children.last().props().selected).toEqual(true);
     });
 
     it('should apply extra classes passed to it', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
+    });
+  });
+
+  describe('When selectedIndex and selected proprty on child are set', () => {
+    const wrapper = shallow(
+      <ContentSwitcher
+        selectedIndex={0}
+        onChange={() => {}}
+        className="extra-class">
+        <Switch kind="anchor" text="one" />
+        <Switch kind="anchor" text="two" selected />
+      </ContentSwitcher>
+    );
+
+    const children = wrapper.find(Switch);
+
+    it('should override selected property on child', () => {
+      expect(children.first().props().selected).toEqual(true);
+      expect(children.last().props().selected).toEqual(false);
     });
   });
 

--- a/src/components/ContentSwitcher/ContentSwitcher.js
+++ b/src/components/ContentSwitcher/ContentSwitcher.js
@@ -10,10 +10,6 @@ export default class ContentSwitcher extends React.Component {
     selectedIndex: PropTypes.number,
   };
 
-  static defaultProps = {
-    selectedIndex: 0,
-  };
-
   state = {
     selectedIndex: this.props.selectedIndex,
   };
@@ -24,7 +20,9 @@ export default class ContentSwitcher extends React.Component {
         index,
         onClick: this.handleChildChange,
         onKeyDown: this.handleChildChange,
-        selected: index === this.state.selectedIndex,
+        ...(typeof this.state.selectedIndex === 'number'
+          ? { selected: index === this.state.selectedIndex }
+          : {}),
       })
     );
   }


### PR DESCRIPTION
#### Changelog

**Changed**

- Addressed #409 by honoring selected property on child if selectedIndex is not specified.
