### PR TITLE
fix(list-box): Prevent focus on icon inside selection

### DIFF
--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -42,7 +42,7 @@ const ListBoxSelection = ({
       onKeyDown={handleOnKeyDown}
       title={description}>
       {selectionCount}
-      <Icon name="close" description={description} focusable={false} />
+      <Icon name="close" description={description} focusable="false" />
     </div>
   );
 };

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -42,7 +42,7 @@ const ListBoxSelection = ({
       onKeyDown={handleOnKeyDown}
       title={description}>
       {selectionCount}
-      <Icon name="close" description={description} />
+      <Icon name="close" description={description} focusable={false} />
     </div>
   );
 };

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -22,6 +22,7 @@ exports[`ListBoxField should render 1`] = `
         <Icon
           description="Clear selected item"
           fillRule="evenodd"
+          focusable="false"
           name="close"
           role="img"
         >
@@ -29,6 +30,7 @@ exports[`ListBoxField should render 1`] = `
             alt="Clear selected item"
             aria-label="Clear selected item"
             fillRule="evenodd"
+            focusable="false"
             height="10"
             name="close"
             role="img"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxSelection-test.js.snap
@@ -27,6 +27,7 @@ exports[`ListBoxSelection should render 1`] = `
     <Icon
       description="translation"
       fillRule="evenodd"
+      focusable="false"
       name="close"
       role="img"
     >
@@ -34,6 +35,7 @@ exports[`ListBoxSelection should render 1`] = `
         alt="translation"
         aria-label="translation"
         fillRule="evenodd"
+        focusable="false"
         height="10"
         name="close"
         role="img"
@@ -82,6 +84,7 @@ exports[`ListBoxSelection should render 2`] = `
     <Icon
       description="translation"
       fillRule="evenodd"
+      focusable="false"
       name="close"
       role="img"
     >
@@ -89,6 +92,7 @@ exports[`ListBoxSelection should render 2`] = `
         alt="translation"
         aria-label="translation"
         fillRule="evenodd"
+        focusable="false"
         height="10"
         name="close"
         role="img"


### PR DESCRIPTION
This prevents a weird issue in IE where focus on the svg causes an
exception in downshift.

The issue occurs only in IE. Basically, downshift tries to manage focus after the input loses focus, and if the element is an SVG, downshift has a fit. This quick fix prevents that on our side.