### PR TITLE
fix(table-toolbar-search): add i18n support

### DIFF
--- a/src/components/DataTable/TableToolbarSearch.js
+++ b/src/components/DataTable/TableToolbarSearch.js
@@ -5,11 +5,20 @@ import Search from '../Search';
 import setupGetInstanceId from './tools/instanceId';
 
 const getInstanceId = setupGetInstanceId();
+const translationKeys = {
+  'carbon.table.toolbar.search.label': 'Filter table',
+  'carbon.table.toolbar.search.placeholder': 'Search',
+};
+
+const translateWithId = id => {
+  return translationKeys[id];
+};
 
 const TableToolbarSearch = ({
   className,
   searchContainerClass,
   onChange,
+  translateWithId: t,
   id = `data-table-search-${getInstanceId()}`,
   ...rest
 }) => {
@@ -24,8 +33,8 @@ const TableToolbarSearch = ({
         {...rest}
         small
         id={id}
-        labelText="Filter table"
-        placeHolderText="Search"
+        labelText={t('carbon.table.toolbar.search.label')}
+        placeHolderText={t('carbon.table.toolbar.search.placeholder')}
         onChange={onChange}
       />
     </div>
@@ -44,12 +53,25 @@ TableToolbarSearch.propTypes = {
    * Provide an optional id for the search container
    */
   id: PropTypes.string,
+
+  /**
+   * Provide an optional className for the overal container of the Search
+   */
   searchContainerClasses: PropTypes.string,
 
   /**
    * Provide an optional hook that is called each time the input is updated
    */
   onChange: PropTypes.func,
+
+  /**
+   * Provide custom text for the component for each translation id
+   */
+  translateWithId: PropTypes.func.isRequired,
+};
+
+TableToolbarSearch.defaultProps = {
+  translateWithId,
 };
 
 export default TableToolbarSearch;

--- a/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -877,6 +877,7 @@ exports[`DataTable should render 1`] = `
           <TableToolbarSearch
             id="custom-id"
             onChange={[Function]}
+            translateWithId={[Function]}
           >
             <div
               className="bx--toolbar-search-container"

--- a/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
+++ b/src/components/DataTable/__tests__/__snapshots__/TableToolbarSearch-test.js.snap
@@ -5,6 +5,7 @@ exports[`DataTable.TableToolbarSearch should render 1`] = `
   className="custom-class"
   id="custom-id"
   onChange={[MockFunction]}
+  translateWithId={[Function]}
 >
   <div
     className="bx--toolbar-search-container"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#837

Add i18n support for `TableToolbarSearch`

#### Changelog

**New**

**Changed**

* `TableToolbarSearch`
  * Now has `translateWithId` prop with default prop fallback for translating label text and placeholder text

**Removed**
