### PR TITLE
fix(DatePicker): treat Flatpickr's default export as a constructor

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -216,7 +216,7 @@ export default class DatePicker extends Component {
       const onHook = (electedDates, dateStr, instance) => {
         this.updateClassNames(instance);
       };
-      this.cal = flatpickr(this.inputField, {
+      this.cal = new flatpickr(this.inputField, {
         appendTo,
         mode: datePickerType,
         allowInput: true,


### PR DESCRIPTION
Fixes #491.

#### Changelog

**Changed**

* A change to treat Flatpickr's default export as a constructor.