### PR TITLE
fix(modal): add role to inner modal content

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -91,6 +91,7 @@ export default class Modal extends Component {
         ref={modal => {
           this.innerModal = modal;
         }}
+        role="dialog"
         className="bx--modal-container">
         <div className="bx--modal-header">
           {passiveModal && modalButton}

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -60,6 +60,7 @@ exports[`ModalWrapper should render 1`] = `
       >
         <div
           className="bx--modal-container"
+          role="dialog"
         >
           <div
             className="bx--modal-header"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#599

Adds WAI-ARIA role to `Modal` 

#### Changelog

**New**

* `role="dialog"` to the inner `Modal` container

