### PR TITLE
feat: add language locale prop to DatePicker for global use

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -19,6 +19,7 @@ const datePickerProps = {
 const datePickerInputProps = {
   className: 'some-class',
   labelText: 'Date Picker label',
+  locale: 'en',
   onClick: action('onClick'),
   onChange: action('onInputChange'),
   placeholder: 'mm/dd/yyyy',

--- a/src/components/DatePicker/DatePicker-test.js
+++ b/src/components/DatePicker/DatePicker-test.js
@@ -167,4 +167,53 @@ describe('DatePicker', () => {
       expect(icon.length).toEqual(1);
     });
   });
+
+  describe('Date picker with locale', () => {
+    const wrapper = mount(
+      <DatePicker
+        onChange={() => {}}
+        datePickerType="range"
+        className="extra-class"
+        locale="es">
+        <div className="test-child">
+          <input
+            type="text"
+            className="bx--date-picker__input"
+            id="input-from"
+          />
+        </div>
+        <div className="test-child">
+          <input type="text" className="bx--date-picker__input" id="input-to" />
+        </div>
+      </DatePicker>
+    );
+
+    const wrapperNoLocale = mount(
+      <DatePicker
+        onChange={() => {}}
+        datePickerType="range"
+        className="extra-class">
+        <div className="test-child">
+          <input
+            type="text"
+            className="bx--date-picker__input"
+            id="input-from"
+          />
+        </div>
+        <div className="test-child">
+          <input type="text" className="bx--date-picker__input" id="input-to" />
+        </div>
+      </DatePicker>
+    );
+
+    it('has the range date picker locale', () => {
+      const datepicker = wrapper.find('DatePicker');
+      expect(datepicker.props().locale).toBe('es');
+    });
+
+    it('has the range date picker without locale defined', () => {
+      const datepicker = wrapperNoLocale.find('DatePicker');
+      expect(datepicker.props().locale).toBe('en');
+    });
+  });
 });

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import flatpickr from 'flatpickr';
+import l10n from 'flatpickr/dist/l10n/index';
 import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import DatePickerInput from '../DatePickerInput';
 
 // Weekdays shorthand for english locale
-flatpickr.l10ns.en.weekdays.shorthand.forEach((day, index) => {
-  const currentDay = flatpickr.l10ns.en.weekdays.shorthand;
+l10n.en.weekdays.shorthand.forEach((day, index) => {
+  const currentDay = l10n.en.weekdays.shorthand;
   if (currentDay[index] === 'Thu' || currentDay[index] === 'Th') {
     currentDay[index] = 'Th';
   } else {
@@ -47,6 +48,113 @@ export default class DatePicker extends Component {
     dateFormat: PropTypes.string,
 
     /**
+     *  The language locale used to format the days of the week, months, and numbers.
+     *
+     * * `ar` - Arabic
+     * * `at` - Austria
+     * * `be` - Belarusian
+     * * `bg` - Bulgarian
+     * * `bn` - Bangla
+     * * `cat` - Catalan
+     * * `cs` - Czech
+     * * `cy` - Welsh
+     * * `da` - Danish
+     * * `de` - German
+     * * `en` - English
+     * * `eo` - Esperanto
+     * * `es` - Spanish
+     * * `et` - Estonian
+     * * `fa` - Persian
+     * * `fi` - Finnish
+     * * `fr` - French
+     * * `gr` - Greek
+     * * `he` - Hebrew
+     * * `hi` - Hindi
+     * * `hr` - Croatian
+     * * `hu` - Hungarian
+     * * `id` - Indonesian
+     * * `it` - Italian
+     * * `ja` - Japanese
+     * * `ko` - Korean
+     * * `lt` - Lithuanian
+     * * `lv` - Latvian
+     * * `mk` - Macedonian
+     * * `mn` - Mongolian
+     * * `ms` - Malaysian
+     * * `my` - Burmese
+     * * `nl` - Dutch
+     * * `no` - Norwegian
+     * * `pa` - Punjabi
+     * * `pl` - Polish
+     * * `pt` - Portuguese
+     * * `ro` - Romanian
+     * * `si` - Sinhala
+     * * `sk` - Slovak
+     * * `sl` - Slovenian
+     * * `sq` - Albanian
+     * * `sr` - Serbian
+     * * `sv` - Swedish
+     * * `th` - Thai
+     * * `tr` - Turkish
+     * * `uk` - Ukrainian
+     * * `vn` - Vietnamese
+     * * `zh` - Mandarin
+     */
+    locale: PropTypes.oneOf([
+      'ar',
+      'at',
+      'be',
+      'bg',
+      'bn',
+      'cat',
+      'cs',
+      'cy',
+      'da',
+      'de',
+      'en',
+      'en',
+      'eo',
+      'es',
+      'et',
+      'fa',
+      'fi',
+      'fr',
+      'gr',
+      'he',
+      'hi',
+      'hr',
+      'hu',
+      'id',
+      'it',
+      'ja',
+      'ko',
+      'lt',
+      'lv',
+      'mk',
+      'mn',
+      'ms',
+      'my',
+      'nl',
+      'no',
+      'pa',
+      'pl',
+      'pt',
+      'ro',
+      'ru',
+      'si',
+      'sk',
+      'sl',
+      'sq',
+      'sr',
+      'sv',
+      'th',
+      'tr',
+      'uk',
+      'vn',
+      'zh',
+    ]),
+
+    /**
      * The value of the date value provided to flatpickr, could
      * be a date, a date number, a date string, an array of dates.
      */
@@ -77,6 +185,7 @@ export default class DatePicker extends Component {
   static defaultProps = {
     short: false,
     dateFormat: 'm/d/Y',
+    locale: 'en',
   };
 
   componentWillUpdate(nextProps) {
@@ -96,7 +205,13 @@ export default class DatePicker extends Component {
   }
 
   componentDidMount() {
-    const { datePickerType, dateFormat, appendTo, onChange } = this.props;
+    const {
+      datePickerType,
+      dateFormat,
+      locale,
+      appendTo,
+      onChange,
+    } = this.props;
     if (datePickerType === 'single' || datePickerType === 'range') {
       const onHook = (electedDates, dateStr, instance) => {
         this.updateClassNames(instance);
@@ -106,6 +221,7 @@ export default class DatePicker extends Component {
         mode: datePickerType,
         allowInput: true,
         dateFormat: dateFormat,
+        locale: l10n[locale],
         plugins:
           datePickerType === 'range'
             ? [new rangePlugin({ input: this.toInputField })]


### PR DESCRIPTION
**Summary**:
Add the flatpickr locale support (https://flatpickr.js.org/localization/) for the DatePicker component. This update will allow for a new prop `locale` to be passed to support the following languages. https://github.com/flatpickr/flatpickr/tree/master/src/l10n

**Examples**:
![screen shot 2018-05-02 at 4 23 00 pm](https://user-images.githubusercontent.com/5651466/39549926-208faa66-4e25-11e8-90ef-9ac99a0cf5ff.png)![screen shot 2018-05-02 at 4 22 37 pm](https://user-images.githubusercontent.com/5651466/39549927-20ad14e8-4e25-11e8-8960-5bfad6641edb.png)

#### Changelog
**Changed**
* Add locale prop to DatePicker to support multiple languages.
