### PR TITLE
fix(date-picker-input): default pattern is faulty

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -21,13 +21,13 @@ const datePickerInputProps = {
   onClick: action('onClick'),
   onChange: action('onInputChange'),
   placeholder: 'mm/dd/yyyy',
-  pattern: 'd{1,2}/d{1,2}/d{4}',
+  pattern: '\\d{1,2}\\/\\d{1,2}\\/\\d{4}',
   id: 'date-picker-input-id',
 };
 
 const simpleShortDatePickerInputProps = {
   placeholder: 'mm/yyyy',
-  pattern: 'd{1,2}/d{4}',
+  pattern: '\\d{1,2}\\/\\d{4}',
 };
 
 storiesOf('DatePicker', module)

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,6 +9,9 @@ export default class DatePickerInput extends Component {
   };
 
   static defaultProps = {
+    // prettier-ignore
+    // Need this format for validation to work on FF
+    // eslint-disable-next-line no-useless-escape
     pattern: '\d{1,2}\/\d{1,2}\/\d{4}',
     type: 'text',
     disabled: false,

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,9 +9,6 @@ export default class DatePickerInput extends Component {
   };
 
   static defaultProps = {
-    // prettier-ignore
-    // Need this format for validation to work on FF
-    // eslint-disable-next-line no-useless-escape
     pattern: '\\d{1,2}\\/\\d{1,2}\\/\\d{4}',
     type: 'text',
     disabled: false,

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -9,7 +9,7 @@ export default class DatePickerInput extends Component {
   };
 
   static defaultProps = {
-    pattern: 'd{1,2}/d{1,2}/d{4}',
+    pattern: '\d{1,2}\/\d{1,2}\/\d{4}',
     type: 'text',
     disabled: false,
     invalid: false,

--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -12,7 +12,7 @@ export default class DatePickerInput extends Component {
     // prettier-ignore
     // Need this format for validation to work on FF
     // eslint-disable-next-line no-useless-escape
-    pattern: '\d{1,2}\/\d{1,2}\/\d{4}',
+    pattern: '\\d{1,2}\\/\\d{1,2}\\/\\d{4}',
     type: 'text',
     disabled: false,
     invalid: false,


### PR DESCRIPTION
The default pattern for the input should be a valid regexp.

I don't know if the intention was to be `\d{1,2}\d{1,2}\d{4}` or if it was to be separated by /s or not.

#### Changelog

**Changed**

* Default `pattern` prop on DatePickerInput is now a valid regexp
