### PR TITLE
fix(DataTable): add isSortable to provide un-sorted headers

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -128,6 +128,7 @@ export default class DataTable extends React.Component {
       ...rest,
       key: header.key,
       sortDirection,
+      isSortable: true,
       isSortHeader: sortHeaderKey === header.key,
       // Compose the event handlers so we don't overwrite a consumer's `onClick`
       // handler

--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -24,6 +24,7 @@ const translateWithId = (key, { sortDirection, isSortHeader, sortStates }) => {
 const TableHeader = ({
   className: headerClassName,
   children,
+  isSortable,
   isSortHeader,
   onClick,
   scope,
@@ -31,6 +32,14 @@ const TableHeader = ({
   translateWithId: t,
   ...rest
 }) => {
+  if (!isSortable) {
+    return (
+      <th {...rest} className={headerClassName} scope={scope}>
+        {children}
+      </th>
+    );
+  }
+
   const className = cx(headerClassName, {
     'bx--table-sort-v2': true,
     'bx--table-sort-v2--active':
@@ -38,6 +47,7 @@ const TableHeader = ({
     'bx--table-sort-v2--ascending':
       isSortHeader && sortDirection === sortStates.ASC,
   });
+
   return (
     <th scope={scope}>
       <button className={className} onClick={onClick} {...rest}>
@@ -67,6 +77,11 @@ TableHeader.propTypes = {
    * Pass in children that will be embedded in the table header label
    */
   children: PropTypes.string,
+
+  /**
+   * Specify whether this header is one through which a user can sort the table
+   */
+  isSortable: PropTypes.bool,
 
   /**
    * Specify whether this header is the header by which a table is being sorted
@@ -101,6 +116,7 @@ TableHeader.propTypes = {
 };
 
 TableHeader.defaultProps = {
+  isSortable: false,
   scope: 'col',
   translateWithId,
 };

--- a/src/components/DataTable/__tests__/TableHeader-test.js
+++ b/src/components/DataTable/__tests__/TableHeader-test.js
@@ -14,7 +14,7 @@ describe('DataTable.TableHeader', () => {
   });
 
   it('should render', () => {
-    const wrapper = mount(
+    const simpleHeader = mount(
       <Table>
         <TableHead>
           <TableRow>
@@ -23,7 +23,20 @@ describe('DataTable.TableHeader', () => {
         </TableHead>
       </Table>
     );
-    expect(wrapper).toMatchSnapshot();
+    expect(simpleHeader).toMatchSnapshot();
+
+    const sortHeader = mount(
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableHeader {...mockProps} isSortHeader>
+              Header
+            </TableHeader>
+          </TableRow>
+        </TableHead>
+      </Table>
+    );
+    expect(sortHeader).toMatchSnapshot();
   });
 
   it('should have an active class if it is the sort header and the sort state is not NONE', () => {

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -404,6 +404,7 @@ exports[`DataTable should render 1`] = `
                 <tr>
                   <TableHeader
                     isSortHeader={false}
+                    isSortable={true}
                     key="fieldA"
                     onClick={[Function]}
                     scope="col"
@@ -454,6 +455,7 @@ exports[`DataTable should render 1`] = `
                   </TableHeader>
                   <TableHeader
                     isSortHeader={false}
+                    isSortable={true}
                     key="fieldB"
                     onClick={[Function]}
                     scope="col"

--- a/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableHeader-test.js.snap
@@ -11,6 +11,7 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
           <tr>
             <TableHeader
               isSortHeader={true}
+              isSortable={false}
               onClick={[MockFunction]}
               scope="col"
               sortDirection="ASC"
@@ -19,43 +20,7 @@ exports[`DataTable.TableHeader should have an active and ascending class if sort
               <th
                 scope="col"
               >
-                <button
-                  className="bx--table-sort-v2 bx--table-sort-v2--active bx--table-sort-v2--ascending"
-                  onClick={[MockFunction]}
-                >
-                  <span
-                    className="bx--table-header-label"
-                  >
-                    Header
-                  </span>
-                  <Icon
-                    className="bx--table-sort-v2__icon"
-                    description="Sort rows by this header in ascending order"
-                    fillRule="evenodd"
-                    name="caret--down"
-                    role="img"
-                  >
-                    <svg
-                      alt="Sort rows by this header in ascending order"
-                      aria-label="Sort rows by this header in ascending order"
-                      className="bx--table-sort-v2__icon"
-                      fillRule="evenodd"
-                      height="5"
-                      name="caret--down"
-                      role="img"
-                      viewBox="0 0 10 5"
-                      width="10"
-                    >
-                      <title>
-                        Sort rows by this header in ascending order
-                      </title>
-                      <path
-                        d="M10 0L5 5 0 0z"
-                        key="key0"
-                      />
-                    </svg>
-                  </Icon>
-                </button>
+                Header
               </th>
             </TableHeader>
           </tr>
@@ -77,6 +42,7 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
           <tr>
             <TableHeader
               isSortHeader={true}
+              isSortable={false}
               onClick={[MockFunction]}
               scope="col"
               sortDirection="NONE"
@@ -85,43 +51,7 @@ exports[`DataTable.TableHeader should have an active class if it is the sort hea
               <th
                 scope="col"
               >
-                <button
-                  className="bx--table-sort-v2"
-                  onClick={[MockFunction]}
-                >
-                  <span
-                    className="bx--table-header-label"
-                  >
-                    Header
-                  </span>
-                  <Icon
-                    className="bx--table-sort-v2__icon"
-                    description="Sort rows by this header in ascending order"
-                    fillRule="evenodd"
-                    name="caret--down"
-                    role="img"
-                  >
-                    <svg
-                      alt="Sort rows by this header in ascending order"
-                      aria-label="Sort rows by this header in ascending order"
-                      className="bx--table-sort-v2__icon"
-                      fillRule="evenodd"
-                      height="5"
-                      name="caret--down"
-                      role="img"
-                      viewBox="0 0 10 5"
-                      width="10"
-                    >
-                      <title>
-                        Sort rows by this header in ascending order
-                      </title>
-                      <path
-                        d="M10 0L5 5 0 0z"
-                        key="key0"
-                      />
-                    </svg>
-                  </Icon>
-                </button>
+                Header
               </th>
             </TableHeader>
           </tr>
@@ -143,6 +73,7 @@ exports[`DataTable.TableHeader should render 1`] = `
           <tr>
             <TableHeader
               isSortHeader={false}
+              isSortable={false}
               onClick={[MockFunction]}
               scope="col"
               sortDirection="NONE"
@@ -151,43 +82,38 @@ exports[`DataTable.TableHeader should render 1`] = `
               <th
                 scope="col"
               >
-                <button
-                  className="bx--table-sort-v2"
-                  onClick={[MockFunction]}
-                >
-                  <span
-                    className="bx--table-header-label"
-                  >
-                    Header
-                  </span>
-                  <Icon
-                    className="bx--table-sort-v2__icon"
-                    description="Sort rows by this header in descending order"
-                    fillRule="evenodd"
-                    name="caret--down"
-                    role="img"
-                  >
-                    <svg
-                      alt="Sort rows by this header in descending order"
-                      aria-label="Sort rows by this header in descending order"
-                      className="bx--table-sort-v2__icon"
-                      fillRule="evenodd"
-                      height="5"
-                      name="caret--down"
-                      role="img"
-                      viewBox="0 0 10 5"
-                      width="10"
-                    >
-                      <title>
-                        Sort rows by this header in descending order
-                      </title>
-                      <path
-                        d="M10 0L5 5 0 0z"
-                        key="key0"
-                      />
-                    </svg>
-                  </Icon>
-                </button>
+                Header
+              </th>
+            </TableHeader>
+          </tr>
+        </TableRow>
+      </thead>
+    </TableHead>
+  </table>
+</Table>
+`;
+
+exports[`DataTable.TableHeader should render 2`] = `
+<Table>
+  <table
+    className="bx--data-table-v2 bx--data-table-v2--zebra"
+  >
+    <TableHead>
+      <thead>
+        <TableRow>
+          <tr>
+            <TableHeader
+              isSortHeader={true}
+              isSortable={false}
+              onClick={[MockFunction]}
+              scope="col"
+              sortDirection="NONE"
+              translateWithId={[Function]}
+            >
+              <th
+                scope="col"
+              >
+                Header
               </th>
             </TableHeader>
           </tr>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#691

Add isSortable to provide un-sorted headers

#### Changelog

**New**

**Changed**

* `TableHeader`
  * Now includes `isSortable` prop that defaults to false that will toggle which header will get rendered
* `DataTable#getHeaderProps` now adds `isSortable: true` to props passed into TableHeader

**Removed**
