### PR TITLE
fix(floating-menu): Hide floating menu if no position available

### DIFF
--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -327,7 +327,7 @@ class FloatingMenu extends React.Component {
           right: 'auto',
         }
       : {
-          left: `${window.innerWidth}px`,
+          visibility: 'hidden',
           top: '0px',
         };
     return React.cloneElement(children, {


### PR DESCRIPTION
Instead of hiding the menu off to the side (which, as it turns out, causes the text to wrap and extend the height of the element), just make it invisible.