### PR TITLE
fix(DatePickerInput): add default onClick prop

### DIFF
--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -14,6 +14,7 @@ export default class DatePickerInput extends Component {
     disabled: false,
     invalid: false,
     labelText: '',
+    onClick: () => {},
   };
 
   render() {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#720

Fixes an issue where an error would be thrown if the onClick prop was not set.

#### Changelog

**New**

* Adds a default onClick prop to `<DatePickerInput />`

**Changed**

* N/A

**Removed**

* N/A
