### PR TITLE
fix(DataTable): update state properly in componentWillReceiveProps

### DIFF
--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -458,4 +458,120 @@ storiesOf('DataTable', module)
         )}
       />
     )
+  )
+  .addWithInfo(
+    'with dynamic rows',
+    `
+      Showcases DataTable behavior when rows are added to the component
+      dynamically.
+    `,
+    () => {
+      class DynamicRows extends React.Component {
+        state = {
+          rows: initialRows,
+          id: 0,
+        };
+
+        handleOnClick = () => {
+          this.setState(state => {
+            const { id: _id, rows } = state;
+            const id = _id + 1;
+            return {
+              id,
+              rows: rows.concat({
+                id: '' + id,
+                name: `New Row ${id}`,
+                protocol: 'HTTP',
+                port: 443,
+                rule: 'Round robin',
+                attached_groups: 'Maureens VM Groups',
+                status: 'Starting',
+              }),
+            };
+          });
+        };
+
+        render() {
+          return (
+            <DataTable
+              rows={this.state.rows}
+              headers={headers}
+              render={({
+                rows,
+                headers,
+                getHeaderProps,
+                getSelectionProps,
+                getBatchActionProps,
+                onInputChange,
+                selectedRows,
+              }) => (
+                <TableContainer title="DataTable with dynamic rows">
+                  <TableToolbar>
+                    <TableBatchActions {...getBatchActionProps()}>
+                      <TableBatchAction
+                        onClick={batchActionClick(selectedRows)}>
+                        Ghost
+                      </TableBatchAction>
+                      <TableBatchAction
+                        onClick={batchActionClick(selectedRows)}>
+                        Ghost
+                      </TableBatchAction>
+                      <TableBatchAction
+                        onClick={batchActionClick(selectedRows)}>
+                        Ghost
+                      </TableBatchAction>
+                    </TableBatchActions>
+                    <TableToolbarSearch onChange={onInputChange} />
+                    <TableToolbarContent>
+                      <TableToolbarAction
+                        iconName="download"
+                        iconDescription="Download"
+                        onClick={action('TableToolbarAction - Download')}
+                      />
+                      <TableToolbarAction
+                        iconName="edit"
+                        iconDescription="Edit"
+                        onClick={action('TableToolbarAction - Edit')}
+                      />
+                      <TableToolbarAction
+                        iconName="settings"
+                        iconDescription="Settings"
+                        onClick={action('TableToolbarAction - Settings')}
+                      />
+                      <Button onClick={this.handleOnClick} small kind="primary">
+                        Add new row
+                      </Button>
+                    </TableToolbarContent>
+                  </TableToolbar>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableSelectAll {...getSelectionProps()} />
+                        {headers.map(header => (
+                          <TableHeader {...getHeaderProps({ header })}>
+                            {header.header}
+                          </TableHeader>
+                        ))}
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map(row => (
+                        <TableRow key={row.id}>
+                          <TableSelectRow {...getSelectionProps({ row })} />
+                          {row.cells.map(cell => (
+                            <TableCell key={cell.id}>{cell.value}</TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            />
+          );
+        }
+      }
+
+      return <DynamicRows />;
+    }
   );

--- a/src/components/DataTable/DataTable-story.js
+++ b/src/components/DataTable/DataTable-story.js
@@ -580,9 +580,6 @@ storiesOf('DataTable', module)
                         iconDescription="Settings"
                         onClick={action('TableToolbarAction - Settings')}
                       />
-                      <Button onClick={action('Add new')} small kind="primary">
-                        Add new
-                      </Button>
                     </TableToolbarContent>
                   </TableToolbar>
                   <Table>

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -108,16 +108,16 @@ export default class DataTable extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const rowIds = this.props.rows.map(row => row.id).sort();
-    const nextRowIds = nextProps.rows.map(row => row.id).sort();
+    const rowIds = this.props.rows.map(row => row.id);
+    const nextRowIds = nextProps.rows.map(row => row.id);
 
     if (!isEqual(rowIds, nextRowIds)) {
       this.setState(state => getDerivedStateFromProps(nextProps, state));
       return;
     }
 
-    const headers = this.props.headers.map(header => header.key).sort();
-    const nextHeaders = nextProps.headers.map(header => header.key).sort();
+    const headers = this.props.headers.map(header => header.key);
+    const nextHeaders = nextProps.headers.map(header => header.key);
 
     if (!isEqual(headers, nextHeaders)) {
       this.setState(state => getDerivedStateFromProps(nextProps, state));

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import isEqual from 'lodash.isequal';
 import getDerivedStateFromProps from './state/getDerivedStateFromProps';
 import { getNextSortState, getCurrentSortState } from './state/sorting';
 import denormalize from './tools/denormalize';
@@ -120,6 +121,22 @@ export default class DataTable extends React.Component {
           key: this.state.sortHeaderKey,
         }),
       });
+      return;
+    }
+
+    const rowIds = this.state.rowIds.sort();
+    const nextRowIds = nextState.rowIds.sort();
+
+    if (!isEqual(rowIds, nextRowIds)) {
+      this.setState(nextState);
+      return;
+    }
+
+    const headers = this.props.headers.map(header => header.key);
+    const nextHeaders = nextProps.headers.map(header => header.key);
+
+    if (!isEqual(headers, nextHeaders)) {
+      this.setState(nextState);
     }
   }
 

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import isEqual from 'lodash.isequal';
 import getDerivedStateFromProps from './state/getDerivedStateFromProps';
-import { getNextSortState, getCurrentSortState } from './state/sorting';
+import { getNextSortState } from './state/sorting';
 import denormalize from './tools/denormalize';
 import { composeEventHandlers } from './tools/events';
 import { defaultFilterRows } from './tools/filter';
@@ -108,35 +108,20 @@ export default class DataTable extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const nextState = getDerivedStateFromProps(nextProps, this.state);
-
-    // Preserve the sorted order by re-sorting the data
-    if (
-      (nextState && nextState.sortHeaderKey !== this.state.sortHeaderKey) ||
-      nextState.sortDirection !== this.state.sortDirection
-    ) {
-      this.setState({
-        ...nextState,
-        ...getCurrentSortState(this.props, this.state, {
-          key: this.state.sortHeaderKey,
-        }),
-      });
-      return;
-    }
-
-    const rowIds = this.state.rowIds.sort();
-    const nextRowIds = nextState.rowIds.sort();
+    const rowIds = this.props.rows.map(row => row.id).sort();
+    const nextRowIds = nextProps.rows.map(row => row.id).sort();
 
     if (!isEqual(rowIds, nextRowIds)) {
-      this.setState(nextState);
+      this.setState(state => getDerivedStateFromProps(nextProps, state));
       return;
     }
 
-    const headers = this.props.headers.map(header => header.key);
-    const nextHeaders = nextProps.headers.map(header => header.key);
+    const headers = this.props.headers.map(header => header.key).sort();
+    const nextHeaders = nextProps.headers.map(header => header.key).sort();
 
     if (!isEqual(headers, nextHeaders)) {
-      this.setState(nextState);
+      this.setState(state => getDerivedStateFromProps(nextProps, state));
+      return;
     }
   }
 

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -303,4 +303,110 @@ describe('DataTable', () => {
       expect(selectedRows.length).toBe(0);
     });
   });
