### PR TITLE
feat(package): add deprecation notices for components

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -14,5 +14,6 @@
     ],
     "@babel/preset-react",
     ["@babel/preset-stage-1", { "decoratorsLegacy": true }]
-  ]
+  ],
+  "plugins": ["dev-expression"]
 }

--- a/config/jest/jsTransform.js
+++ b/config/jest/jsTransform.js
@@ -19,7 +19,7 @@ const babelOptions = {
   ],
   // Adding in here otherwise Jest complains about no plugin for class
   // properties
-  plugins: ['@babel/plugin-proposal-class-properties'],
+  plugins: ['@babel/plugin-proposal-class-properties', 'dev-expression'],
 };
 
 module.exports = createTransformer(babelOptions);

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -4,6 +4,8 @@ jest.unmock('promise');
 jest.unmock('whatwg-fetch');
 jest.unmock('object-assign');
 
+global.__DEV__ = true;
+
 require('../polyfills');
 
 const enzyme = require.requireActual('enzyme');

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
       "jest": true,
       "jasmine": true
     },
+    "globals": {
+      "__DEV__": true
+    },
     "settings": {
       "jsdoc": {
         "tagNamePreference": {
@@ -128,7 +131,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.omit": "^4.5.0",
-    "warning": "3.0.0",
+    "warning": "^3.0.0",
     "window-or-global": "^1.0.1"
   },
   "devDependencies": {
@@ -146,6 +149,7 @@
     "babel-core": "^7.0.0-0",
     "babel-eslint": "^8.0.2",
     "babel-jest": "^22.1.0",
+    "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "bowser": "^1.6.1",
     "carbon-components": "^8.20.0",
@@ -198,7 +202,15 @@
     "presets": [
       "./scripts/env",
       "@babel/preset-react",
-      ["@babel/preset-stage-1", { "decoratorsLegacy": true }]
+      [
+        "@babel/preset-stage-1",
+        {
+          "decoratorsLegacy": true
+        }
+      ]
+    ],
+    "plugins": [
+      "dev-expression"
     ]
   },
   "prettier": {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,8 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const Card = ({ children, className, tabIndex, ...other }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `Card` component from the `carbon-components-react` ' +
+        'package is deprecated. Use the `carbon-addons-cloud-react` package ' +
+        'instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const cardClasses = classNames({
     'bx--card': true,
     [className]: className,

--- a/src/components/CardActionItem/CardActionItem.js
+++ b/src/components/CardActionItem/CardActionItem.js
@@ -2,6 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const CardActionItem = ({
   className,
@@ -11,6 +14,15 @@ const CardActionItem = ({
   description,
   ...other
 }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `CardActionItem` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
   const cardActionItemClasses = classNames({
     'bx--app-actions__button': true,
     [className]: className,

--- a/src/components/CardActions/CardActions.js
+++ b/src/components/CardActions/CardActions.js
@@ -1,8 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const CardActions = ({ children, className, ...other }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `CardActions` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
   const cardActionClasses = classNames({
     'bx--card-footer__app-actions': true,
     [className]: className,

--- a/src/components/CardContent/CardContent-test.js
+++ b/src/components/CardContent/CardContent-test.js
@@ -138,7 +138,7 @@ describe('CardContent', () => {
         'Specified a custom icon while the icon description is provided.',
         "It'll be ignored as an icon description is only used for carbon-icons sprite.",
       ].join('\n');
-      expect(warning.mock.calls).toEqual([[false, message]]);
+      expect(warning.mock.calls[1]).toEqual([false, message]);
     });
   });
 

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -1,8 +1,10 @@
-import warning from 'warning';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { isValidElement } from 'react';
-import classNames from 'classnames';
+import warning from 'warning';
 import Icon from '../Icon';
+
+let didWarnAboutDeprecation = false;
 
 const CardContent = ({
   className,
@@ -14,6 +16,15 @@ const CardContent = ({
   iconDescription,
   ...other
 }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `CardContent` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
   const cardContentClasses = classNames({
     'bx--card__card-overview': true,
     [className]: className,

--- a/src/components/CardFooter/CardFooter.js
+++ b/src/components/CardFooter/CardFooter.js
@@ -1,8 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const CardFooter = ({ children, className, ...other }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `CardContent` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
   const cardFooterClasses = classNames({
     'bx--card-footer': true,
     [className]: className,

--- a/src/components/CardStatus/CardStatus.js
+++ b/src/components/CardStatus/CardStatus.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const appStatus = {
   RUNNING: 0,
@@ -39,6 +42,16 @@ const CardStatus = ({
   stoppedText,
   ...other
 }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `CardContent` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const cardStatusClasses = classNames({
     'bx--card-footer__app-status': true,
     [className]: className,

--- a/src/components/DetailPageHeader/DetailPageHeader.js
+++ b/src/components/DetailPageHeader/DetailPageHeader.js
@@ -7,6 +7,9 @@ import Breadcrumb from '../Breadcrumb';
 import Tabs from '../Tabs';
 import OverflowMenu from '../OverflowMenu';
 import Icon from '../Icon';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 export default class DetailPageHeader extends Component {
   static propTypes = {
@@ -28,11 +31,24 @@ export default class DetailPageHeader extends Component {
     hasTabs: false,
   };
 
-  state = {
-    isScrolled: this.props.isScrolled || false,
-    isScrollingDownward: this.props.isScrollingDownward || false,
-    lastPosition: 0,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      isScrolled: props.isScrolled || false,
+      isScrollingDownward: props.isScrollingDownward || false,
+      lastPosition: 0,
+    };
+
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'Accessing the `DetailPageHeader` component from the ' +
+          '`carbon-components-react` package is deprecated. Use the ' +
+          '`carbon-addons-cloud-react` package instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
+  }
 
   componentDidMount() {
     this._debouncedScroll = debounce(this.handleScroll, 25);

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -2,10 +2,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import window from 'window-or-global';
-
+import warning from 'warning';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import Icon from '../Icon';
+
+let didWarnAboutDeprecation = false;
 
 export default class InteriorLeftNav extends Component {
   static propTypes = {
@@ -21,11 +23,23 @@ export default class InteriorLeftNav extends Component {
     open: true,
   };
 
-  state = {
-    activeHref:
-      this.props.activeHref || (window.location && window.location.pathname),
-    open: this.props.open !== undefined ? this.props.open : true,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeHref:
+        props.activeHref || (window.location && window.location.pathname),
+      open: props.open !== undefined ? props.open : true,
+    };
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'Accessing the `InteriorLeftNav` component from the ' +
+          '`carbon-components-react` package is deprecated. Use the ' +
+          '`carbon-addons-cloud-react` package instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
+  }
 
   componentWillReceiveProps = nextProps => {
     if (nextProps.activeHref) {

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -2,6 +2,9 @@ import window from 'window-or-global';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const newChild = (children, tabIndex) => {
   const child = React.Children.only(children);
@@ -19,6 +22,16 @@ const InteriorLeftNavItem = ({
   activeHref,
   ...other
 }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `InteriorLeftNavItem` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const childHref =
     children.props.href === undefined ? children.props.to : children.props.href;
   const activePath =

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import warning from 'warning';
 import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import Icon from '../Icon';
+
+let didWarnAboutDeprecation = false;
 
 export default class InteriorLeftNavList extends Component {
   static propTypes = {
@@ -30,9 +33,21 @@ export default class InteriorLeftNavList extends Component {
     isExpanded: false,
   };
 
-  state = {
-    open: this.props.open,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: props.open,
+    };
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'Accessing the `InteriorLeftNavList` component from the ' +
+          '`carbon-components-react` package is deprecated. Use the ' +
+          '`carbon-addons-cloud-react` package instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
+  }
 
   toggle = evt => {
     if (evt.which === 13 || evt.which === 32 || evt.type === 'click') {

--- a/src/components/Module/Module.js
+++ b/src/components/Module/Module.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const propTypes = {
   children: PropTypes.node,
@@ -28,6 +31,16 @@ const moduleBodydefaultProps = {
 };
 
 const Module = ({ children, className, size, ...other }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'Accessing the `Module` component from the ' +
+        '`carbon-components-react` package is deprecated. Use the ' +
+        '`carbon-addons-cloud-react` package instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const wrapperClasses = classNames(
     `bx--module bx--module--${size}`,
     className

--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -1,13 +1,29 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import warning from 'warning';
 import Link from '../Link';
+
+let didWarnAboutDeprecation = false;
 
 export class OrderSummary extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
   };
+
+  constructor(props) {
+    super(props);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'Accessing the `OrderSummary` component from the ' +
+          '`carbon-components-react` package is deprecated. Use the ' +
+          '`carbon-addons-cloud-react` package instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
+  }
 
   render() {
     const { children, className, ...other } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,6 +1677,10 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dev-expression@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz#d4a7beefefbb50e3f2734990a82a2486cf9eb9ee"
+
 babel-plugin-dynamic-import-node@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz#bd1d88ac7aaf98df4917c384373b04d971a2b37a"
@@ -10296,7 +10300,7 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@3.0.0, warning@^3.0.0:
+warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:


### PR DESCRIPTION
Adds `babel-plugin-dev-expression` to add in `__DEV__` time checks that warn about deprecated component usage.

#### Changelog

**New**

**Changed**

- [x] `Card`
  - [x] `CardActionItem`
  - [x] `CardContent`
  - [x] `CardFooter`
  - [x] `CardStatus`
- [x] `DetailPageHeader`
- [x] `InteriorLeftNav`
  - [x] `InteriorLeftNavHeader`
  - [x] `InteriorLeftNavItem`
  - [x] `InteriorLeftNavList`
- [x] `Module`
- [x] `OrderSummary`

**Removed**
