### PR TITLE
fix(DatePickerInput): add default onChange prop

### DIFF
--- a/src/components/DatePickerInput/DatePickerInput.js
+++ b/src/components/DatePickerInput/DatePickerInput.js
@@ -15,6 +15,7 @@ export default class DatePickerInput extends Component {
     invalid: false,
     labelText: '',
     onClick: () => {},
+    onChange: () => {},
   };
 
   render() {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#

Add default `onChange` prop in `DatePickerInput` - This fix is similar to the one that has been done for #720 

#### Changelog

**New**
```
static defaultProps = {
    pattern: 'd{1,2}/d{1,2}/d{4}',
    type: 'text',
    disabled: false,
    invalid: false,
    labelText: '',
    onClick: () => {},
    onChange: () => {},
};
```


**Changed**

```
static defaultProps = {
    pattern: 'd{1,2}/d{1,2}/d{4}',
    type: 'text',
    disabled: false,
    invalid: false,
    labelText: '',
    onClick: () => {},
};
```

**Removed**
N/A
