### PR TITLE
feat: open prop will override any event handler

### DIFF
--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -120,6 +120,24 @@ describe('Tooltip', () => {
       expect(wrapper.state().open).toEqual(false);
     });
 
+    it("click doesn't change state when both clickToOpen and open are set", () => {
+      const wrapper = mount(<Tooltip clickToOpen open triggerText="Tooltip" />);
+      const icon = wrapper.find(Icon);
+      icon.simulate('click');
+      expect(wrapper.state().open).toEqual(true);
+      icon.simulate('click');
+      expect(wrapper.state().open).toEqual(true);
+
+      const wrapper2 = mount(
+        <Tooltip clickToOpen open={false} triggerText="Tooltip" />
+      );
+      const icon2 = wrapper2.find(Icon);
+      icon2.simulate('click');
+      expect(wrapper2.state().open).toEqual(false);
+      icon2.simulate('click');
+      expect(wrapper2.state().open).toEqual(false);
+    });
+
     it('hover does not change state when clickToOpen is set', () => {
       const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
       const icon = wrapper.find(Icon);
@@ -129,8 +147,42 @@ describe('Tooltip', () => {
       expect(wrapper.state().open).toEqual(false);
     });
 
+    it('hover does not change state when open is set', () => {
+      const wrapper = mount(<Tooltip open={false} triggerText="Tooltip" />);
+      const icon = wrapper.find(Icon);
+      icon.simulate('mouseover');
+      expect(wrapper.state().open).toEqual(false);
+      icon.simulate('mouseout');
+      expect(wrapper.state().open).toEqual(false);
+
+      const wrapper2 = mount(<Tooltip open triggerText="Tooltip" />);
+      const icon2 = wrapper2.find(Icon);
+      icon2.simulate('mouseover');
+      expect(wrapper2.state().open).toEqual(true);
+      icon2.simulate('mouseout');
+      expect(wrapper2.state().open).toEqual(true);
+    });
+
     it('Enter key press changes state when clickToOpen is set', () => {
       const wrapper = mount(<Tooltip clickToOpen triggerText="Tooltip" />);
+      const icon = wrapper.find(Icon);
+      icon.simulate('keyDown', { which: 'Enter' });
+      expect(wrapper.state().open).toEqual(true);
+      icon.simulate('keyDown', { key: 13 });
+      expect(wrapper.state().open).toEqual(false);
+    });
+
+    it("Enter key press doesn't changes state when open is set", () => {
+      const wrapper = mount(<Tooltip open={false} triggerText="Tooltip" />);
+      const icon = wrapper.find(Icon);
+      icon.simulate('keyDown', { which: 'Enter' });
+      expect(wrapper.state().open).toEqual(false);
+      icon.simulate('keyDown', { key: 13 });
+      expect(wrapper.state().open).toEqual(false);
+    });
+
+    it('Enter key press changes state when open is not set', () => {
+      const wrapper = mount(<Tooltip triggerText="Tooltip" />);
       const icon = wrapper.find(Icon);
       icon.simulate('keyDown', { which: 'Enter' });
       expect(wrapper.state().open).toEqual(true);

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -141,7 +141,7 @@ export default class Tooltip extends Component {
   };
 
   state = {
-    open: this.props.open === undefined ? false : this.props.open,
+    open: Boolean(this.props.open),
   };
 
   componentDidMount() {

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -132,7 +132,6 @@ export default class Tooltip extends Component {
   };
 
   static defaultProps = {
-    open: false,
     direction: DIRECTION_BOTTOM,
     showIcon: true,
     iconName: 'info--glyph',
@@ -142,7 +141,7 @@ export default class Tooltip extends Component {
   };
 
   state = {
-    open: this.props.open,
+    open: this.props.open === undefined ? false : this.props.open,
   };
 
   componentDidMount() {
@@ -168,29 +167,35 @@ export default class Tooltip extends Component {
   };
 
   handleMouse = state => {
-    if (this.props.clickToOpen) {
-      if (state === 'click') {
-        this.setState({ open: !this.state.open });
-      }
-    } else {
-      if (state === 'over') {
-        this.getTriggerPosition();
-        this.setState({ open: true });
+    if (this.props.open === undefined) {
+      if (this.props.clickToOpen) {
+        if (state === 'click') {
+          this.setState({ open: !this.state.open });
+        }
       } else {
-        this.setState({ open: false });
+        if (state === 'over') {
+          this.getTriggerPosition();
+          this.setState({ open: true });
+        } else {
+          this.setState({ open: false });
+        }
       }
     }
   };
 
   handleClickOutside = () => {
-    this.setState({ open: false });
+    if (this.props.open === undefined) {
+      this.setState({ open: false });
+    }
   };
 
   handleKeyPress = evt => {
-    const key = evt.key || evt.which;
+    if (this.props.open === undefined) {
+      const key = evt.key || evt.which;
 
-    if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
-      this.setState({ open: !this.state.open });
+      if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
+        this.setState({ open: !this.state.open });
+      }
     }
   };
 


### PR DESCRIPTION
To address this: https://github.com/carbon-design-system/carbon-components-react/issues/669#issuecomment-370884282 
Closes carbon-design-system/carbon-components-react#669

Tooltip will be fully controlled by `open` if it's defined.

#### Changelog

**Changed**

* if `props.open` is defined on the Tooltip, then all event handler will be skipped /overridden. Changing the `open` from prop is the only way to toggle the display of the tooltip

* Tooltip `state.open` will be initialized to `false` if `open` on props is undefined.

**Removed**

* removed the default prop value from the Tooltip component.