### PR TITLE
fix: console.errors coming from using Datepicker

### DIFF
--- a/src/components/DatePicker/DatePicker-test.js
+++ b/src/components/DatePicker/DatePicker-test.js
@@ -217,6 +217,40 @@ describe('DatePicker', () => {
       expect(datepicker.props().locale).toBe('en');
     });
   });
+
+  describe('Date picker with minDate and maxDate', () => {
+    console.error = jest.genMockFn(); // eslint-disable-line no-console
+
+    const wrapper = mount(
+      <DatePicker
+        onChange={() => {}}
+        datePickerType="range"
+        className="extra-class"
+        minDate="01/01/2018"
+        maxDate="01/30/2018">
+        <div className="test-child">
+          <input
+            type="text"
+            className="bx--date-picker__input"
+            id="input-from"
+          />
+        </div>
+        <div className="test-child">
+          <input type="text" className="bx--date-picker__input" id="input-to" />
+        </div>
+      </DatePicker>
+    );
+
+    it('has the range date picker with min and max dates', () => {
+      const datepicker = wrapper.find('DatePicker');
+      expect(datepicker.props().minDate).toBe('01/01/2018');
+      expect(datepicker.props().maxDate).toBe('01/30/2018');
+    });
+
+    it('should not have "console.error" being created', () => {
+      expect(console.error).not.toBeCalled(); // eslint-disable-line no-console
+    });
+  });
 });
 
 describe('DatePickerSkeleton', () => {

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -180,6 +180,16 @@ export default class DatePicker extends Component {
      * The `change` event handler.
      */
     onChange: PropTypes.func,
+
+    /**
+     * The minimum date that a user can start picking from.
+     */
+    minDate: PropTypes.string,
+
+    /**
+     * The maximum date that a user can pick to.
+     */
+    maxDate: PropTypes.string,
   };
 
   static defaultProps = {
@@ -367,6 +377,8 @@ export default class DatePicker extends Component {
       className,
       short,
       datePickerType,
+      minDate, // eslint-disable-line
+      maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
       ...other


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-react/issues/898

Seeing console errors displaying while using the DatePicker and passing in minDate and maxDate props. 

#### Changelog

**New**

* N/A

**Changed**

* DatePicker.js - adding minDate and maxDate to props-type and render function
* DatePicker-test.js - adding tests for minDate and maxDate to prevent the issue. 

**Removed**

* N/A
