### PR TITLE
Invert tooltip direction base on visibility from viewport

### DIFF
--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -198,23 +198,23 @@ storiesOf('Tooltip', module)
     the tooltip will render above the element. The example below shows the default scenario.
   `,
     () => (
-      <div style={{ marginTop: '2rem' }}>
-        <Tooltip triggerText="Tooltip label" direction="top">
-          <p className="bx--tooltip__label">Tooltip direction is top</p>
-          <p>
-            But you will see the tooltip appear to the bottom of the trigger
-            element
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
-          </p>
-        </Tooltip>
+      <div>
+        Tooltip direction: top
+        {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(num => (
+          <div style={{ marginTop: '2rem' }}>
+            <Tooltip
+              triggerText={`isDynamicDirection: ${num % 2 === 1}`}
+              direction="top"
+              isDynamicDirection={num % 2 === 1}>
+              <p className="bx--tooltip__label">Tooltip direction is top</p>
+              <p>
+                Component will calculate whether the defined direction will
+                cause the tooltip to go beyond the viewport. If so, it will use
+                the opposite direction.
+              </p>
+            </Tooltip>
+          </div>
+        ))}
       </div>
     )
   );

--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -180,14 +180,41 @@ storiesOf('Tooltip', module)
       below shows the option to open on click instead of hover, which is useful when including interactive
       elements such as links inside the tooltip.
     `,
-    () => (
-      <div style={{ marginTop: '2rem' }}>
-        <Tooltip clickToOpen triggerText="Tooltip label">
-          <p className="bx--tooltip__label">Tooltip with link</p>
-          <a href="http://react.carbondesignsystem.com/" target="_blank">
-            Visit Carbon React
-          </a>
-        </Tooltip>
-      </div>
-    )
+    () =>
+      (
+        <div style={{ marginTop: '2rem' }}>
+          <Tooltip clickToOpen triggerText="Tooltip label">
+            <p className="bx--tooltip__label">Tooltip with link</p>
+            <a href="http://react.carbondesignsystem.com/" target="_blank">
+              Visit Carbon React
+            </a>
+          </Tooltip>
+        </div>
+      ).addWithInfo(
+        'invert direction when tooltip is out of viewport',
+        `
+        Tooltips are used to supply additional information to an element when hovering over it. By default,
+        the tooltip will render above the element. The example below shows the default scenario.
+      `,
+        () => (
+          <div style={{ marginTop: '2rem' }}>
+            <Tooltip triggerText="Tooltip label" direction="top">
+              <p className="bx--tooltip__label">Tooltip direction is top</p>
+              <p>
+                But you will see the tooltip appear to the bottom of the trigger
+                element
+              </p>
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+                in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                nulla pariatur. Excepteur sint occaeca cupidatat non proident,
+                sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </p>
+            </Tooltip>
+          </div>
+        )
+      )
   );

