### PR TITLE
fix(floating-menu): positioning in scrollable container maintained

### DIFF
--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -318,25 +318,26 @@ class FloatingMenu extends React.Component {
   _getChildrenWithProps = () => {
     const { styles, children } = this.props;
     const { floatingPosition: pos } = this.state;
-    const style = pos
-      ? Object.assign(
-          {
-            left: `${pos.left}px`,
-            top: `${pos.top}px`,
-            position: 'absolute',
-            right: 'auto',
-            margin: 0,
-            opacity: 1,
-          },
-          styles
-        )
+    // If no pos available, we need to hide the element (offscreen to the right)
+    // This is done so we can measure the content before positioning it correctly.
+    const positioningStyle = pos
+      ? {
+          left: `${pos.left}px`,
+          top: `${pos.top}px`,
+          right: 'auto',
+        }
       : {
           right: `${window.innerWidth}px`,
           top: '0px',
-          position: 'absolute',
         };
     return React.cloneElement(children, {
-      style,
+      style: {
+        ...styles,
+        ...positioningStyle,
+        position: 'absolute',
+        margin: 0,
+        opacity: 1,
+      },
     });
   };
 

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -327,7 +327,7 @@ class FloatingMenu extends React.Component {
           right: 'auto',
         }
       : {
-          right: `${window.innerWidth}px`,
+          left: `${window.innerWidth}px`,
           top: '0px',
         };
     return React.cloneElement(children, {

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -318,21 +318,28 @@ class FloatingMenu extends React.Component {
   _getChildrenWithProps = () => {
     const { styles, children } = this.props;
     const { floatingPosition: pos } = this.state;
-    return !pos
-      ? children
-      : React.cloneElement(children, {
-          style: Object.assign(
-            {
-              left: `${pos.left}px`,
-              top: `${pos.top}px`,
-              position: 'absolute',
-              right: 'auto',
-              margin: 0,
-              opacity: 1,
-            },
-            styles
-          ),
-        });
+    if (pos) {
+      return React.cloneElement(children, {
+        style: Object.assign(
+          {
+            left: `${pos.left}px`,
+            top: `${pos.top}px`,
+            position: 'absolute',
+            right: 'auto',
+            margin: 0,
+            opacity: 1,
+          },
+          styles
+        ),
+      });
+    }
+    return React.cloneElement(children, {
+      style: Object.assign({
+        right: `${window.innerWidth}px`,
+        top: '0px',
+        position: 'absolute',
+      }),
+    });
   };
 
   render() {

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -318,23 +318,25 @@ class FloatingMenu extends React.Component {
   _getChildrenWithProps = () => {
     const { styles, children } = this.props;
     const { floatingPosition: pos } = this.state;
-    const style = pos ? Object.assign(
-      {
-        left: `${pos.left}px`,
-        top: `${pos.top}px`,
-        position: 'absolute',
-        right: 'auto',
-        margin: 0,
-        opacity: 1,
-      },
-      styles
-    ) : {
-      right: `${window.innerWidth}px`,
-      top: '0px',
-      position: 'absolute',
-    }
+    const style = pos
+      ? Object.assign(
+          {
+            left: `${pos.left}px`,
+            top: `${pos.top}px`,
+            position: 'absolute',
+            right: 'auto',
+            margin: 0,
+            opacity: 1,
+          },
+          styles
+        )
+      : {
+          right: `${window.innerWidth}px`,
+          top: '0px',
+          position: 'absolute',
+        };
     return React.cloneElement(children, {
-      style
+      style,
     });
   };
 

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -318,27 +318,23 @@ class FloatingMenu extends React.Component {
   _getChildrenWithProps = () => {
     const { styles, children } = this.props;
     const { floatingPosition: pos } = this.state;
-    if (pos) {
-      return React.cloneElement(children, {
-        style: Object.assign(
-          {
-            left: `${pos.left}px`,
-            top: `${pos.top}px`,
-            position: 'absolute',
-            right: 'auto',
-            margin: 0,
-            opacity: 1,
-          },
-          styles
-        ),
-      });
+    const style = pos ? Object.assign(
+      {
+        left: `${pos.left}px`,
+        top: `${pos.top}px`,
+        position: 'absolute',
+        right: 'auto',
+        margin: 0,
+        opacity: 1,
+      },
+      styles
+    ) : {
+      right: `${window.innerWidth}px`,
+      top: '0px',
+      position: 'absolute',
     }
     return React.cloneElement(children, {
-      style: Object.assign({
-        right: `${window.innerWidth}px`,
-        top: '0px',
-        position: 'absolute',
-      }),
+      style
     });
   };
 

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -318,7 +318,7 @@ class FloatingMenu extends React.Component {
   _getChildrenWithProps = () => {
     const { styles, children } = this.props;
     const { floatingPosition: pos } = this.state;
-    // If no pos available, we need to hide the element (offscreen to the right)
+    // If no pos available, we need to hide the element (offscreen to the left)
     // This is done so we can measure the content before positioning it correctly.
     const positioningStyle = pos
       ? {


### PR DESCRIPTION
Override style of default render to position offscreen to the right
to prevent the window.scrollY from being affected right before
measuring the size of the menu.

This seems to only be an issue in the latest version of react (16.3) probably
due to the asynchronous rendering changes.