### PR TITLE
fix(FileUploader): Reset the internal value so onChange works as expected

### DIFF
--- a/src/components/FileUploader/FileUploader-test.js
+++ b/src/components/FileUploader/FileUploader-test.js
@@ -55,6 +55,15 @@ describe('FileUploaderButton', () => {
     it('does not have default role', () => {
       expect(mountWrapper.props().role).not.toBeTruthy();
     });
+
+    it('resets the input value onClick', () => {
+      const input = mountWrapper.find('.bx--visually-hidden');
+      input.instance().value = '';
+      const evt = { target: { value: input.instance().value } };
+      input.simulate('click', evt);
+
+      expect(evt.target.value).toEqual(null);
+    });
   });
 
   describe('Unique id props', () => {

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -97,6 +97,9 @@ export class FileUploaderButton extends Component {
           multiple={multiple}
           accept={accept}
           onChange={this.handleChange}
+          onClick={evt => {
+            evt.target.value = null;
+          }}
         />
       </div>
     );
@@ -212,7 +215,7 @@ export default class FileUploader extends Component {
 
   clearFiles = () => {
     // A clearFiles function that resets filenames and can be referenced using a ref by the parent.
-    this.setState({ filenames: [], filenameStatus: '' });
+    this.setState({ filenames: [] });
   };
 
   render() {


### PR DESCRIPTION
**BUG**
The FileUploader component currently doesn't allow you to delete a file and then reupload the exact same. The value of `<input type=file ...` isn't reset.

Steps to reproduce:
1. Navigate to the FileUploader: http://react.carbondesignsystem.com/?selectedKind=FileUploader&selectedStory=FileUploader&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

2. Upload a file

3. Click the X or the Clear Files button to clear the file

4. Upload the same file again

5. The file doesn't upload a second time

**FIX**
As advised by:
https://stackoverflow.com/questions/39484895/how-to-allow-input-type-file-to-select-the-same-file-in-react-component

Add an onClick listener to the input file element that clears the value of the element.