### PR TITLE
feat(DataTable): Row cell has header key

### DIFF
--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -262,6 +262,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "b:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -270,6 +273,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "b:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -285,6 +291,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "a:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -293,6 +302,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "a:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -308,6 +320,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "c:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -316,6 +331,9 @@ exports[`DataTable selection should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "c:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -723,6 +741,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "b:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -731,6 +752,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "b:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -746,6 +770,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "a:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -754,6 +781,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "a:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -769,6 +799,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "c:fieldA",
+                    "info": Object {
+                      "header": "fieldA",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,
@@ -777,6 +810,9 @@ exports[`DataTable should render 1`] = `
                   Object {
                     "errors": null,
                     "id": "c:fieldB",
+                    "info": Object {
+                      "header": "fieldB",
+                    },
                     "isEditable": false,
                     "isEditing": false,
                     "isValid": true,

--- a/src/components/DataTable/tools/__tests__/__snapshots__/normalize-test.js.snap
+++ b/src/components/DataTable/tools/__tests__/__snapshots__/normalize-test.js.snap
@@ -5,6 +5,9 @@ Object {
   "a:fieldA": Object {
     "errors": null,
     "id": "a:fieldA",
+    "info": Object {
+      "header": "fieldA",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -13,6 +16,9 @@ Object {
   "a:fieldB": Object {
     "errors": null,
     "id": "a:fieldB",
+    "info": Object {
+      "header": "fieldB",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -21,6 +27,9 @@ Object {
   "a:fieldC": Object {
     "errors": null,
     "id": "a:fieldC",
+    "info": Object {
+      "header": "fieldC",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -29,6 +38,9 @@ Object {
   "b:fieldA": Object {
     "errors": null,
     "id": "b:fieldA",
+    "info": Object {
+      "header": "fieldA",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -37,6 +49,9 @@ Object {
   "b:fieldB": Object {
     "errors": null,
     "id": "b:fieldB",
+    "info": Object {
+      "header": "fieldB",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -45,6 +60,9 @@ Object {
   "b:fieldC": Object {
     "errors": null,
     "id": "b:fieldC",
+    "info": Object {
+      "header": "fieldC",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -53,6 +71,9 @@ Object {
   "c:fieldA": Object {
     "errors": null,
     "id": "c:fieldA",
+    "info": Object {
+      "header": "fieldA",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -61,6 +82,9 @@ Object {
   "c:fieldB": Object {
     "errors": null,
     "id": "c:fieldB",
+    "info": Object {
+      "header": "fieldB",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,
@@ -69,6 +93,9 @@ Object {
   "c:fieldC": Object {
     "errors": null,
     "id": "c:fieldC",
+    "info": Object {
+      "header": "fieldC",
+    },
     "isEditable": false,
     "isEditing": false,
     "isValid": true,

--- a/src/components/DataTable/tools/normalize.js
+++ b/src/components/DataTable/tools/normalize.js
@@ -33,6 +33,9 @@ const normalize = (rows, headers) => {
         isEditing: false,
         isValid: true,
         errors: null,
+        info: {
+          header: key,
+        },
       };
 
       rowsById[row.id].cells[i] = id;


### PR DESCRIPTION
DataTable, the `rows` argument in the renderProp has a new prop in the `cells` array. The `cell` object has a new `info` property with an object value of `{ header : string }` which can indicate the key of the header. Useful to determine the current column for side-effects.

Closes carbon-design-system/carbon-components-react#737

#### Changelog

**New**

* `row.cells[]` objects have a new `info.header` property to indicate the header key of the current cell.

Signed-off-by: Andrew J Daniel <andrewjd1@gmail.com>

