### PR TITLE
fix(ListBox): prevent key events from propagating

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "dependencies": {
     "classnames": "2.2.5",
-    "downshift": "^1.23.2",
+    "downshift": "^1.31.14",
     "flatpickr": "4.4.1",
     "invariant": "^2.2.3",
     "lodash.debounce": "^4.0.8",

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -46,7 +46,6 @@ exports[`DropdownV2 should render 1`] = `
     defaultSelectedItem={null}
     environment={[Window]}
     getA11yStatusMessage={[Function]}
-    id="downshift-1"
     itemToString={[Function]}
     onChange={[Function]}
     onInputValueChange={[Function]}
@@ -55,6 +54,7 @@ exports[`DropdownV2 should render 1`] = `
     onStateChange={[Function]}
     onUserAction={[Function]}
     selectedItemChanged={[Function]}
+    stateReducer={[Function]}
   >
     <ListBox
       className="bx--dropdown-v2"
@@ -64,30 +64,37 @@ exports[`DropdownV2 should render 1`] = `
     >
       <div
         className="bx--dropdown-v2 bx--list-box"
+        onKeyDown={[Function]}
       >
         <ListBoxField
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="open menu"
+          data-toggle={true}
           disabled={false}
+          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           role="button"
+          type="button"
         >
           <div
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="open menu"
             className="bx--list-box__field"
+            data-toggle={true}
             disabled={false}
+            onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
             tabIndex="0"
+            type="button"
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-input-2"
+              htmlFor="downshift-0-input"
             >
               input
             </span>

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -6,6 +6,10 @@ import ListBoxMenu from './ListBoxMenu';
 import { ListBoxType } from './ListBoxPropTypes';
 import childrenOf from '../../prop-types/childrenOf';
 
+const handleOnKeyDown = event => {
+  event.stopPropagation();
+};
+
 /**
  * `ListBox` is a generic container component that handles creating the
  * container class name in response to certain props.
@@ -25,7 +29,11 @@ const ListBox = ({
     'bx--list-box--disabled': disabled,
   });
   return (
-    <div className={className} ref={innerRef} {...rest}>
+    <div
+      {...rest}
+      className={className}
+      ref={innerRef}
+      onKeyDown={handleOnKeyDown}>
       {children}
     </div>
   );

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -7,7 +7,9 @@ import { ListBoxType } from './ListBoxPropTypes';
 import childrenOf from '../../prop-types/childrenOf';
 
 const handleOnKeyDown = event => {
-  event.stopPropagation();
+  if (event.keyCode === 27) {
+    event.stopPropagation();
+  }
 };
 
 /**

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -25,6 +25,7 @@ exports[`ListBox should render 1`] = `
 >
   <div
     className="bx--list-box__container bx--list-box"
+    onKeyDown={[Function]}
   >
     <ListBoxField>
       <div

--- a/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -186,17 +186,17 @@ describe('MultiSelect', () => {
       const getHighlightedId = () =>
         wrapper.find('.bx--list-box__menu-item--highlighted').prop('id');
       simulateArrowDown();
-      expect(getHighlightedId()).toBe('downshift-1-item-0');
+      expect(getHighlightedId()).toBe('downshift-10-item-0');
       simulateArrowDown();
-      expect(getHighlightedId()).toBe('downshift-1-item-1');
+      expect(getHighlightedId()).toBe('downshift-10-item-1');
       // Simulate "wrap" behavior
       simulateArrowDown();
       simulateArrowDown();
       simulateArrowDown();
       simulateArrowDown();
-      expect(getHighlightedId()).toBe('downshift-1-item-0');
+      expect(getHighlightedId()).toBe('downshift-10-item-0');
       simulateArrowUp();
-      expect(getHighlightedId()).toBe('downshift-1-item-4');
+      expect(getHighlightedId()).toBe('downshift-10-item-4');
     });
 
     it('should close the menu when a user clicks outside of the control', () => {

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -55,7 +55,6 @@ exports[`MultiSelect.Filterable should render 1`] = `
       environment={[Window]}
       getA11yStatusMessage={[Function]}
       highlightedIndex={null}
-      id="downshift-1"
       inputValue=""
       isOpen={false}
       itemToString={[Function]}
@@ -68,6 +67,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
       render={[Function]}
       selectedItem={Array []}
       selectedItemChanged={[Function]}
+      stateReducer={[Function]}
     >
       <ListBox
         className="bx--multi-select bx--combo-box"
@@ -77,26 +77,33 @@ exports[`MultiSelect.Filterable should render 1`] = `
       >
         <div
           className="bx--multi-select bx--combo-box bx--list-box"
+          onKeyDown={[Function]}
         >
           <ListBoxField
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="open menu"
+            data-toggle={true}
             disabled={false}
+            onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
             role="button"
+            type="button"
           >
             <div
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="open menu"
               className="bx--list-box__field"
+              data-toggle={true}
               disabled={false}
+              onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"
               tabIndex="0"
+              type="button"
             >
               <input
                 aria-activedescendant={null}
@@ -105,7 +112,7 @@ exports[`MultiSelect.Filterable should render 1`] = `
                 autoComplete="off"
                 className="bx--text-input"
                 disabled={false}
-                id="downshift-input-2"
+                id="downshift-0-input"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,9 +2757,9 @@ caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
-carbon-components@^8.18.14:
-  version "8.18.14"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.18.14.tgz#579383adfe880469cd1bd78bb2c2b12d47a43273"
+carbon-components@^8.18.15:
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-8.19.0.tgz#225dd71c819b5670c6e3c79181c8b8e7ed2220cb"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"
@@ -3784,9 +3784,9 @@ dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
-downshift@^1.23.2:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.25.0.tgz#7f6e2dda4aa5ddbb2932401bd61e7b741e92c02e"
+downshift@^1.31.14:
+  version "1.31.14"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.14.tgz#98b04614cad2abc4297d0d02b50ff2c48b2625e7"
 
 duplexer2@~0.1.0:
   version "0.1.4"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#600

#### Changelog

**New**

**Changed**

* `package.json`
  * Updated `downshift` dependency
* `src/components/ListBox`
  * Now prevents event propagation for key events through `onKeyDown`

**Removed**
