### PR TITLE
fix(DropdownV2): remove form-item class from base ListBox

### DIFF
--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -63,7 +63,7 @@ exports[`DropdownV2 should render 1`] = `
       type="default"
     >
       <div
-        className="bx--dropdown-v2 bx--list-box bx--form-item"
+        className="bx--dropdown-v2 bx--list-box"
       >
         <ListBoxField
           aria-expanded={false}

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -21,7 +21,6 @@ const ListBox = ({
   const className = cx({
     [containerClassName]: !!containerClassName,
     'bx--list-box': true,
-    'bx--form-item': true,
     'bx--list-box--inline': type === 'inline',
     'bx--list-box--disabled': disabled,
   });

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -9,7 +9,7 @@ exports[`ListBox should render 1`] = `
       "calls": Array [
         Array [
           <div
-            class="bx--list-box__container bx--list-box bx--form-item"
+            class="bx--list-box__container bx--list-box"
           >
             <div
               class="bx--list-box__field"
@@ -24,7 +24,7 @@ exports[`ListBox should render 1`] = `
   type="default"
 >
   <div
-    className="bx--list-box__container bx--list-box bx--form-item"
+    className="bx--list-box__container bx--list-box"
   >
     <ListBoxField>
       <div

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -76,7 +76,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
         type="default"
       >
         <div
-          className="bx--multi-select bx--combo-box bx--list-box bx--form-item"
+          className="bx--multi-select bx--combo-box bx--list-box"
         >
           <ListBoxField
             aria-expanded={false}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#569

#### Changelog

**New**

**Changed**

* Removes `bx--form-item` from base `ListBox` component

**Removed**
