### PR TITLE
feat: support control tooltip open state with prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ npm install -S carbon-components-react carbon-components carbon-icons
 yarn add carbon-components-rect carbon-components carbon-icons
 ```
 
-1.  These components require the use of [Webpack](http://webpack.github.io/docs/tutorials/getting-started/) in your project. See our [`webpack.config.js`](/.storybook/webpack.config.js) for an example configuration.
+1. These components require the use of [Webpack](http://webpack.github.io/docs/tutorials/getting-started/) in your project. See our [`webpack.config.js`](/.storybook/webpack.config.js) for an example configuration.
 
-2.  Components do not import any of the styles themselves, use the scss or css from `carbon-components` to bring in styling. You can also use the `unpkg` cdn to bring in the styles wholesale - `unpkg.com/carbon-components/css/carbon-components.css` aliases the latest css file.
+2. Components do not import any of the styles themselves, use the scss or css from `carbon-components` to bring in styling. You can also use the `unpkg` cdn to bring in the styles wholesale - `unpkg.com/carbon-components/css/carbon-components.css` aliases the latest css file.
 
-3.  For older browsers (e.g. IE11), polyfills listed in [`carbon-components-react/.storybook/polyfills.js` file](./.storybook/polyfills.js) is required.
+3. For older browsers (e.g. IE11), polyfills listed in [`carbon-components-react/.storybook/polyfills.js` file](./.storybook/polyfills.js) is required.
 
 ## Development
 
@@ -34,17 +34,17 @@ Please refer to the [Contribution Guidelines](./.github/CONTRIBUTING.md) before 
 
 We recommend the use of [React Storybook](https://github.com/storybooks/react-storybook) for developing components.
 
-1.  Start the server:
+1. Start the server:
 
-    ```
-    $ yarn storybook
-    ```
+   ```
+   $ yarn storybook
+   ```
 
-2.  Open browser to `http://localhost:9000/`.
+2. Open browser to `http://localhost:9000/`.
 
-3.  Develop components in their respective folders (`/components` or `/internal`).
+3. Develop components in their respective folders (`/components` or `/internal`).
 
-4.  Write stories for your components in `/.storybook`.
+4. Write stories for your components in `/.storybook`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,31 +20,31 @@ npm install -S carbon-components-react carbon-components carbon-icons
 yarn add carbon-components-rect carbon-components carbon-icons
 ```
 
-1. These components require the use of [Webpack](http://webpack.github.io/docs/tutorials/getting-started/) in your project. See our [`webpack.config.js`](/.storybook/webpack.config.js) for an example configuration.
+1.  These components require the use of [Webpack](http://webpack.github.io/docs/tutorials/getting-started/) in your project. See our [`webpack.config.js`](/.storybook/webpack.config.js) for an example configuration.
 
-2. Components do not import any of the styles themselves, use the scss or css from `carbon-components` to bring in styling. You can also use the `unpkg` cdn to bring in the styles wholesale - `unpkg.com/carbon-components/css/carbon-components.css` aliases the latest css file.
+2.  Components do not import any of the styles themselves, use the scss or css from `carbon-components` to bring in styling. You can also use the `unpkg` cdn to bring in the styles wholesale - `unpkg.com/carbon-components/css/carbon-components.css` aliases the latest css file.
 
-3. For older browsers (e.g. IE11), polyfills listed in [`carbon-components-react/.storybook/polyfills.js` file](./.storybook/polyfills.js) is required.
+3.  For older browsers (e.g. IE11), polyfills listed in [`carbon-components-react/.storybook/polyfills.js` file](./.storybook/polyfills.js) is required.
 
 ## Development
 
-Please refer to the [Contribution Guidelines](./github/CONTRIBUTING.md) before starting any work.
+Please refer to the [Contribution Guidelines](./.github/CONTRIBUTING.md) before starting any work.
 
 ### Using the server
 
 We recommend the use of [React Storybook](https://github.com/storybooks/react-storybook) for developing components.
 
-1. Start the server:
+1.  Start the server:
 
-   ```
-   $ yarn storybook
-   ```
+    ```
+    $ yarn storybook
+    ```
 
-2. Open browser to `http://localhost:9000/`.
+2.  Open browser to `http://localhost:9000/`.
 
-3. Develop components in their respective folders (`/components` or `/internal`).
+3.  Develop components in their respective folders (`/components` or `/internal`).
 
-4. Write stories for your components in `/.storybook`.
+4.  Write stories for your components in `/.storybook`.
 
 ## Contributing
 

--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -161,6 +161,16 @@ describe('Tooltip', () => {
       rootWrapper.instance().handleClickOutside();
       expect(rootWrapper.state().open).toEqual(false);
     });
+
+    it('prop.open change should update open state', () => {
+      const rootWrapper = mount(<Tooltip open={false} triggerText="Tooltip" />);
+      expect(rootWrapper.state().open).toEqual(false);
+      rootWrapper.setProps({
+        open: true,
+        triggerText: 'Tooltip',
+      });
+      expect(rootWrapper.state().open).toEqual(true);
+    });
   });
 
   describe('getTriggerPosition', () => {

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -151,6 +151,15 @@ export default class Tooltip extends Component {
     });
   }
 
+  componentWillReceiveProps(newProps) {
+    /**
+     * so that tooltip can be controlled programmatically thru this `open` prop
+     */
+    this.setState({
+      open: newProps.open,
+    });
+  }
+
   getTriggerPosition = () => {
     if (this.triggerEl) {
       const triggerPosition = this.triggerEl.getBoundingClientRect();


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#669

support control tooltip open state by `props.open`

#### Changelog

**Changed**

* update tooltip internal open state when the prop `open` changed

