### PR TITLE
feat(fileUploaded): Added accept attribute

### DIFF
--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -30,6 +30,7 @@ storiesOf('FileUploader', module)
         labelDescription="only .jpg files at 500mb or less"
         buttonLabel="Add files"
         filenameStatus="edit"
+        accept={['.jpg', '.png']}
         multiple
       />
     )

--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -27,7 +27,7 @@ storiesOf('FileUploader', module)
     () => (
       <FileUploader
         labelTitle="Upload"
-        labelDescription="only .jpg files at 500mb or less"
+        labelDescription="only .jpg and .png files at 500mb or less"
         buttonLabel="Add files"
         filenameStatus="edit"
         accept={['.jpg', '.png']}

--- a/src/components/FileUploader/FileUploader-test.js
+++ b/src/components/FileUploader/FileUploader-test.js
@@ -48,6 +48,10 @@ describe('FileUploaderButton', () => {
       expect(mountWrapper.props().disableLabelChanges).toEqual(false);
     });
 
+    it('renders with default accept prop', () => {
+      expect(mountWrapper.props().accept).toEqual([]);
+    });
+
     it('does not have default role', () => {
       expect(mountWrapper.props().role).not.toBeTruthy();
     });

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -18,6 +18,7 @@ export class FileUploaderButton extends Component {
     role: PropTypes.string,
     tabIndex: PropTypes.number,
     buttonKind: PropTypes.oneOf(['primary', 'secondary']),
+    accept: PropTypes.arrayOf(PropTypes.string),
   };
   static defaultProps = {
     tabIndex: 0,
@@ -27,6 +28,7 @@ export class FileUploaderButton extends Component {
     multiple: false,
     onChange: () => {},
     onClick: () => {},
+    accept: [],
   };
   state = {
     labelText: this.props.labelText,
@@ -62,6 +64,7 @@ export class FileUploaderButton extends Component {
       role,
       tabIndex,
       buttonKind,
+      accept,
       ...other
     } = this.props;
     const classes = classNames({
@@ -92,6 +95,7 @@ export class FileUploaderButton extends Component {
           id={this.uid}
           type="file"
           multiple={multiple}
+          accept={accept}
           onChange={this.handleChange}
         />
       </div>
@@ -167,6 +171,7 @@ export default class FileUploader extends Component {
     onChange: PropTypes.func,
     onClick: PropTypes.func,
     className: PropTypes.string,
+    accept: PropTypes.arrayOf(PropTypes.string),
   };
 
   static defaultProps = {
@@ -177,6 +182,7 @@ export default class FileUploader extends Component {
     multiple: false,
     onChange: () => {},
     onClick: () => {},
+    accept: [],
   };
 
   state = {
@@ -214,6 +220,7 @@ export default class FileUploader extends Component {
       labelTitle,
       className,
       multiple,
+      accept,
       ...other
     } = this.props;
 
@@ -232,6 +239,7 @@ export default class FileUploader extends Component {
           buttonKind={buttonKind}
           onChange={this.handleChange}
           disableLabelChanges
+          accept={accept}
         />
         <div className="bx--file-container">
           {this.state.filenames.length === 0


### PR DESCRIPTION
The input type=file has an attribute, `accept`, that allows the user to set which file types the input accepts. It doesn't actually prevent upload of other files, but it does make the user's process of finding files that will be accepted easier.

Reference:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file