### PR TITLE
fix(overflow-menu-item): Support nodes as items

### DIFF
--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -57,7 +57,7 @@ OverflowMenuItem.propTypes = {
   /**
    * The text in the menu item.
    */
-  itemText: PropTypes.string.isRequired,
+  itemText: PropTypes.node.isRequired,
 
   /**
    * `true` to make this menu item a divider.


### PR DESCRIPTION
Remove proptype warning on itemText.

There should be nothing that prevents more complex children in the overflowmenuitem. This supports things like React Intl, etc.

{{short description}}

#### Changelog

**Changed**

* OverflowMenuItem: itemText can be any valid react node (including a string)