### PR TITLE
fix(DataTable): Cancel deselects all

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -239,10 +239,38 @@ export default class DataTable extends React.Component {
   getTablePrefix = () => `data-table-${this.instanceId}`;
 
   /**
-   * Handler for the `onCancel` event to hide the batch action bar
+   * Helper for toggling all selected items in a state. Does not call
+   * setState, so use it when setting state.
+   * @param {Object} initialState
+   * @returns {Object} object to put into this.setState (use spread operator)
+   */
+  setAllSelectedState = (initialState, isSelected) => {
+    const { rowIds } = initialState;
+    return {
+      rowsById: rowIds.reduce(
+        (acc, id) => ({
+          ...acc,
+          [id]: {
+            ...initialState.rowsById[id],
+            isSelected,
+          },
+        }),
+        {}
+      ),
+    };
+  };
+
+  /**
+   * Handler for the `onCancel` event to hide the batch action bar and
+   * deselect all selected rows
    */
   handleOnCancel = () => {
-    this.setState({ shouldShowBatchActions: false });
+    this.setState(state => {
+      return {
+        shouldShowBatchActions: false,
+        ...this.setAllSelectedState(state, false),
+      };
+    });
   };
 
   /**
@@ -254,16 +282,7 @@ export default class DataTable extends React.Component {
       const isSelected = this.getSelectedRows().length !== rowIds.length;
       return {
         shouldShowBatchActions: isSelected,
-        rowsById: rowIds.reduce(
-          (acc, id) => ({
-            ...acc,
-            [id]: {
-              ...state.rowsById[id],
-              isSelected,
-            },
-          }),
-          {}
-        ),
+        ...this.setAllSelectedState(state, isSelected),
       };
     });
   };

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -274,5 +274,22 @@ describe('DataTable', () => {
       const { selectedRows } = getLastCallFor(mockProps.render)[0];
       expect(selectedRows.length).toBe(1);
     });
+
+    it('should deselect all rows when onCancel invoked', () => {
+      const wrapper = mount(<DataTable {...mockProps} />);
+      getSelectAll(wrapper).simulate('click');
+      expect(getSelectAll(wrapper).prop('checked')).toBe(true);
+
+      const { getBatchActionProps } = getLastCallFor(mockProps.render)[0];
+      expect(getBatchActionProps().shouldShowBatchActions).toBe(true);
+
+      getBatchActionProps().onCancel();
+
+      wrapper.update();
+
+      expect(getSelectAll(wrapper).prop('checked')).toBe(false);
+      const { selectedRows } = getLastCallFor(mockProps.render)[0];
+      expect(selectedRows.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#712

In a DataTable that uses a TableBatchActions, clicking the Cancel button will deselect all items as well as hiding the batch actions toolbar

#### Changelog

**Changed**

* Cancel button deselects items in a table
