### PR TITLE
docs(NumberInput): add a comment on how to access the new value in onChange (#759)

### DIFF
--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -12,6 +12,10 @@ export default class NumberInput extends Component {
     label: PropTypes.string,
     max: PropTypes.number,
     min: PropTypes.number,
+    /**
+     * The new value is available in 'imaginaryTarget.value'
+     * i.e. to get the value: evt.imaginaryTarget.value
+     */
     onChange: PropTypes.func,
     onClick: PropTypes.func,
     step: PropTypes.number,


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#759

Ideally, this comment would be added in the Description column in proptypes table in the NumberInput Storybook, but I'm not sure how to do that?

#### Changelog
**Changed**

* Updated NumberInput `onChange` docs