### PR TITLE
feat(Tooltip): handle hover-over on tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip-test.js
+++ b/src/components/Tooltip/Tooltip-test.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import debounce from 'lodash.debounce';
 import Icon from '../Icon';
 import FloatingMenu from '../../internal/FloatingMenu';
 import Tooltip from '../Tooltip';
 import { mount } from 'enzyme';
+
+jest.mock('lodash.debounce');
+
+debounce.mockImplementation(fn => fn);
 
 describe('Tooltip', () => {
   describe('Renders as expected with defaults', () => {

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -230,7 +230,8 @@ export default class Tooltip extends Component {
   };
 
   handleClickOutside = evt => {
-    const shouldPreventClose = evt.target && this._tooltipEl && this._tooltipEl.contains(evt.target);
+    const shouldPreventClose =
+      evt.target && this._tooltipEl && this._tooltipEl.contains(evt.target);
     if (!shouldPreventClose) {
       this.setState({ open: false });
     }

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -231,7 +231,10 @@ export default class Tooltip extends Component {
 
   handleClickOutside = evt => {
     const shouldPreventClose =
-      evt.target && this._tooltipEl && this._tooltipEl.contains(evt.target);
+      evt &&
+      evt.target &&
+      this._tooltipEl &&
+      this._tooltipEl.contains(evt.target);
     if (!shouldPreventClose) {
       this.setState({ open: false });
     }

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -143,6 +143,12 @@ export default class Tooltip extends Component {
   };
 
   /**
+   * A flag to detect if `oncontextmenu` event is fired right before `mouseover`/`mouseout`/`focus`/`blur` events.
+   * @type {boolean}
+   */
+  _hasContextMenu = false;
+
+  /**
    * The element of the tooltip body.
    * @type {Element}
    * @private
@@ -212,17 +218,22 @@ export default class Tooltip extends Component {
         : { mouseover: 'over', mouseout: 'out', focus: 'over', blur: 'out' }[
             evt.type
           ];
+    const hadContextMenu = this._hasContextMenu;
+    this._hasContextMenu = evt.type === 'contextmenu';
     if (this.props.clickToOpen) {
       if (state === 'click') {
         this.setState({ open: !this.state.open });
       }
-    } else if (state) {
+    } else if (state && (state !== 'out' || !hadContextMenu)) {
       this._debouncedHandleHover(state, evt.relatedTarget);
     }
   };
 
-  handleClickOutside = () => {
-    this.setState({ open: false });
+  handleClickOutside = evt => {
+    const shouldPreventClose = evt.target && this._tooltipEl && this._tooltipEl.contains(evt.target);
+    if (!shouldPreventClose) {
+      this.setState({ open: false });
+    }
   };
 
   handleKeyPress = evt => {
@@ -331,6 +342,7 @@ export default class Tooltip extends Component {
               onMouseOut={evt => this.handleMouse(evt)}
               onFocus={evt => this.handleMouse(evt)}
               onBlur={evt => this.handleMouse(evt)}
+              onContextMenu={evt => this.handleMouse(evt)}
               ref={node => {
                 this._tooltipEl = node;
               }}>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import debounce from 'lodash.debounce';
 import Icon from '../Icon';
 import classNames from 'classnames';
 import FloatingMenu, {
@@ -141,6 +142,13 @@ export default class Tooltip extends Component {
     menuOffset: getMenuOffset,
   };
 
+  /**
+   * The element of the tooltip body.
+   * @type {Element}
+   * @private
+   */
+  _tooltipEl = null;
+
   state = {
     open: this.props.open,
   };
@@ -167,18 +175,49 @@ export default class Tooltip extends Component {
     }
   };
 
-  handleMouse = state => {
+  /**
+   * Handles `mouseover`/`mouseout`/`focus`/`blur` event.
+   * @param {string} state `over` to show the tooltip, `out` to hide the tooltip.
+   * @param {Element} [relatedTarget] For handing `mouseout` event, indicates where the mouse pointer is gone.
+   */
+  _handleHover = (state, relatedTarget) => {
+    if (state === 'over') {
+      this.getTriggerPosition();
+      this.setState({ open: true });
+    } else {
+      // Note: SVGElement in IE11 does not have `.contains()`
+      const shouldPreventClose =
+        relatedTarget &&
+        ((this.triggerEl &&
+          this.triggerEl.contains &&
+          this.triggerEl.contains(relatedTarget)) ||
+          (this._tooltipEl && this._tooltipEl.contains(relatedTarget)));
+      if (!shouldPreventClose) {
+        this.setState({ open: false });
+      }
+    }
+  };
+
+  /**
+   * The debounced version of the `mouseover`/`mouseout`/`focus`/`blur` event handler.
+   * @type {Function}
+   * @private
+   */
+  _debouncedHandleHover = debounce(this._handleHover, 200);
+
+  handleMouse = evt => {
+    const state =
+      typeof evt === 'string'
+        ? evt
+        : { mouseover: 'over', mouseout: 'out', focus: 'over', blur: 'out' }[
+            evt.type
+          ];
     if (this.props.clickToOpen) {
       if (state === 'click') {
         this.setState({ open: !this.state.open });
       }
-    } else {
-      if (state === 'over') {
-        this.getTriggerPosition();
-        this.setState({ open: true });
-      } else {
-        this.setState({ open: false });
-      }
+    } else if (state) {
+      this._debouncedHandleHover(state, evt.relatedTarget);
     }
   };
 
@@ -241,10 +280,10 @@ export default class Tooltip extends Component {
                 id={triggerId}
                 role="button"
                 tabIndex="0"
-                onMouseOver={() => this.handleMouse('over')}
-                onMouseOut={() => this.handleMouse('out')}
-                onFocus={() => this.handleMouse('over')}
-                onBlur={() => this.handleMouse('out')}
+                onMouseOver={evt => this.handleMouse(evt)}
+                onMouseOut={evt => this.handleMouse(evt)}
+                onFocus={evt => this.handleMouse(evt)}
+                onBlur={evt => this.handleMouse(evt)}
                 aria-haspopup="true"
                 aria-owns={tooltipId}
                 aria-expanded={open}>
@@ -266,10 +305,10 @@ export default class Tooltip extends Component {
               ref={node => {
                 this.triggerEl = node;
               }}
-              onMouseOver={() => this.handleMouse('over')}
-              onMouseOut={() => this.handleMouse('out')}
-              onFocus={() => this.handleMouse('over')}
-              onBlur={() => this.handleMouse('out')}
+              onMouseOver={evt => this.handleMouse(evt)}
+              onMouseOut={evt => this.handleMouse(evt)}
+              onFocus={evt => this.handleMouse(evt)}
+              onBlur={evt => this.handleMouse(evt)}
               aria-haspopup="true"
               aria-owns={tooltipId}
               aria-expanded={open}>
@@ -287,7 +326,14 @@ export default class Tooltip extends Component {
               className={tooltipClasses}
               {...other}
               data-floating-menu-direction={direction}
-              aria-labelledby={triggerId}>
+              aria-labelledby={triggerId}
+              onMouseOver={evt => this.handleMouse(evt)}
+              onMouseOut={evt => this.handleMouse(evt)}
+              onFocus={evt => this.handleMouse(evt)}
+              onBlur={evt => this.handleMouse(evt)}
+              ref={node => {
+                this._tooltipEl = node;
+              }}>
               {children}
             </div>
           </FloatingMenu>


### PR DESCRIPTION
Closes #669.
Refs carbon-design-system/carbon-components#266.

This PR is for preventing tooltip from being closed when the mouse is on the open tooltip.

#### Changelog

**New**

* Code to detect if the mouse is is on the open tooltip
* Code to debounce event handlers that open/close tooltip (Moving mouse cursor from the trigger button to the open tooltip causes mouse pointer to go to another element between them, and thus detecting mouse position right after the mouse cursor goes out of the trigger button will detect another element)