### PR TITLE
feat(DataTable): Preserve sorting in DataTable when it is re-rendered

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import getDerivedStateFromProps from './state/getDerivedStateFromProps';
-import { getNextSortState } from './state/sorting';
+import { getNextSortState, getCurrentSortState } from './state/sorting';
 import denormalize from './tools/denormalize';
 import { composeEventHandlers } from './tools/events';
 import { defaultFilterRows } from './tools/filter';
@@ -102,14 +102,24 @@ export default class DataTable extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = getDerivedStateFromProps(props);
+    this.state = getDerivedStateFromProps(props, {});
     this.instanceId = getInstanceId();
   }
 
   componentWillReceiveProps(nextProps) {
-    const nextState = getDerivedStateFromProps(nextProps);
-    if (nextState) {
-      this.setState(nextState);
+    const nextState = getDerivedStateFromProps(nextProps, this.state);
+
+    // Preserve the sorted order by re-sorting the data
+    if (
+      (nextState && nextState.sortHeaderKey !== this.state.sortHeaderKey) ||
+      nextState.sortDirection !== this.state.sortDirection
+    ) {
+      this.setState({
+        ...nextState,
+        ...getCurrentSortState(this.props, this.state, {
+          key: this.state.sortHeaderKey,
+        }),
+      });
     }
   }
 

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -129,8 +129,17 @@ describe('DataTable', () => {
 
       header.simulate('click');
       expect(wrapper.state('rowIds')).toEqual(['b', 'a', 'c']);
+    });
 
-      wrapper.setProps({ rows: [] });
+    it('should re-sort new row props by the current sort state', () => {
+      const wrapper = mount(<DataTable {...mockProps} />);
+      const header = getHeaderAt(wrapper, 0);
+
+      header.simulate('click');
+      expect(wrapper.state('rowIds')).toEqual(['a', 'b', 'c']);
+
+      wrapper.setProps({ rows: mockProps.rows });
+      expect(wrapper.state('rowIds')).toEqual(['a', 'b', 'c']);
     });
 
     it('should reset to DESC ordering when another header is clicked', () => {

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -129,6 +129,8 @@ describe('DataTable', () => {
 
       header.simulate('click');
       expect(wrapper.state('rowIds')).toEqual(['b', 'a', 'c']);
+
+      wrapper.setProps({ rows: [] });
     });
 
     it('should reset to DESC ordering when another header is clicked', () => {

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -73,7 +73,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                   <TableSelectAll
                     ariaLabel="Select all rows"
                     checked={false}
-                    id="data-table-6__select-all"
+                    id="data-table-7__select-all"
                     name="select-all"
                     onSelect={[Function]}
                   >
@@ -83,14 +83,14 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                       <InlineCheckbox
                         ariaLabel="Select all rows"
                         checked={false}
-                        id="data-table-6__select-all"
+                        id="data-table-7__select-all"
                         name="select-all"
                         onClick={[Function]}
                       >
                         <input
                           checked={false}
                           className="bx--checkbox"
-                          id="data-table-6__select-all"
+                          id="data-table-7__select-all"
                           name="select-all"
                           onClick={[Function]}
                           type="checkbox"
@@ -98,7 +98,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                         <label
                           aria-label="Select all rows"
                           className="bx--checkbox-label"
-                          htmlFor="data-table-6__select-all"
+                          htmlFor="data-table-7__select-all"
                         />
                       </InlineCheckbox>
                     </th>
@@ -380,7 +380,7 @@ exports[`DataTable selection should render 1`] = `
                   <TableSelectAll
                     ariaLabel="Select all rows"
                     checked={false}
-                    id="data-table-5__select-all"
+                    id="data-table-6__select-all"
                     name="select-all"
                     onSelect={[Function]}
                   >
@@ -390,14 +390,14 @@ exports[`DataTable selection should render 1`] = `
                       <InlineCheckbox
                         ariaLabel="Select all rows"
                         checked={false}
-                        id="data-table-5__select-all"
+                        id="data-table-6__select-all"
                         name="select-all"
                         onClick={[Function]}
                       >
                         <input
                           checked={false}
                           className="bx--checkbox"
-                          id="data-table-5__select-all"
+                          id="data-table-6__select-all"
                           name="select-all"
                           onClick={[Function]}
                           type="checkbox"
@@ -405,7 +405,7 @@ exports[`DataTable selection should render 1`] = `
                         <label
                           aria-label="Select all rows"
                           className="bx--checkbox-label"
-                          htmlFor="data-table-5__select-all"
+                          htmlFor="data-table-6__select-all"
                         />
                       </InlineCheckbox>
                     </th>
@@ -525,7 +525,7 @@ exports[`DataTable selection should render 1`] = `
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
-                    id="data-table-5__select-row-b"
+                    id="data-table-6__select-row-b"
                     name="select-row-b"
                     onSelect={[Function]}
                   >
@@ -533,14 +533,14 @@ exports[`DataTable selection should render 1`] = `
                       <InlineCheckbox
                         ariaLabel="Select row"
                         checked={false}
-                        id="data-table-5__select-row-b"
+                        id="data-table-6__select-row-b"
                         name="select-row-b"
                         onClick={[Function]}
                       >
                         <input
                           checked={false}
                           className="bx--checkbox"
-                          id="data-table-5__select-row-b"
+                          id="data-table-6__select-row-b"
                           name="select-row-b"
                           onClick={[Function]}
                           type="checkbox"
@@ -548,7 +548,7 @@ exports[`DataTable selection should render 1`] = `
                         <label
                           aria-label="Select row"
                           className="bx--checkbox-label"
-                          htmlFor="data-table-5__select-row-b"
+                          htmlFor="data-table-6__select-row-b"
                         />
                       </InlineCheckbox>
                     </td>
@@ -576,7 +576,7 @@ exports[`DataTable selection should render 1`] = `
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
-                    id="data-table-5__select-row-a"
+                    id="data-table-6__select-row-a"
                     name="select-row-a"
                     onSelect={[Function]}
                   >
@@ -584,14 +584,14 @@ exports[`DataTable selection should render 1`] = `
                       <InlineCheckbox
                         ariaLabel="Select row"
                         checked={false}
-                        id="data-table-5__select-row-a"
+                        id="data-table-6__select-row-a"
                         name="select-row-a"
                         onClick={[Function]}
                       >
                         <input
                           checked={false}
                           className="bx--checkbox"
-                          id="data-table-5__select-row-a"
+                          id="data-table-6__select-row-a"
                           name="select-row-a"
                           onClick={[Function]}
                           type="checkbox"
@@ -599,7 +599,7 @@ exports[`DataTable selection should render 1`] = `
                         <label
                           aria-label="Select row"
                           className="bx--checkbox-label"
-                          htmlFor="data-table-5__select-row-a"
+                          htmlFor="data-table-6__select-row-a"
                         />
                       </InlineCheckbox>
                     </td>
@@ -627,7 +627,7 @@ exports[`DataTable selection should render 1`] = `
                   <TableSelectRow
                     ariaLabel="Select row"
                     checked={false}
-                    id="data-table-5__select-row-c"
+                    id="data-table-6__select-row-c"
                     name="select-row-c"
                     onSelect={[Function]}
                   >
@@ -635,14 +635,14 @@ exports[`DataTable selection should render 1`] = `
                       <InlineCheckbox
                         ariaLabel="Select row"
                         checked={false}
-                        id="data-table-5__select-row-c"
+                        id="data-table-6__select-row-c"
                         name="select-row-c"
                         onClick={[Function]}
                       >
                         <input
                           checked={false}
                           className="bx--checkbox"
-                          id="data-table-5__select-row-c"
+                          id="data-table-6__select-row-c"
                           name="select-row-c"
                           onClick={[Function]}
                           type="checkbox"
@@ -650,7 +650,7 @@ exports[`DataTable selection should render 1`] = `
                         <label
                           aria-label="Select row"
                           className="bx--checkbox-label"
-                          htmlFor="data-table-5__select-row-c"
+                          htmlFor="data-table-6__select-row-c"
                         />
                       </InlineCheckbox>
                     </td>

--- a/src/components/DataTable/state/__tests__/getDerivedStateFromProps-test.js
+++ b/src/components/DataTable/state/__tests__/getDerivedStateFromProps-test.js
@@ -1,0 +1,26 @@
+import getDerivedStateFromProps from '../getDerivedStateFromProps';
+
+const props = {
+  rows: [],
+  headers: [],
+};
+
+describe('getDerivedStateFromProps', () => {
+  it('uses prevState if available', () => {
+    const prevState = { sortDirection: 'DESC', sortHeaderKey: 'mockKey' };
+    expect(getDerivedStateFromProps(props, prevState)).toEqual(
+      expect.objectContaining({
+        ...prevState,
+      })
+    );
+  });
+
+  it('has default values if prevState is not available', () => {
+    expect(getDerivedStateFromProps(props, {})).toEqual(
+      expect.objectContaining({
+        sortDirection: 'NONE',
+        sortHeaderKey: null,
+      })
+    );
+  });
+});

--- a/src/components/DataTable/state/__tests__/sorting-test.js
+++ b/src/components/DataTable/state/__tests__/sorting-test.js
@@ -4,6 +4,7 @@ describe('sorting state', () => {
   let initialSortState;
   let getNextSortDirection;
   let getNextSortState;
+  let getCurrentSortState;
 
   beforeEach(() => {
     jest.mock('../../tools/sorting', () => ({
@@ -15,6 +16,7 @@ describe('sorting state', () => {
     initialSortState = sorting.initialSortState;
     getNextSortDirection = sorting.getNextSortDirection;
     getNextSortState = sorting.getNextSortState;
+    getCurrentSortState = sorting.getCurrentSortState;
   });
 
   describe('sortStates', () => {
@@ -181,6 +183,87 @@ describe('sorting state', () => {
         sortDirection: sortStates.NONE,
         // Initial row order
         rowIds: ['a', 'b', 'c'],
+      });
+    });
+  });
+
+  describe('getCurrentSortState', () => {
+    let mockProps;
+    let mockState;
+
+    beforeEach(() => {
+      mockProps = {
+        locale: 'en',
+        sortRow: jest.fn(),
+      };
+      mockState = {
+        sortDirection: sortStates.NONE,
+        sortHeaderKey: null,
+        rowIds: ['b', 'a', 'c'],
+        initialRowOrder: ['a', 'b', 'c'],
+        cellsById: {
+          'a:a': {
+            value: 'row-a:header-a',
+          },
+          'a:b': {
+            value: 'row-a:header-b',
+          },
+          'a:c': {
+            value: 'row-a:header-c',
+          },
+          'b:a': {
+            value: 'row-b:header-a',
+          },
+          'b:b': {
+            value: 'row-b:header-b',
+          },
+          'b:c': {
+            value: 'row-b:header-c',
+          },
+        },
+      };
+    });
+
+    it('should sort based on the current sort state options', () => {
+      const sortHeaderKey = 'a';
+      const state1 = getCurrentSortState(mockProps, mockState, {
+        key: sortHeaderKey,
+      });
+      const state2 = getCurrentSortState(
+        mockProps,
+        {
+          ...mockState,
+          sortDirection: 'DESC',
+        },
+        {
+          key: sortHeaderKey,
+        }
+      );
+      const state3 = getCurrentSortState(
+        mockProps,
+        {
+          ...mockState,
+          sortDirection: 'ASC',
+        },
+        {
+          key: sortHeaderKey,
+        }
+      );
+      expect(state1).toEqual({
+        sortHeaderKey,
+        sortDirection: sortStates.NONE,
+        rowIds: ['a', 'b', 'c'],
+      });
+      expect(state2).toEqual({
+        sortHeaderKey,
+        sortDirection: sortStates.DESC,
+        rowIds: ['b', 'a', 'c'],
+      });
+      expect(state3).toEqual({
+        sortHeaderKey,
+        sortDirection: sortStates.ASC,
+        // Initial row order
+        rowIds: ['b', 'a', 'c'],
       });
     });
   });

--- a/src/components/DataTable/state/getDerivedStateFromProps.js
+++ b/src/components/DataTable/state/getDerivedStateFromProps.js
@@ -8,14 +8,14 @@ import normalize from '../tools/normalize';
  * Currently, it's being used as a way to normalize the incoming data that we
  * are receiving for rows
  */
-const getDerivedStateFromProps = props => {
+const getDerivedStateFromProps = (props, prevState) => {
   const { rowIds, rowsById, cellsById } = normalize(props.rows, props.headers);
   return {
     rowIds,
     rowsById,
     cellsById,
-    sortDirection: initialSortState,
-    sortHeaderKey: null,
+    sortDirection: prevState.sortDirection || initialSortState,
+    sortHeaderKey: prevState.sortHeaderKey || null,
     // Copy over rowIds so the reference doesn't mutate the stored
     // `initialRowOrder`
     initialRowOrder: rowIds.slice(),

--- a/src/components/DataTable/state/sorting.js
+++ b/src/components/DataTable/state/sorting.js
@@ -43,9 +43,25 @@ export const getNextSortDirection = (prevHeader, header, prevState) => {
   return sortStates.DESC;
 };
 
+export const getNextSortState = (props, state, { key }) => {
+  const { sortDirection, sortHeaderKey } = state;
+
+  const nextSortDirection = getNextSortDirection(
+    key,
+    sortHeaderKey,
+    sortDirection
+  );
+
+  return getSortedState(props, state, key, nextSortDirection);
+};
+
+export const getCurrentSortState = (props, state, { key }) => {
+  return getSortedState(props, state, key, state.sortDirection);
+};
+
 /**
- * Derive the next set of sort state fields from props and state for the given
- * header key.
+ * Derive the set of sorted state fields from props and state for the given
+ * header key and sortDirection
  *
  * @param {Object} props
  * @param {string} props.locale The current locale
@@ -54,31 +70,18 @@ export const getNextSortDirection = (prevHeader, header, prevState) => {
  * @param {Object} state
  * @param {Array<string>} state.rowIds Array of row ids
  * @param {Object} state.cellsById Lookup object for cells by id
- * @param {string} state.sortDirection The current sort direction
- * @param {string} state.sortHeaderKey The current sort header ky
  * @param {Array<string>} state.initialRowOrder Initial row order for the
  * current set of rows
- * @param {Object} options
- * @param {string} options.key the key for the given header we are derving the
- * next sort state for
+ * @param {string} key The key for the given header we are derving the
+ * sorted state for
+ * @param {string} sortDirection The sortState that we want to order by
  * @returns {Object}
  */
-export const getNextSortState = (props, state, { key }) => {
-  const {
-    rowIds,
-    cellsById,
-    sortDirection,
-    sortHeaderKey,
-    initialRowOrder,
-  } = state;
+const getSortedState = (props, state, key, sortDirection) => {
+  const { rowIds, cellsById, initialRowOrder } = state;
   const { locale, sortRow } = props;
-  const nextSortDirection = getNextSortDirection(
-    key,
-    sortHeaderKey,
-    sortDirection
-  );
   const nextRowIds =
-    nextSortDirection !== sortStates.NONE
+    sortDirection !== sortStates.NONE
       ? sortRows({
           rowIds,
           cellsById,
@@ -90,7 +93,7 @@ export const getNextSortState = (props, state, { key }) => {
       : initialRowOrder;
   return {
     sortHeaderKey: key,
-    sortDirection: nextSortDirection,
+    sortDirection: sortDirection,
     rowIds: nextRowIds,
   };
 };

--- a/src/components/DataTable/tools/__tests__/sorting-test.js
+++ b/src/components/DataTable/tools/__tests__/sorting-test.js
@@ -1,0 +1,24 @@
+import { defaultSortRow } from '../sorting';
+import { sortStates } from '../../state/sorting';
+
+describe('defaultSortRow', () => {
+  it('should sort data in ascending order', () => {
+    const sortProps = {
+      sortDirection: sortStates.ASC,
+      sortStates: sortStates,
+      locale: 'en',
+    };
+    expect(defaultSortRow('a', 'b', sortProps)).toBeGreaterThan(0);
+    expect(defaultSortRow('1', '2', sortProps)).toBeGreaterThan(0);
+  });
+
+  it('should sort data in descending order', () => {
+    const sortProps = {
+      sortDirection: sortStates.DESC,
+      sortStates: sortStates,
+      locale: 'en',
+    };
+    expect(defaultSortRow('a', 'b', sortProps)).toBeLessThan(0);
+    expect(defaultSortRow('1', '2', sortProps)).toBeLessThan(0);
+  });
+});

--- a/src/components/DataTable/tools/sorting.js
+++ b/src/components/DataTable/tools/sorting.js
@@ -80,7 +80,7 @@ export const defaultSortRow = (
   cellB,
   { sortDirection, sortStates, locale }
 ) => {
-  if (sortDirection === sortStates.DESC) {
+  if (sortDirection === sortStates.ASC) {
     return compare(cellB, cellA, locale);
   }
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react #705 

Changes to make DataTable preserve the sort when it is re-rendered. This includes re-sorting the rows when new props are received

#### Changelog

**New**

* getCurrentSortState - Returns the sorted state based on the current sort options in the state

**Changed**

* DataTable.componentWillReceiveProps - Now triggers a resort of new data based on sort options in state, this is to preserve sort
