### PR TITLE
fix(DatePicker): lazily evaluate FlatPickr module

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,34 +1,47 @@
 const path = require('path');
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.scss$/,
-        use: [
-          { loader: 'style-loader' },
-          {
-            loader: 'css-loader',
-            options: { importLoaders: 2 },
+module.exports = storybookBaseConfig => {
+  storybookBaseConfig.module.rules.push(
+    {
+      test: /flatpickr\.js$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            babelrc: false,
+            plugins: [
+              require.resolve('../scripts/babel-plugin-wrap-amd-factory'),
+            ],
           },
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: () => [
-                require('autoprefixer')({
-                  browsers: ['last 1 version', 'ie >= 11'],
-                }),
-              ],
-            },
+        },
+      ],
+    },
+    {
+      test: /\.scss$/,
+      use: [
+        { loader: 'style-loader' },
+        {
+          loader: 'css-loader',
+          options: { importLoaders: 2 },
+        },
+        {
+          loader: 'postcss-loader',
+          options: {
+            plugins: () => [
+              require('autoprefixer')({
+                browsers: ['last 1 version', 'ie >= 11'],
+              }),
+            ],
           },
-          {
-            loader: 'sass-loader',
-            options: {
-              includePaths: [path.resolve(__dirname, '..', 'node_modules')],
-            },
+        },
+        {
+          loader: 'sass-loader',
+          options: {
+            includePaths: [path.resolve(__dirname, '..', 'node_modules')],
           },
-        ],
-      },
-    ],
-  },
+        },
+      ],
+    }
+  );
+  return storybookBaseConfig;
 };

--- a/scripts/babel-plugin-wrap-amd-factory.js
+++ b/scripts/babel-plugin-wrap-amd-factory.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = function wrapFactory(babel) {
+  const t = babel.types;
+  return {
+    visitor: {
+      BlockStatement(path) {
+        const parentNode = path.parentPath.node;
+        const grandParentNode = path.parentPath.parentPath.node;
+        if (
+          t.isFunctionExpression(parentNode) &&
+          parentNode.params.length === 0 &&
+          t.isCallExpression(grandParentNode)
+        ) {
+          const clone = t.blockStatement([
+            t.returnStatement(t.cloneDeep(parentNode)),
+          ]);
+          path.replaceWith(clone);
+          path.stop();
+        }
+      },
+    },
+  };
+};

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -81,6 +81,11 @@ module.exports = {
     babel({
       exclude: ['node_modules/**'], // only transpile our source code
     }),
+    babel({
+      babelrc: false,
+      plugins: [require.resolve('./babel-plugin-wrap-amd-factory')],
+      include: ['node_modules/flatpickr/**'],
+    }),
     replace({
       'process.env.NODE_ENV': JSON.stringify(env),
     }),

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -16,6 +16,11 @@ l10n.en.weekdays.shorthand.forEach((day, index) => {
   }
 });
 
+const flatpickrClass = (() => {
+  let cached;
+  return () => (flatpickr.l10ns ? flatpickr : cached || (cached = flatpickr()));
+})();
+
 export default class DatePicker extends Component {
   static propTypes = {
     /**
@@ -216,7 +221,7 @@ export default class DatePicker extends Component {
       const onHook = (electedDates, dateStr, instance) => {
         this.updateClassNames(instance);
       };
-      this.cal = flatpickr(this.inputField, {
+      this.cal = flatpickrClass()(this.inputField, {
         appendTo,
         mode: datePickerType,
         allowInput: true,


### PR DESCRIPTION
Fixes #868.

#### Changelog

**New**

* Mechanism to codemod Flatpickr AMD module, transforming:

From:

```javascript
define([], function () {
  (Flatpickr code containing window object access reported in #868)
  …
  return flatpickr;
});
```

To:

```javascript
define([], function () {
  return function () {
     (Flatpickr code containing window object access reported in #868)
     …
     return flatpickr;
  };
});
```

* `<DatePicker>` code to evaluate such function-wrapped version of Flatpickr module. It automatically detects if the module is function-wrapped or not, to support applications importing Carbon modules directly (where our codemod is not automatically applied).