### PR TITLE
fix(code-snippet): fixed keyboard interaction

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.js
+++ b/src/components/CodeSnippet/CodeSnippet.js
@@ -16,7 +16,7 @@ const CodeSnippet = ({
   const wrapperClasses = classNames('bx--snippet', className, snippetType);
   return (
     <div className={wrapperClasses} {...other}>
-      <div className="bx--snippet-container">
+      <div role="textbox" tabIndex={0} className="bx--snippet-container">
         <code>
           <pre ref={wrappedContentRef}>{children}</pre>
         </code>


### PR DESCRIPTION
Closes #602 

Added `role` and `tabIndex` to the snippet container so you can focus on it using the keyboard, and use the arrow keys to scroll the content.

#### Changelog

**Changed**

* `CodeSnippet.js`