--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -180,41 +180,41 @@ storiesOf('Tooltip', module)
       below shows the option to open on click instead of hover, which is useful when including interactive
       elements such as links inside the tooltip.
     `,
-    () =>
-      (
-        <div style={{ marginTop: '2rem' }}>
-          <Tooltip clickToOpen triggerText="Tooltip label">
-            <p className="bx--tooltip__label">Tooltip with link</p>
-            <a href="http://react.carbondesignsystem.com/" target="_blank">
-              Visit Carbon React
-            </a>
-          </Tooltip>
-        </div>
-      ).addWithInfo(
-        'invert direction when tooltip is out of viewport',
-        `
-        Tooltips are used to supply additional information to an element when hovering over it. By default,
-        the tooltip will render above the element. The example below shows the default scenario.
-      `,
-        () => (
-          <div style={{ marginTop: '2rem' }}>
-            <Tooltip triggerText="Tooltip label" direction="top">
-              <p className="bx--tooltip__label">Tooltip direction is top</p>
-              <p>
-                But you will see the tooltip appear to the bottom of the trigger
-                element
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-                enim ad minim veniam, quis nostrud exercitation ullamco laboris
-                nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-                in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur. Excepteur sint occaeca cupidatat non proident,
-                sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-            </Tooltip>
-          </div>
-        )
-      )
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip clickToOpen triggerText="Tooltip label">
+          <p className="bx--tooltip__label">Tooltip with link</p>
+          <a href="http://react.carbondesignsystem.com/" target="_blank">
+            Visit Carbon React
+          </a>
+        </Tooltip>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'invert direction when tooltip is out of viewport',
+    `
+    Tooltips are used to supply additional information to an element when hovering over it. By default,
+    the tooltip will render above the element. The example below shows the default scenario.
+  `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip triggerText="Tooltip label" direction="top">
+          <p className="bx--tooltip__label">Tooltip direction is top</p>
+          <p>
+            But you will see the tooltip appear to the bottom of the trigger
+            element
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaeca cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )
   );

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -130,6 +130,11 @@ export default class Tooltip extends Component {
      * `true` if opening tooltip should be triggered by clicking the trigger button.
      */
     clickToOpen: PropTypes.bool,
+
+    /**
+     * `true` if tooltip direction should be calcuated base on it's visiblity on viewport
+     */
+    isDynamicDirection: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -140,6 +145,7 @@ export default class Tooltip extends Component {
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
     menuOffset: getMenuOffset,
+    isDynamicDirection: false,
   };
 
   /**
@@ -272,6 +278,7 @@ export default class Tooltip extends Component {
       // Exclude `clickToOpen` from `other` to avoid passing it along to `<div>`
       // eslint-disable-next-line no-unused-vars
       clickToOpen,
+      isDynamicDirection,
       ...other
     } = this.props;
 
@@ -336,6 +343,7 @@ export default class Tooltip extends Component {
             menuPosition={this.state.triggerPosition}
             menuDirection={direction}
             menuOffset={menuOffset}
+            isMenuDynamicDirection={isDynamicDirection}
             updateDirection={updatedDirection => {
               // update the value to display the arror at correct place
               this._tooltipEl.setAttribute(

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -335,7 +335,14 @@ export default class Tooltip extends Component {
           <FloatingMenu
             menuPosition={this.state.triggerPosition}
             menuDirection={direction}
-            menuOffset={menuOffset}>
+            menuOffset={menuOffset}
+            updateDirection={updatedDirection => {
+              // update the value to display the arror at correct place
+              this._tooltipEl.setAttribute(
+                'data-floating-menu-direction',
+                updatedDirection
+              );
+            }}>
             <div
               id={tooltipId}
               className={tooltipClasses}

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -71,6 +71,7 @@ const getFloatingPosition = ({
   offset = {},
   direction = DIRECTION_BOTTOM,
   scrollY = 0,
+  isDynamicDirection = false,
 }) => {
   const {
     left: refLeft = 0,
@@ -109,7 +110,9 @@ const getFloatingPosition = ({
     menuSize,
   });
   // get the inverted direction
-  const invertedDirection = _getInversions(inversion)[direction];
+  const invertedDirection = isDynamicDirection
+    ? _getInversions(inversion)[direction]
+    : direction;
   return {
     ...proposedPositions[invertedDirection](),
     invertedDirection,
@@ -130,7 +133,9 @@ const _shouldInvertDirection = ({
     window.innerHeight || 0
   );
   return {
-    vertical: proposedTop + menuSize.height > viewportHeight || proposedTop < 0,
+    vertical:
+      proposedTop + menuSize.height > viewportHeight + scrollY ||
+      proposedTop < 0,
     horizontal:
       proposedLeft + menuSize.width > viewportWidth || proposedLeft < 0,
   };
@@ -194,6 +199,15 @@ class FloatingMenu extends React.Component {
      * The callback called when the menu body has been mounted to/will be unmounted from the DOM.
      */
     menuRef: PropTypes.func,
+
+    /**
+     * `true` if menu direction should be calcuated base on it's visiblity on viewport
+     */
+    isMenuDynamicDirection: PropTypes.bool,
+
+    /**
+     * the callback called when the menu direction/position is calculated. currently used to update the arrow on the tooltip
+     */
     updateDirection: PropTypes.func,
   };
 
@@ -201,6 +215,7 @@ class FloatingMenu extends React.Component {
     menuPosition: {},
     menuOffset: {},
     menuDirection: DIRECTION_BOTTOM,
+    isMenuDynamicDirection: false,
   };
 
   state = {
@@ -262,6 +277,7 @@ class FloatingMenu extends React.Component {
       menuPosition: refPosition = {},
       menuOffset = {},
       menuDirection,
+      isMenuDynamicDirection,
     } = this.props;
 
     if (
@@ -287,12 +303,13 @@ class FloatingMenu extends React.Component {
           direction: menuDirection,
           offset,
           scrollY: window.scrollY,
+          isDynamicDirection: isMenuDynamicDirection,
         });
         this.setState({
           floatingPosition,
         });
         if (this.props.updateDirection) {
-          this.props.updateDirection(floatingPosition.visibleDirection);
+          this.props.updateDirection(floatingPosition.invertedDirection);
         }
       }
     }


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#763

Calculate the tooltip visibility on the viewport and invert the position if the defined one doesn't allow user to see the tooltip fully on the window viewport

#### Changelog

**Changed**

* Added logic to detect the out of viewport scenario and invert the direction of the tooltip
