### PR TITLE
"fix(Modal):  close the Modal when expected

### DIFF
--- a/src/components/Modal/Modal-test.js
+++ b/src/components/Modal/Modal-test.js
@@ -89,13 +89,13 @@ describe('Modal', () => {
 
   describe('events', () => {
     it('should set expected class when state is open', () => {
-      const wrapper = mount(<ModalWrapper />);
+      const wrapper = mount(<Modal />);
       const modal = wrapper.find(Modal);
       const modalContainer = modal.find('.bx--modal');
       const openClass = 'is-visible';
 
       expect(modalContainer.hasClass(openClass)).not.toEqual(true);
-      wrapper.setState({ isOpen: true });
+      wrapper.setState({ open: true });
       expect(wrapper.find('.bx--modal').hasClass(openClass)).toEqual(true);
     });
 
@@ -108,31 +108,31 @@ describe('Modal', () => {
     });
 
     it('should set open state to false when close button is clicked', () => {
-      const wrapper = mount(<ModalWrapper />);
+      const wrapper = mount(<Modal />);
       const modal = wrapper.find(Modal);
       const closeBtn = modal.find('.bx--modal-close');
-      wrapper.setState({ isOpen: true });
-      expect(wrapper.state('isOpen')).toEqual(true);
+      wrapper.setState({ open: true });
+      expect(wrapper.state('open')).toEqual(true);
       closeBtn.simulate('click');
-      expect(wrapper.state('isOpen')).not.toEqual(true);
+      expect(wrapper.state('open')).not.toEqual(true);
     });
 
     it('should stay open when "inner modal" is clicked', () => {
-      const wrapper = mount(<ModalWrapper />);
+      const wrapper = mount(<Modal />);
       const modal = wrapper.find(Modal);
       const div = modal.find('.bx--modal-container');
-      wrapper.setState({ isOpen: true });
+      wrapper.setState({ open: true });
       div.simulate('click');
-      expect(wrapper.state('isOpen')).toEqual(true);
+      expect(wrapper.state('open')).toEqual(true);
     });
 
     it('should close when "outer modal" is clicked...not "inner modal"', () => {
-      const wrapper = mount(<ModalWrapper />);
+      const wrapper = mount(<Modal />);
       const modal = wrapper.find(Modal);
       const div = modal.find('.bx--modal');
-      wrapper.setState({ isOpen: true });
+      wrapper.setState({ open: true });
       div.simulate('click');
-      expect(wrapper.state('isOpen')).toEqual(false);
+      expect(wrapper.state('open')).toEqual(false);
     });
 
     it('should handle keyDown events', () => {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -36,6 +36,18 @@ export default class Modal extends Component {
     modalLabel: '',
   };
 
+  state = {
+    open: this.props.open,
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.open !== this.state.open) {
+      this.setState({
+        open: nextProps.open,
+      });
+    }
+  }
+
   handleKeyDown = evt => {
     if (evt.which === 27) {
       this.props.onRequestClose();
@@ -44,11 +56,18 @@ export default class Modal extends Component {
 
   handleClick = evt => {
     if (this.innerModal && !this.innerModal.contains(evt.target)) {
-      this.props.onRequestClose();
+      this.onRequestClose();
     }
   };
 
+  onRequestClose = () => {
+    this.setState({
+      open: false,
+    });
+  };
+
   render() {
+    const { open } = this.state;
     const {
       modalHeading,
       modalLabel,
@@ -56,7 +75,6 @@ export default class Modal extends Component {
       passiveModal,
       secondaryButtonText,
       primaryButtonText,
-      open,
       onRequestClose,
       onRequestSubmit,
       onSecondarySubmit,
@@ -82,7 +100,7 @@ export default class Modal extends Component {
       <button
         className="bx--modal-close"
         type="button"
-        onClick={onRequestClose}>
+        onClick={this.onRequestClose}>
         <Icon
           name="close"
           className="bx--modal-close__icon"


### PR DESCRIPTION
Closes  #797

Add state for  reading from state not from props
description of `onRequestClose`
Add `componentWillReceiveProps` for sync state

#### Changelog

The Modal close when expected

**Changed**

**Removed**

