### PR TITLE
Fix on format on .gh-pages/coverage folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Test your changes by running our test commands:
   npm run test-watch
   ```
 
-* Generate code coverage report (stored in .gh-pages/coverage folder):
+* Generate code coverage report (stored in `.gh-pages/coverage` folder):
 
   ```
   npm run coverage


### PR DESCRIPTION


Closes carbon-design-system/carbon-components-react#

{{short description}}

#### Changelog

**New**

Added  ` to .gh-pages/coverage

**Changed**

Added backticks to the location of this folder: .gh-pages/coverage

**Removed**

Nothing removed
