### PR TITLE
feat(DatePicker): Added minDate and maxDate props and pass them on to flatpickr

### DIFF
--- a/src/components/DatePicker/DatePicker-story.js
+++ b/src/components/DatePicker/DatePicker-story.js
@@ -92,6 +92,26 @@ storiesOf('DatePicker', module)
     )
   )
   .addWithInfo(
+    'range with calendar and min/max dates',
+    `
+      A range Date Picker consists of two input fields and a calendar.
+    `,
+    () => (
+      <DatePicker
+        {...datePickerProps}
+        minDate="1/10/2020"
+        maxDate="1/20/2020"
+        datePickerType="range"
+        dateFormat="m/d/Y">
+        <DatePickerInput {...datePickerInputProps} id="date-picker-input-id" />
+        <DatePickerInput
+          {...datePickerInputProps}
+          id="date-picker-input-id-2"
+        />
+      </DatePicker>
+    )
+  )
+  .addWithInfo(
     'fully controlled',
     `
       If your application needs to control the value of the date picker and

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -211,6 +211,8 @@ export default class DatePicker extends Component {
       locale,
       appendTo,
       onChange,
+      minDate,
+      maxDate,
     } = this.props;
     if (datePickerType === 'single' || datePickerType === 'range') {
       const onHook = (electedDates, dateStr, instance) => {
@@ -222,6 +224,8 @@ export default class DatePicker extends Component {
         allowInput: true,
         dateFormat: dateFormat,
         locale: l10n[locale],
+        minDate: minDate,
+        maxDate: maxDate,
         plugins:
           datePickerType === 'range'
             ? [new rangePlugin({ input: this.toInputField })]


### PR DESCRIPTION
`flatpickr` accepts a `minDate` and a `maxDate` property for `range`-type date pickers, but the Carbon wrapper around it doesn't. This PR makes it possible to pass `minDate` and `maxDate` to the `flatpickr` constructor. Consequently, this code works as expected:

```javascript
<DatePicker
  id="date-picker"
  onChange={anonymous()}
  minDate="1/10/2020"
  maxDate="1/20/2020"
  datePickerType="range"
>
<DatePickerInput
  className="some-class"
  labelText="Date Picker label"
  locale="en"
  onClick={onClick()}
  onChange={onInputChange()}
  placeholder="mm/dd/yyyy"
  id="date-picker-input-id"
/>
<DatePickerInput
  className="some-class"
  labelText="Date Picker label"
  locale="en"
  onClick={onClick()}
  onChange={onInputChange()}
  placeholder="mm/dd/yyyy"
  id="date-picker-input-id-2"
/>
</DatePicker>
```

#### Changelog

**New**

* Added support for `minDate` and `maxDate` props in `range` DatePickers


