### PR TITLE
feat(OverflowMenuItem): call onClick for Space/Enter key presses

### DIFF
--- a/src/components/OverflowMenuItem/OverflowMenuItem-test.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem-test.js
@@ -38,5 +38,63 @@ describe('OverflowMenuItem', () => {
 
       expect(wrapper.hasClass('bx--overflow-menu--divider')).toEqual(true);
     });
+
+    it('calls onClick function when clicked', () => {
+      const clickFn = jest.fn();
+      const wrapper = shallowRender({
+        itemText: 'testing',
+        closeMenu: () => {},
+        onClick: clickFn,
+      });
+
+      const button = wrapper.find('button');
+      button.simulate('click');
+      expect(clickFn).toHaveBeenCalled();
+    });
+
+    it('calls onClick function when Space is pressed', () => {
+      const spaceKey = 32;
+      const clickFn = jest.fn();
+      const wrapper = shallowRender({
+        itemText: 'testing',
+        closeMenu: () => {},
+        onClick: clickFn,
+      });
+
+      const button = wrapper.find('button');
+      button.simulate('keydown', { which: spaceKey });
+      expect(clickFn).toHaveBeenCalled();
+    });
+
+    it('calls onClick function when Enter is pressed', () => {
+      const enterKey = 13;
+      const clickFn = jest.fn();
+      const wrapper = shallowRender({
+        itemText: 'testing',
+        closeMenu: () => {},
+        onClick: clickFn,
+      });
+
+      const button = wrapper.find('button');
+      button.simulate('keydown', { which: enterKey });
+      expect(clickFn).toHaveBeenCalled();
+    });
+
+    it('calls onKeyDown function when provided instead of onClick function', () => {
+      const enterKey = 13;
+      const clickFn = jest.fn();
+      const keyFn = jest.fn();
+      const wrapper = shallowRender({
+        itemText: 'testing',
+        closeMenu: () => {},
+        onClick: clickFn,
+        onKeyDown: keyFn,
+      });
+
+      const button = wrapper.find('button');
+      button.simulate('keydown', { which: enterKey });
+      expect(clickFn).not.toHaveBeenCalled();
+      expect(keyFn).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -32,12 +32,22 @@ const OverflowMenuItem = ({
     closeMenu();
   };
 
+  const handleKey = evt => {
+    const key = evt.key || evt.which;
+
+    if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
+      onClick(evt);
+      closeMenu();
+    }
+  };
+
   const primaryFocusProp = !primaryFocus
     ? {}
     : { 'data-floating-menu-primary-focus': true };
   const item = (
     <li className={overflowMenuItemClasses} role="menuitem">
       <button
+        onKeyDown={handleKey}
         {...other}
         {...primaryFocusProp}
         className={overflowMenuBtnClasses}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#818

Make it easier for consumers to build accessible overflow menus - saves them having to add their own key handlers for each menu item.

#### Changelog

**New**

* To help with Accessibility, OverflowMenuItem now calls `onClick` function for Space/Enter key presses (unless an `onKeyPress` function is already provided)