+
+  describe('componentWillReceiveProps', () => {
+    let mockProps;
+
+    beforeEach(() => {
+      mockProps = {
+        rows: [
+          {
+            id: 'b',
+            fieldA: 'Field 2:A',
+            fieldB: 'Field 2:B',
+          },
+          {
+            id: 'a',
+            fieldA: 'Field 1:A',
+            fieldB: 'Field 1:B',
+          },
+          {
+            id: 'c',
+            fieldA: 'Field 3:A',
+            fieldB: 'Field 3:B',
+          },
+        ],
+        headers: [
+          {
+            key: 'fieldA',
+            header: 'Field A',
+          },
+          {
+            key: 'fieldB',
+            header: 'Field B',
+          },
+        ],
+        locale: 'en',
+        render: jest.fn(({ rows, headers, getHeaderProps }) => (
+          <Table>
+            <TableHead>
+              <TableRow>
+                {headers.map(header => (
+                  <TableHeader {...getHeaderProps({ header })}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map(row => (
+                <TableRow key={row.id}>
+                  {row.cells.map(cell => (
+                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )),
+      };
+    });
+
+    it('should add additional rows when receiving new props', () => {
+      const wrapper = mount(<DataTable {...mockProps} />);
+      const args = mockProps.render.mock.calls[0][0];
+
+      expect(args.rows.length).toEqual(mockProps.rows.length);
+
+      const nextRows = [
+        ...mockProps.rows,
+        {
+          id: 'd',
+          fieldA: 'Field 4:A',
+          fieldB: 'Field 4:B',
+        },
+      ];
+
+      wrapper.setProps({ rows: nextRows });
+
+      const nextArgs = mockProps.render.mock.calls[1][0];
+      expect(nextArgs.rows.length).toBe(nextRows.length);
+    });
+
+    it('should add additional headers when receiving new props', () => {
+      const wrapper = mount(<DataTable {...mockProps} />);
+      const args = mockProps.render.mock.calls[0][0];
+
+      expect(args.headers).toEqual(mockProps.headers);
+
+      const nextProps = {
+        rows: mockProps.rows.map(row => ({
+          ...row,
+          fieldC: 'Field X:C',
+        })),
+        headers: [
+          ...mockProps.headers,
+          {
+            key: 'fieldC',
+            header: 'Field C',
+          },
+        ],
+      };
+
+      wrapper.setProps(nextProps);
+
+      const nextArgs = mockProps.render.mock.calls[1][0];
+      expect(nextArgs.headers).toEqual(nextProps.headers);
+    });
+  });
 });

--- a/src/components/DataTable/__tests__/DataTable-test.js
+++ b/src/components/DataTable/__tests__/DataTable-test.js
@@ -417,6 +417,7 @@ describe('DataTable', () => {
 
       const nextArgs = mockProps.render.mock.calls[1][0];
       expect(nextArgs.rows.length).toBe(nextRows.length);
+      expect(nextArgs.rows.map(row => row.id)).toEqual(['b', 'a', 'c', 'd']);
     });
 
     it('should add additional headers when receiving new props', () => {

--- a/src/components/DataTable/state/__tests__/getDerivedStateFromProps-test.js
+++ b/src/components/DataTable/state/__tests__/getDerivedStateFromProps-test.js
@@ -1,26 +1,90 @@
 import getDerivedStateFromProps from '../getDerivedStateFromProps';
-
-const props = {
-  rows: [],
-  headers: [],
-};
+import { defaultSortRow } from '../../tools/sorting';
 
 describe('getDerivedStateFromProps', () => {
   it('uses prevState if available', () => {
     const prevState = { sortDirection: 'DESC', sortHeaderKey: 'mockKey' };
+    const props = {
+      rows: [],
+      headers: [],
+    };
     expect(getDerivedStateFromProps(props, prevState)).toEqual(
-      expect.objectContaining({
-        ...prevState,
-      })
+      expect.objectContaining(prevState)
     );
   });
 
   it('has default values if prevState is not available', () => {
+    const props = {
+      rows: [],
+      headers: [],
+    };
     expect(getDerivedStateFromProps(props, {})).toEqual(
       expect.objectContaining({
         sortDirection: 'NONE',
         sortHeaderKey: null,
       })
     );
+  });
+
+  describe('with previous state', () => {
+    let mockProps;
+
+    beforeEach(() => {
+      mockProps = {
+        rows: [
+          {
+            id: '1',
+            sortField: 'b',
+          },
+          {
+            id: '2',
+            sortField: 'c',
+          },
+          {
+            id: '0',
+            sortField: 'a',
+          },
+        ],
+        headers: [
+          {
+            key: 'sortField',
+            header: 'Sort field',
+          },
+        ],
+        sortRow: defaultSortRow,
+        locale: 'en',
+      };
+    });
+
+    it('should preserve the previous sort state', () => {
+      const initialState = getDerivedStateFromProps(mockProps, {});
+      expect(initialState.rowIds).toEqual(['1', '2', '0']);
+      const prevState = {
+        sortHeaderKey: 'sortField',
+        sortDirection: 'DESC',
+      };
+      const nextState = getDerivedStateFromProps(mockProps, prevState);
+      expect(nextState.rowIds).toEqual(['0', '1', '2']);
+    });
+
+    it('should preserve the previous filter state', () => {
+      const initialState = getDerivedStateFromProps(mockProps, {});
+      expect(initialState.filterInputValue).toBe(null);
+      const prevState = {
+        filterInputValue: 'a',
+      };
+      const nextState = getDerivedStateFromProps(mockProps, prevState);
+      expect(nextState.filterInputValue).toBe('a');
+    });
+
+    it('should preserve the previous batch action state', () => {
+      const initialState = getDerivedStateFromProps(mockProps, {});
+      expect(initialState.shouldShowBatchActions).toBe(false);
+      const prevState = {
+        shouldShowBatchActions: true,
+      };
+      const nextState = getDerivedStateFromProps(mockProps, prevState);
+      expect(nextState.shouldShowBatchActions).toBe(true);
+    });
   });
 });

--- a/src/components/DataTable/state/__tests__/sorting-test.js
+++ b/src/components/DataTable/state/__tests__/sorting-test.js
@@ -4,7 +4,6 @@ describe('sorting state', () => {
   let initialSortState;
   let getNextSortDirection;
   let getNextSortState;
-  let getCurrentSortState;
 
   beforeEach(() => {
     jest.mock('../../tools/sorting', () => ({
@@ -16,7 +15,6 @@ describe('sorting state', () => {
     initialSortState = sorting.initialSortState;
     getNextSortDirection = sorting.getNextSortDirection;
     getNextSortState = sorting.getNextSortState;
-    getCurrentSortState = sorting.getCurrentSortState;
   });
 
   describe('sortStates', () => {
@@ -183,87 +181,6 @@ describe('sorting state', () => {
         sortDirection: sortStates.NONE,
         // Initial row order
         rowIds: ['a', 'b', 'c'],
-      });
-    });
-  });
-
-  describe('getCurrentSortState', () => {
-    let mockProps;
-    let mockState;
-
-    beforeEach(() => {
-      mockProps = {
-        locale: 'en',
-        sortRow: jest.fn(),
-      };
-      mockState = {
-        sortDirection: sortStates.NONE,
-        sortHeaderKey: null,
-        rowIds: ['b', 'a', 'c'],
-        initialRowOrder: ['a', 'b', 'c'],
-        cellsById: {
-          'a:a': {
-            value: 'row-a:header-a',
-          },
-          'a:b': {
-            value: 'row-a:header-b',
-          },
-          'a:c': {
-            value: 'row-a:header-c',
-          },
-          'b:a': {
-            value: 'row-b:header-a',
-          },
-          'b:b': {
-            value: 'row-b:header-b',
-          },
-          'b:c': {
-            value: 'row-b:header-c',
-          },
-        },
-      };
-    });
-
-    it('should sort based on the current sort state options', () => {
-      const sortHeaderKey = 'a';
-      const state1 = getCurrentSortState(mockProps, mockState, {
-        key: sortHeaderKey,
-      });
-      const state2 = getCurrentSortState(
-        mockProps,
-        {
-          ...mockState,
-          sortDirection: 'DESC',
-        },
-        {
-          key: sortHeaderKey,
-        }
-      );
-      const state3 = getCurrentSortState(
-        mockProps,
-        {
-          ...mockState,
-          sortDirection: 'ASC',
-        },
-        {
-          key: sortHeaderKey,
-        }
-      );
-      expect(state1).toEqual({
-        sortHeaderKey,
-        sortDirection: sortStates.NONE,
-        rowIds: ['a', 'b', 'c'],
-      });
-      expect(state2).toEqual({
-        sortHeaderKey,
-        sortDirection: sortStates.DESC,
-        rowIds: ['b', 'a', 'c'],
-      });
-      expect(state3).toEqual({
-        sortHeaderKey,
-        sortDirection: sortStates.ASC,
-        // Initial row order
-        rowIds: ['b', 'a', 'c'],
       });
     });
   });

--- a/src/components/DataTable/state/getDerivedStateFromProps.js
+++ b/src/components/DataTable/state/getDerivedStateFromProps.js
@@ -9,7 +9,11 @@ import normalize from '../tools/normalize';
  * are receiving for rows
  */
 const getDerivedStateFromProps = (props, prevState) => {
-  const { rowIds, rowsById, cellsById } = normalize(props.rows, props.headers);
+  const { rowIds, rowsById, cellsById } = normalize(
+    props.rows,
+    props.headers,
+    prevState
+  );
   const state = {
     rowIds,
     rowsById,

--- a/src/components/DataTable/state/getDerivedStateFromProps.js
+++ b/src/components/DataTable/state/getDerivedStateFromProps.js
@@ -1,4 +1,4 @@
-import { initialSortState } from './sorting';
+import { initialSortState, getSortedState } from './sorting';
 import normalize from '../tools/normalize';
 
 /**
@@ -10,7 +10,7 @@ import normalize from '../tools/normalize';
  */
 const getDerivedStateFromProps = (props, prevState) => {
   const { rowIds, rowsById, cellsById } = normalize(props.rows, props.headers);
-  return {
+  const state = {
     rowIds,
     rowsById,
     cellsById,
@@ -19,13 +19,24 @@ const getDerivedStateFromProps = (props, prevState) => {
     // Copy over rowIds so the reference doesn't mutate the stored
     // `initialRowOrder`
     initialRowOrder: rowIds.slice(),
-
-    filterInputValue: null,
+    filterInputValue: prevState.filterInputValue || null,
 
     // Optional state field to indicate whether a consumer should show a
     // batch actions menu
-    shouldShowBatchActions: false,
+    shouldShowBatchActions: prevState.shouldShowBatchActions || false,
   };
+
+  if (prevState.sortDirection && prevState.sortHeaderKey) {
+    const { rowIds } = getSortedState(
+      props,
+      state,
+      prevState.sortHeaderKey,
+      prevState.sortDirection
+    );
+    state.rowIds = rowIds;
+  }
+
+  return state;
 };
 
 export default getDerivedStateFromProps;

--- a/src/components/DataTable/state/sorting.js
+++ b/src/components/DataTable/state/sorting.js
@@ -55,10 +55,6 @@ export const getNextSortState = (props, state, { key }) => {
   return getSortedState(props, state, key, nextSortDirection);
 };
 
-export const getCurrentSortState = (props, state, { key }) => {
-  return getSortedState(props, state, key, state.sortDirection);
-};
-
 /**
  * Derive the set of sorted state fields from props and state for the given
  * header key and sortDirection
@@ -77,7 +73,7 @@ export const getCurrentSortState = (props, state, { key }) => {
  * @param {string} sortDirection The sortState that we want to order by
  * @returns {Object}
  */
-const getSortedState = (props, state, key, sortDirection) => {
+export const getSortedState = (props, state, key, sortDirection) => {
   const { rowIds, cellsById, initialRowOrder } = state;
   const { locale, sortRow } = props;
   const nextRowIds =

--- a/src/components/DataTable/tools/normalize.js
+++ b/src/components/DataTable/tools/normalize.js
@@ -7,7 +7,8 @@ import { getCellId } from './cells';
  * @param {Array<Object>} headers
  * @returns {Object}
  */
-const normalize = (rows, headers) => {
+const normalize = (rows, headers, prevState = {}) => {
+  const { rowsById: prevRowsByIds } = prevState;
   const rowIds = new Array(rows.length);
   const rowsById = {};
   const cellsById = {};
@@ -23,6 +24,13 @@ const normalize = (rows, headers) => {
       cells: new Array(headers.length),
     };
 
+    // If we have a previous state, and the row existed in that previous state,
+    // then we'll set the state values of the row to the previous state values.
+    if (prevRowsByIds && prevRowsByIds[row.id] !== undefined) {
+      rowsById[row.id].isSelected = prevRowsByIds[row.id].isSelected;
+      rowsById[row.id].isExpanded = prevRowsByIds[row.id].isExpanded;
+    }
+
     headers.forEach(({ key }, i) => {
       const id = getCellId(row.id, key);
       // Initialize the cell info and state values, namely for editing
@@ -37,6 +45,9 @@ const normalize = (rows, headers) => {
           header: key,
         },
       };
+
+      // TODO: When working on inline edits, we'll need to derive the state
+      // values similarly to rows above.
 
       rowsById[row.id].cells[i] = id;
     });


### PR DESCRIPTION
Closes #740 

Adds an extra check in the `cWRP` hook that will check to see if there are additional rowIds in the `nextState` and will update state accordingly, if so.

#### Changelog

**New**

**Changed**

* `DataTable`
  * Add behavior to `cWRP` to validate rowIds
  * Add corresponding tests for bugfix
  * Add `with dynamic rows` story to `DataTable-story`

**Removed**

![datatable](https://user-images.githubusercontent.com/3901764/38152346-f643193a-342c-11e8-8c74-bdbfbbb34819.gif)
