### PR TITLE
fix(RadioTile): Accepts className in props

### DIFF
--- a/src/components/RadioTile/RadioTile-test.js
+++ b/src/components/RadioTile/RadioTile-test.js
@@ -65,8 +65,8 @@ describe('RadioButton', () => {
         expect(label.text()).toMatch(/test label text/);
       });
 
-      it('should have the class passed through props', () => {
-        expect(label.hasClass(label.props.className)).toEqual(true);
+      it('should not have the className when no class is passed through props', () => {
+        expect(label.hasClass(label.props.className)).toEqual(false);
       });
     });
 

--- a/src/components/RadioTile/RadioTile-test.js
+++ b/src/components/RadioTile/RadioTile-test.js
@@ -64,6 +64,10 @@ describe('RadioButton', () => {
         wrapper.setProps({ labelText: 'test label text' });
         expect(label.text()).toMatch(/test label text/);
       });
+
+      it('should have the class passed through props', () => {
+        expect(label.hasClass(label.props.className).toEqual(true));
+      });
     });
 
     describe('wrapper', () => {

--- a/src/components/RadioTile/RadioTile-test.js
+++ b/src/components/RadioTile/RadioTile-test.js
@@ -68,6 +68,13 @@ describe('RadioButton', () => {
       it('should not have the className when no class is passed through props', () => {
         expect(label.hasClass(label.props.className)).toEqual(false);
       });
+
+      it('should have the className passed through props', () => {
+        const label = render({
+          className: 'extra-class',
+        });
+        expect(label.hasClass('extra-class')).toEqual(true);
+      });
     });
 
     describe('wrapper', () => {

--- a/src/components/RadioTile/RadioTile-test.js
+++ b/src/components/RadioTile/RadioTile-test.js
@@ -66,7 +66,7 @@ describe('RadioButton', () => {
       });
 
       it('should have the class passed through props', () => {
-        expect(label.hasClass(label.props.className).toEqual(true));
+        expect(label.hasClass(label.props.className)).toEqual(true);
       });
     });
 

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -17,7 +17,6 @@ export default class RadioTile extends React.Component {
 
   static defaultProps = {
     onChange: () => {},
-    className: null,
   };
 
   componentWillMount() {
@@ -29,16 +28,11 @@ export default class RadioTile extends React.Component {
   };
 
   render() {
-    const { children, ...other } = this.props;
+    const { children, className, ...other } = this.props;
 
-    const classes = classNames(
-      this.props.className,
-      'bx--tile',
-      'bx--tile--selectable',
-      {
-        'bx--tile--is-selected': this.props.checked,
-      }
-    );
+    const classes = classNames(className, 'bx--tile', 'bx--tile--selectable', {
+      'bx--tile--is-selected': this.props.checked,
+    });
 
     return (
       <label htmlFor={this.uid} className={classes}>

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 export default class RadioTile extends React.Component {
   static propTypes = {
     checked: PropTypes.bool,
+    className: PropTypes.string,
     defaultChecked: PropTypes.bool,
     id: PropTypes.string,
     name: PropTypes.string,
@@ -29,9 +30,14 @@ export default class RadioTile extends React.Component {
   render() {
     const { children, ...other } = this.props;
 
-    const classes = classNames('bx--tile', 'bx--tile--selectable', {
-      'bx--tile--is-selected': this.props.checked,
-    });
+    const classes = classNames(
+      this.props.className,
+      'bx--tile',
+      'bx--tile--selectable',
+      {
+        'bx--tile--is-selected': this.props.checked,
+      }
+    );
 
     return (
       <label htmlFor={this.uid} className={classes}>

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -17,6 +17,7 @@ export default class RadioTile extends React.Component {
 
   static defaultProps = {
     onChange: () => {},
+    className: null,
   };
 
   componentWillMount() {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#

`label` in `RadioTile` now accepts className via Props


#### Changelog

**New**

```
static propTypes = {
          checked: PropTypes.bool,
          className: PropTypes.string,
          defaultChecked: PropTypes.bool,
          id: PropTypes.string,
          name: PropTypes.string,
          onChange: PropTypes.func,
          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
  };
```

**Changed**

* `className: PropTypes.string`

**Removed**

* N/A
