### PR TITLE
fix(Tooltip): prevent aria-owns attribute being set unless the target really exists

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -287,6 +287,11 @@ export default class Tooltip extends Component {
     );
 
     const triggerClasses = classNames('bx--tooltip__trigger', triggerClassName);
+    const ariaOwnsProps = !open
+      ? {}
+      : {
+          'aria-owns': tooltipId,
+        };
 
     return (
       <div>
@@ -303,8 +308,8 @@ export default class Tooltip extends Component {
                 onFocus={evt => this.handleMouse(evt)}
                 onBlur={evt => this.handleMouse(evt)}
                 aria-haspopup="true"
-                aria-owns={tooltipId}
-                aria-expanded={open}>
+                aria-expanded={open}
+                {...ariaOwnsProps}>
                 <Icon
                   onKeyDown={this.handleKeyPress}
                   onClick={() => this.handleMouse('click')}
@@ -328,8 +333,8 @@ export default class Tooltip extends Component {
               onFocus={evt => this.handleMouse(evt)}
               onBlur={evt => this.handleMouse(evt)}
               aria-haspopup="true"
-              aria-owns={tooltipId}
-              aria-expanded={open}>
+              aria-expanded={open}
+              {...ariaOwnsProps}>
               {triggerText}
             </div>
           )}


### PR DESCRIPTION
Fixes #913.

#### Changelog

**Changed**

* The `<Tooltip>` code now does not set `area-owns` unless it’s open