### PR TITLE
fix(pagination): remove | when pageInputDisabled is true

### DIFF
--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -188,16 +188,17 @@ export default class PaginationV2 extends Component {
           <button
             className="bx--pagination__button bx--pagination__button--backward"
             onClick={this.decrementPage}
-            disabled={this.props.disabled || statePage === 1}>
+            disabled={this.props.disabled || statePage === 1}
+            style={
+              pageInputDisabled ? { borderRight: 0, marginRight: '1px' } : null
+            }>
             <Icon
               className="bx--pagination__button-icon"
               name="chevron--left"
               description={backwardText}
             />
           </button>
-          {pageInputDisabled ? (
-            <span className="bx--pagination__text">|</span>
-          ) : (
+          {pageInputDisabled ? null : (
             <Select
               id={`bx-pagination-select-${inputId + 2}`}
               labelText={itemsPerPageText}

--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -144,6 +144,13 @@ export default class PaginationV2 extends Component {
     const statePage = this.state.page;
     const statePageSize = this.state.pageSize;
     const classNames = classnames('bx--pagination', className);
+    const backButtonClasses = classnames(
+      'bx--pagination__button',
+      'bx--pagination__button--backward',
+      {
+        'bx--pagination__button--no-index': pageInputDisabled,
+      }
+    );
     const inputId = id || this.uniqueId;
     const totalPages = Math.ceil(totalItems / statePageSize);
     const selectItems = this.renderSelectItems(totalPages);
@@ -186,12 +193,9 @@ export default class PaginationV2 extends Component {
               : pageRangeText(statePage, Math.ceil(totalItems / statePageSize))}
           </span>
           <button
-            className="bx--pagination__button bx--pagination__button--backward"
+            className={backButtonClasses}
             onClick={this.decrementPage}
-            disabled={this.props.disabled || statePage === 1}
-            style={
-              pageInputDisabled ? { borderRight: 0, marginRight: '1px' } : null
-            }>
+            disabled={this.props.disabled || statePage === 1}>
             <Icon
               className="bx--pagination__button-icon"
               name="chevron--left"


### PR DESCRIPTION
Instead of placing a `|` with no padding, it will now render nothing. Added some conditional styles to prevent a double border / outline being hidden under other button.

<img width="923" alt="screen shot 2018-02-22 at 10 23 06 am" src="https://user-images.githubusercontent.com/11928039/36550456-f66d211e-17ba-11e8-950b-60020d67ecb2.png">

<img width="606" alt="screen shot 2018-02-22 at 10 23 00 am" src="https://user-images.githubusercontent.com/11928039/36550476-fe0f0be4-17ba-11e8-9263-9bcf8aa77a84.png">

Closes https://github.com/carbon-design-system/carbon-components-react/issues/637