### PR TITLE
feat(Dropdown): Add onOpen and onClose props

### DIFF
--- a/src/components/Dropdown/Dropdown-story.js
+++ b/src/components/Dropdown/Dropdown-story.js
@@ -22,6 +22,8 @@ storiesOf('Dropdown', module)
       <Dropdown
         {...dropdownEvents}
         onChange={action('onChange')}
+        onOpen={action('onOpen')}
+        onClose={action('onClose')}
         defaultText="Dropdown label">
         <DropdownItem itemText="Option 1" value="option1" />
         <DropdownItem itemText="Option 2" value="option2" />
@@ -41,6 +43,8 @@ storiesOf('Dropdown', module)
       <Dropdown
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
+        onOpen={action('onOpen')}
+        onClose={action('onClose')}
         defaultText="Option 1"
         value="all">
         <DropdownItem itemText="Option 1" value="option1" />
@@ -61,6 +65,8 @@ storiesOf('Dropdown', module)
       <Dropdown
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
+        onOpen={action('onOpen')}
+        onClose={action('onClose')}
         defaultText="Dropdown label"
         disabled>
         <DropdownItem itemText="Option 1" value="option1" />
@@ -81,6 +87,8 @@ storiesOf('Dropdown', module)
       <Dropdown
         {...dropdownEvents}
         onChange={selectedItemInfo => console.log(selectedItemInfo)}
+        onOpen={action('onOpen')}
+        onClose={action('onClose')}
         defaultText="Dropdown label"
         value="all"
         selectedText="Option 4">

--- a/src/components/Dropdown/Dropdown-test.js
+++ b/src/components/Dropdown/Dropdown-test.js
@@ -98,9 +98,11 @@ describe('Dropdown', () => {
 
   describe('events', () => {
     const onClick = jest.fn();
+    const onOpen = jest.fn();
+    const onClose = jest.fn();
 
     const wrapper = mount(
-      <Dropdown onClick={onClick}>
+      <Dropdown onClick={onClick} onOpen={onOpen} onClose={onClose}>
         <DropdownItem
           className="test-child"
           itemText="test-child"
@@ -158,6 +160,17 @@ describe('Dropdown', () => {
       const listener = wrapper.find(ClickListener);
       listener.props().onClickOutside();
       expect(wrapper.state().open).toBe(false);
+    });
+
+    it('fires open and close callbacks when the dropdown is clicked', () => {
+      onOpen.mockReset();
+      onClose.mockReset();
+      dropdown.simulate('click');
+      expect(onOpen).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+      dropdown.simulate('click');
+      expect(onOpen).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
     });
 
     it('should not open when disabled', () => {

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -13,6 +13,8 @@ export default class Dropdown extends PureComponent {
     tabIndex: PropTypes.number,
     onClick: PropTypes.func,
     onChange: PropTypes.func.isRequired,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
     selectedText: PropTypes.string,
     open: PropTypes.bool,
     iconDescription: PropTypes.string,
@@ -25,6 +27,8 @@ export default class Dropdown extends PureComponent {
     disabled: false,
     iconDescription: 'open list of options',
     onChange: () => {},
+    onOpen: () => {},
+    onClose: () => {},
   };
 
   constructor(props) {
@@ -34,6 +38,15 @@ export default class Dropdown extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     this.setState(this.resetState(nextProps));
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.open && this.state.open) {
+      this.props.onOpen();
+    }
+    if (prevState.open && !this.state.open) {
+      this.props.onClose();
+    }
   }
 
   resetState(props) {
@@ -93,6 +106,8 @@ export default class Dropdown extends PureComponent {
       iconDescription,
       disabled,
       selectedText, // eslint-disable-line no-unused-vars
+      onOpen, // eslint-disable-line no-unused-vars
+      onClose, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#655

#### Changelog

**New**

- To the `Dropdown` component, added two new properties `onOpen` which is called with no arguments when the dropdown is opened, and `onClose` which is called with no arguments when the dropdown is closed.
- Added these to `Dropdown-story.js` for demonstration purposes too.
- Tests.
