### PR TITLE
docs(OverflowMenu): more docs on floating mode

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -66,7 +66,7 @@ export default class OverflowMenu extends Component {
     flipped: PropTypes.bool,
 
     /**
-     * `true` if the menu should be floated.
+     * `true` if the menu should be floated, making the DOM of the menu body orphaned from the trigger button.
      * Useful when the container of the triggering element cannot have `overflow:visible` style, etc.
      */
     floatingMenu: PropTypes.bool,


### PR DESCRIPTION
Refs #841.

#### Changelog

**Changed**

* Better documentation for `floatingMenu` prop in `<OverflowMenu>`.