### PR TITLE
fix(Loading): add missing bx--loading-overlay--stop class

### DIFF
--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -24,6 +24,10 @@ export default class Loading extends React.Component {
       'bx--loading--stop': !active,
     });
 
+    const overlayClasses = classNames('bx--loading-overlay', {
+      'bx--loading-overlay--stop': !active,
+    });
+
     const loading = (
       <div {...other} className={loadingClasses}>
         <svg className="bx--loading__svg" viewBox="-75 -75 150 150">
@@ -33,7 +37,7 @@ export default class Loading extends React.Component {
     );
 
     return withOverlay ? (
-      <div className="bx--loading-overlay">{loading}</div>
+      <div className={overlayClasses}>{loading}</div>
     ) : (
       loading
     );


### PR DESCRIPTION
Fixes #650.

#### Changelog

**New**

* Support for `bx--loading-overlay--stop` CSS class.