### PR TITLE
fix(date-picker): Provide examples for fully controlled datepicker

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action, decorateAction } from '@storybook/addon-actions';
 import DatePicker from '../DatePicker';
 import DatePickerInput from '../DatePickerInput';
+import WithState from '../../tools/withState';
 
 // Datepickers last argument contains an instance of flatpickr
 // and will cause action logger to enter an infinite loop. Just don't log that argument
@@ -86,5 +87,39 @@ storiesOf('DatePicker', module)
           id="date-picker-input-id-2"
         />
       </DatePicker>
+    )
+  )
+  .addWithInfo(
+    'fully controlled',
+    `
+      If your application needs to control the value of the date picker and
+      be notified of any changes.
+    `,
+    () => (
+      <WithState initialState={{ date: '' }}>
+        {({ state, setState }) => (
+          <>
+            <DatePicker
+              datePickerType="single"
+              dateFormat="m/d/Y"
+              value={state.date}
+              onChange={eventOrDates => {
+                const value = eventOrDates.target
+                  ? eventOrDates.target.value
+                  : eventOrDates[0];
+                setState({ date: value });
+              }}>
+              <DatePickerInput
+                key="label"
+                labelText="Controlled Date"
+                id="date-picker-input-id"
+              />
+            </DatePicker>
+            <button onClick={() => setState({ date: '01/01/2011' })}>
+              Click me to set to 01/01/2011
+            </button>
+          </>
+        )}
+      </WithState>
     )
   );

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -52,7 +52,13 @@ export default class DatePicker extends Component {
      */
     value: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.array,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.object,
+        ])
+      ),
       PropTypes.object,
       PropTypes.number,
     ]),

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -47,9 +47,15 @@ export default class DatePicker extends Component {
     dateFormat: PropTypes.string,
 
     /**
-     * The value of the `<input>`.
+     * The value of the date value provided to flatpickr, could
+     * be a date, a date number, a date string, an array of dates.
      */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.array,
+      PropTypes.object,
+      PropTypes.number,
+    ]),
 
     /**
      * The DOM element the Flatpicker should be inserted into. `<body>` by default.
@@ -236,6 +242,7 @@ export default class DatePicker extends Component {
       short,
       datePickerType,
       dateFormat, // eslint-disable-line
+      onChange, // eslint-disable-line
       ...other
     } = this.props;
 


### PR DESCRIPTION
Also prevent onChange event from being placed on the any other element.

#### Changelog

**Changed**

* datepicker `onChange` prop triggers properly when provided the `value` prop. So the onChange event on the datepicker is only called when a date is selected and not on input change. Input change can be caught on datepicker-input.