### PR TITLE
chore(build): fix babel config for test

### DIFF
--- a/config/jest/jsTransform.js
+++ b/config/jest/jsTransform.js
@@ -14,7 +14,7 @@ const babelOptions = {
         },
       },
     ],
-    '@babel/preset-stage-1',
+    ['@babel/preset-stage-1', { decoratorsLegacy: true }],
     '@babel/preset-react',
   ],
   // Adding in here otherwise Jest complains about no plugin for class


### PR DESCRIPTION
Follow-up fix of https://github.com/carbon-design-system/carbon-components-react/pull/886, applying a similar fix to babel config for test.

#### Changelog

**Changed**

* Add `decoratorsLegacy: true` to stage-1 preset in babel config for test
