### PR TITLE
fix(multi-select): swap selectable, multi select styles. Bug fixes

### DIFF
--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import uid from '../../tools/uniqueId';
 import Icon from '../Icon';
+import classNames from 'classnames';
 
 export default class RadioTile extends React.Component {
   static propTypes = {
@@ -28,8 +29,12 @@ export default class RadioTile extends React.Component {
   render() {
     const { children, ...other } = this.props;
 
+    const classes = classNames('bx--tile', 'bx--tile--selectable', {
+      'bx--tile--is-selected': this.props.checked,
+    });
+
     return (
-      <label htmlFor={this.uid} className="bx--tile bx--tile--selectable">
+      <label htmlFor={this.uid} className={classes}>
         <input
           {...other}
           type="radio"

--- a/src/components/Tile/Tile-story.js
+++ b/src/components/Tile/Tile-story.js
@@ -55,10 +55,10 @@ storiesOf('Tile', module)
          Although you can set the checked prop on the Tile, when using the RadioTile component
          as a child of the Tile Group, either set the defaultSelected or valueSelected which will
          automatically set the selected prop on the corresponding RadioTile component.
-  
+
          Use defaultSelected when you want a tile to be selected initially, but don't need to set it
          at a later time. If you do need to set it dynamically at a later time, then use the valueSelected property instead.
-  
+
          Use this to select one tile at a time.
       `,
     () => (

--- a/src/components/Tile/Tile-test.js
+++ b/src/components/Tile/Tile-test.js
@@ -97,16 +97,6 @@ describe('Tile', () => {
       expect(wrapper.hasClass('extra-class')).toEqual(true);
     });
 
-    it('toggles the selectable class on click', () => {
-      expect(wrapper.children().hasClass('bx--tile--is-selected')).toEqual(
-        false
-      );
-      wrapper.simulate('click');
-      expect(wrapper.children().hasClass('bx--tile--is-selected')).toEqual(
-        true
-      );
-    });
-
     it('toggles the selectable state on click', () => {
       expect(wrapper.state().selected).toEqual(false);
       wrapper.simulate('click');

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -168,14 +168,7 @@ export class SelectableTile extends Component {
       ...other
     } = this.props;
 
-    const classes = classNames(
-      'bx--tile',
-      'bx--tile--selectable',
-      {
-        'bx--tile--is-selected': this.state.selected,
-      },
-      className
-    );
+    const classes = classNames('bx--tile', 'bx--tile--selectable', className);
 
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -38,7 +38,8 @@ export default class TileGroup extends React.Component {
   }
 
   getRadioTiles = () => {
-    const children = React.Children.map(this.props.children, tileRadio => {
+    const childrenArray = React.Children.toArray(this.props.children);
+    const children = childrenArray.map(tileRadio => {
       const { value, ...other } = tileRadio.props;
       /* istanbul ignore if */
       if (tileRadio.props.hasOwnProperty('checked')) {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#681

This swaps single select and multiselect border styles

#### Changelog

**Changed**

* swapped single select and multiselect styles
* ensure omitted tiles do not break rendering
