### PR TITLE
fix(OverflowMenu): allow key events to be handled by menu items

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -120,7 +120,21 @@ describe('OverflowMenu', () => {
       expect(rootWrapper.state().open).toEqual(true);
     });
 
-    it('should toggle state in response to Enter or Space', () => {
+    it('should toggle state in response to Enter or Space when the menu is closed', () => {
+      const enterKey = 13;
+      const spaceKey = 32;
+      const rootWrapper = shallow(<OverflowMenu />);
+      const menu = rootWrapper.childAt(0);
+
+      rootWrapper.setState({ open: false });
+
+      menu.simulate('keydown', { which: spaceKey });
+      expect(rootWrapper.state().open).toEqual(true);
+      menu.simulate('keydown', { which: enterKey });
+      expect(rootWrapper.state().open).toEqual(true);
+    });
+
+    it('should NOT toggle state in response to Enter or Space when the menu is open', () => {
       const enterKey = 13;
       const spaceKey = 32;
       const rootWrapper = shallow(<OverflowMenu />);
@@ -129,7 +143,7 @@ describe('OverflowMenu', () => {
       rootWrapper.setState({ open: true });
 
       menu.simulate('keydown', { which: spaceKey });
-      expect(rootWrapper.state().open).toEqual(false);
+      expect(rootWrapper.state().open).toEqual(true);
       menu.simulate('keydown', { which: enterKey });
       expect(rootWrapper.state().open).toEqual(true);
     });

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -231,10 +231,13 @@ export default class OverflowMenu extends Component {
   };
 
   handleKeyPress = evt => {
-    const key = evt.key || evt.which;
+    // only respond to key events when the menu is closed, so that menu items still respond to key events
+    if (!this.state.open) {
+      const key = evt.key || evt.which;
 
-    if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
-      this.setState({ open: !this.state.open });
+      if (key === 'Enter' || key === 13 || key === ' ' || key === 32) {
+        this.setState({ open: true });
+      }
     }
   };
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#818

Allow menu items to be selected by pressing Space/Enter. Previously the key handler caused the menu to close, before the menu items had chance to handle the event. But the menu closes when tabbing out of the menu, so the handler is only needed to open the menu, not to close it.

The fix can be seen from the OverflowMenu storybook - without the fix, selecting menu items using the keyboard doesn't show anything in the Action Logger, but with the fix the onClick action is fired.

#### Changelog

**Changed**

* Accessibility fix: Allow overflow menu items to be selected by pressing Space/Enter
