### PR TITLE
fix(ExpandableTile): improve the description for the chevron (#933)

### DIFF
--- a/src/components/Tile/Tile-test.js
+++ b/src/components/Tile/Tile-test.js
@@ -161,13 +161,16 @@ describe('Tile', () => {
       expect(wrapper.state().expanded).toEqual(true);
     });
 
-    it('displays the appropriate tooltip for the chevron depending on state', () => {
+    it('displays the default tooltip for the chevron depending on state', () => {
+      const defaultExpandedIconText = 'Collapse';
+      const defaultCollapsedIconText = 'Expand';
+
       // Force the expanded tile to be collapsed.
       wrapper.setState({ expanded: false });
       const collapsedDescription = wrapper
         .find('[name="chevron--down"]')
         .getElements()[0].props.description;
-      expect(collapsedDescription).toEqual('Expand');
+      expect(collapsedDescription).toEqual(defaultCollapsedIconText);
 
       // click on the item to expand it.
       wrapper.simulate('click');
@@ -176,7 +179,31 @@ describe('Tile', () => {
       const expandedDescription = wrapper
         .find('[name="chevron--down"]')
         .getElements()[0].props.description;
-      expect(expandedDescription).toEqual('Collapse');
+      expect(expandedDescription).toEqual(defaultExpandedIconText);
+    });
+
+    it('displays the custom tooltips for the chevron depending on state', () => {
+      const tileExpandedIconText = 'Click To Collapse';
+      const tileCollapsedIconText = 'Click To Expand';
+
+      // Force the custom icon text
+      wrapper.setProps({ tileExpandedIconText, tileCollapsedIconText });
+
+      // Force the expanded tile to be collapsed.
+      wrapper.setState({ expanded: false });
+      const collapsedDescription = wrapper
+        .find('[name="chevron--down"]')
+        .getElements()[0].props.description;
+      expect(collapsedDescription).toEqual(tileCollapsedIconText);
+
+      // click on the item to expand it.
+      wrapper.simulate('click');
+
+      // Validate the description change
+      const expandedDescription = wrapper
+        .find('[name="chevron--down"]')
+        .getElements()[0].props.description;
+      expect(expandedDescription).toEqual(tileExpandedIconText);
     });
   });
 });

--- a/src/components/Tile/Tile-test.js
+++ b/src/components/Tile/Tile-test.js
@@ -160,5 +160,23 @@ describe('Tile', () => {
       wrapper.simulate('click');
       expect(wrapper.state().expanded).toEqual(true);
     });
+
+    it('displays the appropriate tooltip for the chevron depending on state', () => {
+      // Force the expanded tile to be collapsed.
+      wrapper.setState({ expanded: false });
+      const collapsedDescription = wrapper
+        .find('[name="chevron--down"]')
+        .getElements()[0].props.description;
+      expect(collapsedDescription).toEqual('Expand');
+
+      // click on the item to expand it.
+      wrapper.simulate('click');
+
+      // Validate the description change
+      const expandedDescription = wrapper
+        .find('[name="chevron--down"]')
+        .getElements()[0].props.description;
+      expect(expandedDescription).toEqual('Collapse');
+    });
   });
 });

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -225,6 +225,8 @@ export class ExpandableTile extends Component {
     className: PropTypes.string,
     expanded: PropTypes.bool,
     tabIndex: PropTypes.number,
+    tileCollapsedIconText: PropTypes.string,
+    tileExpandedIconText: PropTypes.string,
   };
 
   static defaultProps = {
@@ -232,6 +234,8 @@ export class ExpandableTile extends Component {
     expanded: false,
     tileMaxHeight: '0',
     handleClick: () => {},
+    tileCollapsedIconText: 'Expand',
+    tileExpandedIconText: 'Collapse',
   };
 
   componentWillReceiveProps({ expanded, tileMaxHeight, tilePadding }) {
@@ -295,6 +299,8 @@ export class ExpandableTile extends Component {
       tilePadding, // eslint-disable-line
       handleClick, // eslint-disable-line
       expanded, // eslint-disable-line
+      tileCollapsedIconText, // eslint-disable-line
+      tileExpandedIconText, // eslint-disable-line
       ...other
     } = this.props;
 
@@ -328,7 +334,9 @@ export class ExpandableTile extends Component {
         <button className="bx--tile__chevron">
           <Icon
             name="chevron--down"
-            description={this.state.expanded ? 'Collapse' : 'Expand'}
+            description={
+              this.state.expanded ? tileExpandedIconText : tileCollapsedIconText
+            }
           />
         </button>
         <div

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -326,7 +326,10 @@ export class ExpandableTile extends Component {
         onClick={this.handleClick}
         tabIndex={tabIndex}>
         <button className="bx--tile__chevron">
-          <Icon name="chevron--down" description="Tile chevron" />
+          <Icon
+            name="chevron--down"
+            description={this.state.expanded ? 'Collapse' : 'Expand'}
+          />
         </button>
         <div
           ref={tileContent => {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#933

This PR will update the chevron inside of an ExpandableTile component to display a description of "Expand" when the tile is collapsed, and "Collapse" when the tile is expanded.

#### Changelog

**Changed**

* ExpandableTile chevron Icon now changes description based on the `expanded` state of the component.

