### PR TITLE
fix(dropdown-skeleton): fix class typo

### DIFF
--- a/src/components/DropdownV2/Dropdown.Skeleton.js
+++ b/src/components/DropdownV2/Dropdown.Skeleton.js
@@ -12,7 +12,7 @@ const DropdownSkeleton = ({ inline }) => {
   });
   return (
     <div className={wrapperClasses}>
-      <div role="button" class="bx--list-box__field">
+      <div role="button" className="bx--list-box__field">
         <span className="bx--list-box__label" />
       </div>
     </div>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-react/issues/946

Change from `class` to `className`