### PR TITLE
feat(click-listener): Able to change ref prop name if desired

### DIFF
--- a/src/internal/ClickListener.js
+++ b/src/internal/ClickListener.js
@@ -9,6 +9,7 @@ export default class ClickListener extends React.Component {
   static propTypes = {
     children: PropTypes.element.isRequired,
     onClickOutside: PropTypes.func.isRequired,
+    refPropName: PropTypes.string,
   };
 
   constructor(props) {
@@ -37,7 +38,7 @@ export default class ClickListener extends React.Component {
   }
 
   handleRef(el) {
-    const { children } = this.props;
+    const { children, refPropName } = this.props;
     this.element = el;
 
     /**
@@ -49,8 +50,9 @@ export default class ClickListener extends React.Component {
      *   <Child ref={targetedRefHere} />
      * </ClickListener>
      */
-    if (children.ref && typeof children.ref === 'function') {
-      children.ref(el);
+    const childRef = children[refPropName || 'ref'];
+    if (childRef && typeof childRef === 'function') {
+      childRef(el);
     }
   }
 


### PR DESCRIPTION
Sometimes the children is an HoC whose element is not useful. Allowing
HoCs to pass the ref on to wrapped instances.

This change is made with the hopes that clicklistener can be exposed externally at some point.