### PR TITLE
fix(icon-skeleton): Add missing export for IconSkeleton component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,3 +150,4 @@ export TextAreaSkeleton from './components/TextArea/TextArea.Skeleton';
 export TextInputSkeleton from './components/TextInput/TextInput.Skeleton';
 export ToggleSkeleton from './components/Toggle/Toggle.Skeleton';
 export ToggleSmallSkeleton from './components/ToggleSmall/ToggleSmall.Skeleton';
+export IconSkeleton from './components/Icon/Icon.Skeleton';


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#

Export was missing for the IconSkeleton component

