### PR TITLE
chore(package): update to React v16.4

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -7,16 +7,18 @@ export default class Container extends Component {
     const { story } = this.props;
 
     return (
-      <div
-        role="main"
-        style={{
-          padding: '3em',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}>
-        {story()}
-      </div>
+      <React.StrictMode>
+        <div
+          role="main"
+          style={{
+            padding: '3em',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}>
+          {story()}
+        </div>
+      </React.StrictMode>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
   "peerDependencies": {
     "carbon-components": "^8.20.0",
     "carbon-icons": "^7.0.5",
-    "react": "^15.3.2 || ^16.1.0",
-    "react-dom": "^15.3.2 || ^16.1.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "dependencies": {
     "classnames": "2.2.5",
@@ -173,9 +173,9 @@
     "prettier": "^1.10.0",
     "promise": "^8.0.1",
     "prop-types": "^15.5.8",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
-    "react-test-renderer": "^16.1.0",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
+    "react-test-renderer": "^16.3.0",
     "requestanimationframe": "^0.0.23",
     "rimraf": "^2.6.1",
     "rollup": "^0.57.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "prop-types": "^15.5.8",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-test-renderer": "^16.3.0",
+    "react-test-renderer": "^16.4.0",
     "requestanimationframe": "^0.0.23",
     "rimraf": "^2.6.1",
     "rollup": "^0.57.0",

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -24,7 +24,7 @@ export default class AccordionItem extends Component {
     open: this.props.open,
   };
 
-  componentWillReceiveProps({ open }) {
+  UNSAFE_componentWillReceiveProps({ open }) {
     if (open !== this.props.open) {
       this.setState({ open });
     }

--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -112,7 +112,7 @@ export default class ComboBox extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState(state => ({
       inputValue: getInputValue(nextProps, state),
     }));

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -33,7 +33,7 @@ export default class ComposedModal extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.open !== this.state.open) {
       this.setState({
         open: nextProps.open,

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -107,7 +107,7 @@ export default class DataTable extends React.Component {
     this.instanceId = getInstanceId();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const rowIds = this.props.rows.map(row => row.id);
     const nextRowIds = nextProps.rows.map(row => row.id);
 

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -205,7 +205,7 @@ export default class DatePicker extends Component {
     locale: 'en',
   };
 
-  componentWillUpdate(nextProps) {
+  UNSAFE_componentWillUpdate(nextProps) {
     if (nextProps.value !== this.props.value) {
       if (
         this.props.datePickerType === 'single' ||

--- a/src/components/DetailPageHeader/DetailPageHeader.js
+++ b/src/components/DetailPageHeader/DetailPageHeader.js
@@ -39,7 +39,7 @@ export default class DetailPageHeader extends Component {
     window.addEventListener('scroll', this._debouncedScroll);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.isScrolled !== this.props.isScrolled) {
       this.setState({ isScrolled: nextProps.isScrolled });
     }

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -37,7 +37,7 @@ export default class Dropdown extends PureComponent {
     this.state = this.resetState(props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState(this.resetState(nextProps));
   }
 

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -33,10 +33,10 @@ export class FileUploaderButton extends Component {
   state = {
     labelText: this.props.labelText,
   };
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uid = this.props.id || uid();
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.labelText !== this.props.labelText) {
       this.setState({ labelText: nextProps.labelText });
     }
@@ -195,7 +195,7 @@ export default class FileUploader extends Component {
 
   nodes = [];
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.filenameStatus !== this.props.filenameStatus) {
       this.setState({ filenameStatus: nextProps.filenameStatus });
     }

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -27,7 +27,7 @@ export default class InteriorLeftNav extends Component {
     open: this.props.open !== undefined ? this.props.open : true,
   };
 
-  componentWillReceiveProps = nextProps => {
+  UNSAFE_componentWillReceiveProps = nextProps => {
     if (nextProps.activeHref) {
       this.setState({ activeHref: nextProps.activeHref });
     }

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -60,7 +60,7 @@ export default class NumberInput extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this.setState({ value: nextProps.value });
     }

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -217,7 +217,7 @@ export default class OverflowMenu extends Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.open !== this.props.open) {
       this.setState({ open: nextProps.open });
     }

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -62,7 +62,7 @@ export default class Pagination extends Component {
         : this.props.pageSizes[0],
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uniqueId = `${Math.floor(Math.random() * 0xffff)}`;
   }
 
@@ -79,7 +79,7 @@ export default class Pagination extends Component {
     this.pageInputDebouncer.cancel();
   }
 
-  componentWillReceiveProps({ pageSizes, page, pageSize }) {
+  UNSAFE_componentWillReceiveProps({ pageSizes, page, pageSize }) {
     if (!equals(pageSizes, this.props.pageSizes)) {
       this.setState({ pageSize: pageSizes[0], page: 1 });
     }

--- a/src/components/PaginationV2/PaginationV2.js
+++ b/src/components/PaginationV2/PaginationV2.js
@@ -133,11 +133,11 @@ export default class PaginationV2 extends Component {
         : this.props.pageSizes[0],
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uniqueId = ++instanceId;
   }
 
-  componentWillReceiveProps({ pageSizes, page, pageSize }) {
+  UNSAFE_componentWillReceiveProps({ pageSizes, page, pageSize }) {
     if (!equals(pageSizes, this.props.pageSizes)) {
       this.setState({ pageSize: pageSizes[0], page: 1 });
     }

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -70,7 +70,7 @@ export class ProgressIndicator extends Component {
     currentIndex: this.props.currentIndex,
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.currentIndex !== this.props.currentIndex) {
       this.setState({ currentIndex: nextProps.currentIndex });
     }

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -20,7 +20,7 @@ export default class RadioButton extends React.Component {
     onChange: () => {},
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uid = this.props.id || uid();
   }
 

--- a/src/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.js
@@ -23,13 +23,13 @@ export default class RadioButtonGroup extends React.Component {
     selected: null,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       selected: this.props.valueSelected || this.props.defaultSelected || null,
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.hasOwnProperty('valueSelected')) {
       this.setState({
         selected: nextProps.valueSelected,

--- a/src/components/RadioTile/RadioTile.js
+++ b/src/components/RadioTile/RadioTile.js
@@ -19,7 +19,7 @@ export default class RadioTile extends React.Component {
     onChange: () => {},
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uid = this.props.id || uid();
   }
 

--- a/src/components/SearchLayoutButton/SearchLayoutButton.js
+++ b/src/components/SearchLayoutButton/SearchLayoutButton.js
@@ -35,7 +35,7 @@ class SearchLayoutButton extends Component {
     format: this.props.format || 'list',
   };
 
-  componentWillReceiveProps({ format }) {
+  UNSAFE_componentWillReceiveProps({ format }) {
     const { format: prevFormat } = this.props;
     if (prevFormat !== format) {
       this.setState({ format: format || 'list' });

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -129,7 +129,7 @@ export default class Slider extends PureComponent {
     this.updatePosition();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(nextProps, this.props)) {
       this.updatePosition();
     }

--- a/src/components/StructuredList/StructuredList-test.js
+++ b/src/components/StructuredList/StructuredList-test.js
@@ -7,7 +7,7 @@ import {
   StructuredListRow,
   StructuredListCell,
 } from '../StructuredList';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 describe('StructuredListWrapper', () => {
   describe('Renders as expected', () => {
@@ -86,9 +86,9 @@ describe('StructuredListInput', () => {
     });
 
     it('Should render unique id with multiple inputs when no id prop is given', () => {
-      const wrapper1 = shallow(<StructuredListInput className="extra-class" />);
-      const wrapper2 = shallow(<StructuredListInput className="extra-class" />);
-      expect(wrapper1.props().id).not.toEqual(wrapper2.props().id);
+      const wrapper1 = mount(<StructuredListInput className="extra-class" />);
+      const wrapper2 = mount(<StructuredListInput className="extra-class" />);
+      expect(wrapper1.instance().uid).not.toEqual(wrapper2.instance().uid);
     });
   });
 });

--- a/src/components/StructuredList/StructuredList.js
+++ b/src/components/StructuredList/StructuredList.js
@@ -76,7 +76,7 @@ export class StructuredListInput extends Component {
     title: 'title',
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.uid = this.props.id || uid();
   }
 

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -35,7 +35,7 @@ export default class Tabs extends React.Component {
     selected: this.props.selected,
   };
 
-  componentWillReceiveProps({ selected }) {
+  UNSAFE_componentWillReceiveProps({ selected }) {
     this.selectTabAt(selected);
   }
 

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -65,7 +65,7 @@ export class ClickableTile extends Component {
     }
   };
 
-  componentWillReceiveProps({ clicked }) {
+  UNSAFE_componentWillReceiveProps({ clicked }) {
     if (clicked !== this.props.clicked) {
       this.setState({ clicked });
     }
@@ -160,7 +160,7 @@ export class SelectableTile extends Component {
     }
   };
 
-  componentWillReceiveProps({ selected }) {
+  UNSAFE_componentWillReceiveProps({ selected }) {
     if (selected !== this.props.selected) {
       this.setState({ selected });
     }
@@ -234,7 +234,7 @@ export class ExpandableTile extends Component {
     handleClick: () => {},
   };
 
-  componentWillReceiveProps({ expanded, tileMaxHeight, tilePadding }) {
+  UNSAFE_componentWillReceiveProps({ expanded, tileMaxHeight, tilePadding }) {
     if (expanded !== this.props.expanded) {
       this.setState({ expanded });
     }

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -23,13 +23,13 @@ export default class TileGroup extends React.Component {
     selected: null,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       selected: this.props.valueSelected || this.props.defaultSelected || null,
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.hasOwnProperty('valueSelected')) {
       this.setState({
         selected: nextProps.valueSelected,

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -48,7 +48,7 @@ export default class TimePicker extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this.setState({ value: nextProps.value });
     }

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -165,7 +165,7 @@ export default class Tooltip extends Component {
     });
   }
 
-  componentWillReceiveProps({ open }) {
+  UNSAFE_componentWillReceiveProps({ open }) {
     /**
      * so that tooltip can be controlled programmatically through this `open` prop
      */

--- a/src/tools/withState.js
+++ b/src/tools/withState.js
@@ -6,7 +6,7 @@ export default class WithState extends React.PureComponent {
     initialState: PropTypes.object,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState(this.props.initialState);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,9 +8420,9 @@ react-docgen@^2.20.0:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@^16.3.0:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
+react-dom@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8461,9 +8461,9 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+react-is@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
 
 react-modal@^3.1.10:
   version "3.1.11"
@@ -8506,14 +8506,14 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-test-renderer@^16.3.0:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+react-test-renderer@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.0.tgz#0dbe0e24263e94e1830c7afb1f403707fad313a3"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-    react-is "^16.3.2"
+    react-is "^16.4.0"
 
 react-transition-group@^1.1.2:
   version "1.2.1"
@@ -8536,9 +8536,9 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.3.0:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+react@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,9 +8420,9 @@ react-docgen@^2.20.0:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@^16.1.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@^16.3.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -8461,6 +8461,10 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-modal@^3.1.10:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.11.tgz#95c8223fcee7013258ad2d149c38c9f870c89958"
@@ -8494,13 +8498,22 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.1.0:
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-test-renderer@^16.3.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react-transition-group@^1.1.2:
   version "1.2.1"
@@ -8523,9 +8536,9 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.1.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.3.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Updates the project to use React v16.3, including new features like `forwardRef` and `StrictMode`, in addition to updating the usage of deprecated lifecycle hooks by prefixing them with `UNSAFE_`.

Most likely would be a candidate for v9, or a release post-v9.
