### PR TITLE
fix(PaginationV2): adjust spacing, resolves #778

### DIFF
--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -158,9 +158,7 @@ export default class PaginationV2 extends Component {
     return (
       <div className={classNames} {...other}>
         <div className="bx--pagination__left">
-          <span className="bx--pagination__text">
-            {itemsPerPageText}:&nbsp;&nbsp;
-          </span>
+          <span className="bx--pagination__text">{itemsPerPageText}:</span>
           <Select
             id={`bx-pagination-select-${inputId}`}
             labelText={itemsPerPageText}


### PR DESCRIPTION
Closes #778

fix spacing discrepancy (Carbon Vanilla vs. React)

#### Changelog

**New**
**Changed**

 * Remove the space added after the text

**Removed**

