### PR TITLE
fix(TooltipSimple): handle case when the tooltip icon not displaying

### DIFF
--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -27,9 +27,7 @@ const TooltipSimple = ({
             tabIndex="0"
             role="button"
             {...other}>
-            {showIcon && (
-              <Icon role="img" name={iconName} description={iconDescription} />
-            )}
+            <Icon role="img" name={iconName} description={iconDescription} />
           </div>
         </div>
       ) : (

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -17,18 +17,33 @@ const TooltipSimple = ({
 
   const tooltipWrapperClasses = classNames(`bx--tooltip--simple`, className);
   return (
-    <div className={tooltipWrapperClasses}>
-      {children}
-      <div
-        className={tooltipClasses}
-        data-tooltip-text={text}
-        tabIndex="0"
-        role="button"
-        {...other}>
-        {showIcon && (
-          <Icon role="img" name={iconName} description={iconDescription} />
-        )}
-      </div>
+    <div>
+      {showIcon ? (
+        <div className={tooltipWrapperClasses}>
+          {children}
+          <div
+            className={tooltipClasses}
+            data-tooltip-text={text}
+            tabIndex="0"
+            role="button"
+            {...other}>
+            {showIcon && (
+              <Icon role="img" name={iconName} description={iconDescription} />
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className={tooltipWrapperClasses}>
+          <div
+            className={tooltipClasses}
+            data-tooltip-text={text}
+            tabIndex="0"
+            role="button"
+            {...other}>
+            {children}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION

Closes #786

Add condition to handle case when the tooltip icon not displaying

#### Changelog
**New**
The TooltipSimple without the icon is displayed 

**Changed**

**Removed**

