### PR TITLE
fix(container): add role of main to storybook container

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -8,6 +8,7 @@ export default class Container extends Component {
 
     return (
       <div
+        role="main"
         style={{
           padding: '3em',
           display: 'flex',


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#611
Closes https://github.com/carbon-design-system/carbon-components-react/issues/616


#### Changelog

**New**
- `role="main"` added to the main storybook `Container`

