### PR TITLE
fix(Slider): ensure emitting number with onChange

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -148,7 +148,7 @@ export default class Slider extends PureComponent {
           prevState,
           props
         );
-        const newValue = fromInput ? evt.target.value : newSliderValue;
+        const newValue = fromInput ? Number(evt.target.value) : newSliderValue;
         if (prevState.left === left && prevState.value === newValue) {
           return { dragging: false };
         }


### PR DESCRIPTION
Refs #645. Addresses https://github.com/carbon-design-system/carbon-components-react/issues/645#issuecomment-368619856, ensuring emitting number for `onChange`.

#### Changelog

**Changed**

- The value of `onChange` upon change in `<input>` is now a number, instead of a string.