### PR TITLE
Enhancement: Allow React elements in DataTable.TableHeader

### DIFF
--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -76,7 +76,10 @@ TableHeader.propTypes = {
   /**
    * Pass in children that will be embedded in the table header label
    */
-  children: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ])
 
   /**
    * Specify whether this header is one through which a user can sort the table

--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -76,7 +76,7 @@ TableHeader.propTypes = {
   /**
    * Pass in children that will be embedded in the table header label
    */
-  children: PropTypes.node
+  children: PropTypes.node,
 
   /**
    * Specify whether this header is one through which a user can sort the table

--- a/src/components/DataTable/TableHeader.js
+++ b/src/components/DataTable/TableHeader.js
@@ -76,10 +76,7 @@ TableHeader.propTypes = {
   /**
    * Pass in children that will be embedded in the table header label
    */
-  children: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element
-  ])
+  children: PropTypes.node
 
   /**
    * Specify whether this header is one through which a user can sort the table


### PR DESCRIPTION
Altered Prop~Types for DataTable.TableHeader to prevent warnings when a user supplies a React Element as the child of the TableHeader, currently it only allows a string and hence no custom styling
