### PR TITLE
fix(Modal): update ariaLabel to be aria-label and add it to the story

### DIFF
--- a/src/components/Modal/Modal-story.js
+++ b/src/components/Modal/Modal-story.js
@@ -22,6 +22,7 @@ storiesOf('Modal', module)
         {...modalProps}
         open
         modalHeading="Modal heading"
+        modalAriaLabel="Modal Heading"
         modalLabel="Optional label"
         primaryButtonText="Primary Button"
         secondaryButtonText="Secondary Button">

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -98,7 +98,7 @@ export default class Modal extends Component {
         }}
         role="dialog"
         className="bx--modal-container"
-        ariaLabel={modalAriaLabel}>
+        aria-label={modalAriaLabel}>
         <div className="bx--modal-header">
           {passiveModal && modalButton}
           {modalLabel && (


### PR DESCRIPTION
Aria is actually kinda strange in react. It is one of the few html attributes that is supported in it's original state and not camelCased. https://reactjs.org/docs/accessibility.html

This means that react doesn't translate ariaLabel to be `aria-label` in the html element. You must instead define it as `aria-label` in react.

This goes for all `aria-*` attributes.