### PR TITLE
chore: add back in TooltipSimple with deprecation notices

### DIFF
--- a/src/components/TooltipSimple/TooltipSimple-story.js
+++ b/src/components/TooltipSimple/TooltipSimple-story.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import TooltipSimple from '../TooltipSimple';
+
+storiesOf('TooltipSimple', module)
+  .addWithInfo(
+    'default',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render above the element. The example below shows the default scenario.
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <TooltipSimple text="This is some Tooltip text." className="some-class">
+          <p className="bx--tooltip__trigger">Tooltip - hover</p>
+        </TooltipSimple>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'position',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render above the element. The example below shows specifying the position (supports 'bottom' and 'top')
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <TooltipSimple position="bottom" text="This is some Tooltip text.">
+          <p className="bx--tooltip__trigger">Tooltip - hover</p>
+        </TooltipSimple>
+      </div>
+    )
+  )
+  .addWithInfo(
+    'no icon',
+    `
+      Tooltips are used to supply additional information to an element when hovering over it. By default,
+      the tooltip will render with an information Icon. The example below shows the option to exclude the Icon.
+    `,
+    () => (
+      <div style={{ marginTop: '2rem' }}>
+        <TooltipSimple text="This is some Tooltip text." showIcon={false}>
+          <p className="bx--tooltip__trigger">Tooltip - hover</p>
+        </TooltipSimple>
+      </div>
+    )
+  );

--- a/src/components/TooltipSimple/TooltipSimple-test.js
+++ b/src/components/TooltipSimple/TooltipSimple-test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import Icon from '../Icon';
+import TooltipSimple from '../TooltipSimple';
+import { mount } from 'enzyme';
+
+describe('TooltipSimple', () => {
+  describe('Renders as expected with defaults', () => {
+    const wrapper = mount(
+      <TooltipSimple text="Basic TooltipSimple Text" className="extra-class">
+        <a href="/">A Link</a>
+      </TooltipSimple>
+    );
+    const tooltipWrapper = wrapper.find('.bx--tooltip--simple').first();
+    const tooltip = wrapper.find('.bx--tooltip--simple__top').first();
+
+    describe('tooltip container', () => {
+      it('renders a tooltip container', () => {
+        expect(tooltipWrapper.length).toEqual(1);
+      });
+
+      it('has the expected classes', () => {
+        expect(tooltip.hasClass('bx--tooltip--simple__top')).toEqual(true);
+      });
+
+      it('applies extra classes to the tooltip container', () => {
+        expect(tooltipWrapper.hasClass('extra-class')).toEqual(true);
+      });
+
+      it('has the tooltip text specified', () => {
+        expect(tooltip.props()['data-tooltip-text']).toEqual(
+          'Basic TooltipSimple Text'
+        );
+      });
+    });
+
+    describe('children', () => {
+      it('should wrap the children in the tooltip container', () => {
+        const child = tooltipWrapper.find('a').first();
+        expect(child.length).toEqual(1);
+      });
+    });
+  });
+
+  describe('Renders as expected with specified properties', () => {
+    const wrapper = mount(
+      <TooltipSimple
+        text="Basic TooltipSimple Text"
+        position="bottom"
+        showIcon={false}>
+        <a href="/">A Link</a>
+      </TooltipSimple>
+    );
+    const tooltip = wrapper.find('.bx--tooltip--simple__bottom').first();
+    describe('tooltip container', () => {
+      it("sets the tooltip's position", () => {
+        expect(tooltip.hasClass('bx--tooltip--simple__bottom')).toEqual(true);
+      });
+
+      it('does not render info icon', () => {
+        const icon = tooltip.find(Icon);
+        expect(icon.length).toBe(0);
+      });
+    });
+  });
+});

--- a/src/components/TooltipSimple/TooltipSimple.js
+++ b/src/components/TooltipSimple/TooltipSimple.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import warning from 'warning';
+import Icon from '../Icon';
+
+let didWarnAboutDeprecation = false;
+
+const TooltipSimple = ({
+  children,
+  className,
+  position,
+  text,
+  showIcon,
+  iconName,
+  iconDescription,
+  ...other
+}) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'The `TooltipSimple` component has been deprecated and will be removed ' +
+        'in the next major release of `carbon-components-react`. Please use ' +
+        '`TooltipDefinition` or `TooltipIcon` instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+  const tooltipClasses = classNames(`bx--tooltip--simple__${position}`);
+
+  const tooltipWrapperClasses = classNames(`bx--tooltip--simple`, className);
+  return (
+    <div>
+      {showIcon ? (
+        <div className={tooltipWrapperClasses}>
+          {children}
+          <div
+            className={tooltipClasses}
+            data-tooltip-text={text}
+            tabIndex="0"
+            role="button"
+            {...other}>
+            <Icon role="img" name={iconName} description={iconDescription} />
+          </div>
+        </div>
+      ) : (
+        <div className={tooltipWrapperClasses}>
+          <div
+            className={tooltipClasses}
+            data-tooltip-text={text}
+            tabIndex="0"
+            role="button"
+            {...other}>
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+TooltipSimple.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  position: PropTypes.oneOf(['bottom', 'top']),
+  text: PropTypes.string.isRequired,
+  showIcon: PropTypes.bool,
+  iconName: PropTypes.string,
+  iconDescription: PropTypes.string,
+};
+
+TooltipSimple.defaultProps = {
+  position: 'top',
+  showIcon: true,
+  iconName: 'info--glyph',
+  iconDescription: 'tooltip',
+  text: 'Provide text',
+};
+
+export default TooltipSimple;

--- a/src/components/TooltipSimple/index.js
+++ b/src/components/TooltipSimple/index.js
@@ -1,0 +1,1 @@
+export default from './TooltipSimple';


### PR DESCRIPTION
Adds back in TooltipSimple since this is being deprecated in v9. Also adds in appropriate deprecation notices and recommendations to use either TooltipDefinition, or TooltipIcon, instead.

#### Changelog

**New**

* `TooltipSimple`

**Changed**

**Removed**
