### PR TITLE
fix(DataTable): add indeterminate state to select all

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -207,22 +207,24 @@ export default class DataTable extends React.Component {
     }
 
     // Otherwise, we're working on `TableSelectAll` which handles toggling the
-    // selection state of all rows. If we have no rows, then this value defaults
-    // to false.
-    const checked =
-      this.state.rowIds.length > 0
-        ? this.getSelectedRows().length === this.state.rowIds.length
-        : false;
+    // selection state of all rows.
+    const rowCount = this.state.rowIds.length;
+    const selectedRowCount = this.getSelectedRows().length;
+    const checked = rowCount > 0 && selectedRowCount === rowCount;
+    const indeterminate =
+      rowCount > 0 && selectedRowCount > 0 && selectedRowCount !== rowCount;
+
     const translationKey = checked
       ? translationKeys.unselectAll
       : translationKeys.selectAll;
     return {
       ...rest,
-      checked,
-      onSelect: composeEventHandlers([this.handleSelectAll, onClick]),
-      id: `${this.getTablePrefix()}__select-all`,
-      name: 'select-all',
       ariaLabel: t(translationKey),
+      checked,
+      id: `${this.getTablePrefix()}__select-all`,
+      indeterminate,
+      name: 'select-all',
+      onSelect: composeEventHandlers([this.handleSelectAll, onClick]),
     };
   };
 

--- a/src/components/DataTable/TableSelectAll.js
+++ b/src/components/DataTable/TableSelectAll.js
@@ -2,14 +2,22 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import InlineCheckbox from '../InlineCheckbox';
 
-const TableSelectAll = ({ ariaLabel, checked, id, name, onSelect }) => (
+const TableSelectAll = ({
+  ariaLabel,
+  checked,
+  id,
+  indeterminate,
+  name,
+  onSelect,
+}) => (
   <th scope="col">
     <InlineCheckbox
+      ariaLabel={ariaLabel}
+      checked={checked}
       id={id}
+      indeterminate={indeterminate}
       name={name}
       onClick={onSelect}
-      checked={checked}
-      ariaLabel={ariaLabel}
     />
   </th>
 );
@@ -29,6 +37,11 @@ TableSelectAll.propTypes = {
    * Provide an `id` for the underlying input control
    */
   id: PropTypes.string.isRequired,
+
+  /**
+   * Specify whether the selection only has a subset of all items
+   */
+  indeterminate: PropTypes.bool,
 
   /**
    * Provide a `name` for the underlying input control

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -74,6 +74,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                     ariaLabel="Select all rows"
                     checked={false}
                     id="data-table-7__select-all"
+                    indeterminate={false}
                     name="select-all"
                     onSelect={[Function]}
                   >
@@ -84,6 +85,7 @@ exports[`DataTable selection should have select-all default to un-checked if no 
                         ariaLabel="Select all rows"
                         checked={false}
                         id="data-table-7__select-all"
+                        indeterminate={false}
                         name="select-all"
                         onClick={[Function]}
                       >
@@ -399,6 +401,7 @@ exports[`DataTable selection should render 1`] = `
                     ariaLabel="Select all rows"
                     checked={false}
                     id="data-table-6__select-all"
+                    indeterminate={false}
                     name="select-all"
                     onSelect={[Function]}
                   >
@@ -409,6 +412,7 @@ exports[`DataTable selection should render 1`] = `
                         ariaLabel="Select all rows"
                         checked={false}
                         id="data-table-6__select-all"
+                        indeterminate={false}
                         name="select-all"
                         onClick={[Function]}
                       >

--- a/src/components/InlineCheckbox/InlineCheckbox.js
+++ b/src/components/InlineCheckbox/InlineCheckbox.js
@@ -1,58 +1,97 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const InlineCheckbox = ({
-  id,
-  checked,
-  ariaLabel,
-  name,
-  onClick,
-  onKeyDown,
-}) => (
-  <React.Fragment>
-    <input
-      id={id}
-      className="bx--checkbox"
-      type="checkbox"
-      name={name}
-      checked={checked}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-    />
-    <label htmlFor={id} className="bx--checkbox-label" aria-label={ariaLabel} />
-  </React.Fragment>
-);
+export default class InlineCheckbox extends React.Component {
+  static propTypes = {
+    /**
+     * Specify the label for the control
+     */
+    ariaLabel: PropTypes.string.isRequired,
 
-InlineCheckbox.propTypes = {
-  /**
-   * Provide an `id` for the underlying input control
-   */
-  id: PropTypes.string.isRequired,
+    /**
+     * Specify whether the underlying control is checked, or not
+     */
+    checked: PropTypes.bool.isRequired,
 
-  /**
-   * Provide a `name` for the underlying input control
-   */
-  name: PropTypes.string.isRequired,
+    /**
+     * Provide an `id` for the underlying input control
+     */
+    id: PropTypes.string.isRequired,
 
-  /**
-   * Specify the label for the control
-   */
-  ariaLabel: PropTypes.string.isRequired,
+    /**
+     * Specify whether the control is in an indterminate state
+     */
+    indeterminate: PropTypes.bool,
 
-  /**
-   * Provide a handler that is invoked when a user clicks on the control
-   */
-  onClick: PropTypes.func,
+    /**
+     * Provide a `name` for the underlying input control
+     */
+    name: PropTypes.string.isRequired,
 
-  /**
-   * Provide a handler that is invoked on the key down event for the control
-   */
-  onKeyDown: PropTypes.func,
+    /**
+     * Provide a handler that is invoked when a user clicks on the control
+     */
+    onClick: PropTypes.func,
 
-  /**
-   * Specify whether the underlying control is checked, or not
-   */
-  checked: PropTypes.bool.isRequired,
-};
+    /**
+     * Provide a handler that is invoked on the key down event for the control
+     */
+    onKeyDown: PropTypes.func,
+  };
 
-export default InlineCheckbox;
+  componentDidMount() {
+    this.inputNode.indeterminate = this.props.indeterminate;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.indeterminate !== this.props.indeterminate) {
+      this.inputNode.indeterminate = this.props.indeterminate;
+    }
+  }
+
+  handleRef = el => {
+    this.inputNode = el;
+  };
+
+  render() {
+    const {
+      id,
+      indeterminate,
+      checked,
+      ariaLabel,
+      name,
+      onClick,
+      onKeyDown,
+    } = this.props;
+    const inputProps = {
+      id,
+      name,
+      onClick,
+      onKeyDown,
+      className: 'bx--checkbox',
+      type: 'checkbox',
+      ref: this.handleRef,
+      checked: false,
+    };
+
+    if (checked) {
+      inputProps.checked = true;
+    }
+
+    if (indeterminate) {
+      inputProps.checked = false;
+      inputProps['aria-checked'] = 'mixed';
+    }
+
+    return (
+      <React.Fragment>
+        <input {...inputProps} />
+        <label
+          htmlFor={id}
+          className="bx--checkbox-label"
+          aria-label={ariaLabel}
+        />
+      </React.Fragment>
+    );
+  }
+}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#853

Updates `DataTable` and `InlineCheckbox` to offer an indeterminate state for when a subset of rows are selected.

#### Changelog

**New**

**Changed**

* `DataTable`
  * updated logic to include indeterminate check
* `TableSelectAll`
  * now forwards along indeterminate prop
* `InlineCheckbox`
  * now accepts an `indeterminate` prop and adds logic to set property on underlying input node

**Removed**
