### PR TITLE
chore: add deprecation notices for components in v9

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
 import ClickListener from '../../internal/ClickListener';
 import Icon from '../Icon';
+
+let didWarnAboutDeprecation = false;
 
 export default class Dropdown extends PureComponent {
   static propTypes = {
@@ -35,6 +38,14 @@ export default class Dropdown extends PureComponent {
   constructor(props) {
     super(props);
     this.state = this.resetState(props);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `Dropdown` component is being updated in the next release of ' +
+          '`carbon-components-react`. Please use `DropdownV2` instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {

--- a/src/components/DropdownItem/DropdownItem.js
+++ b/src/components/DropdownItem/DropdownItem.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const DropdownItem = ({
   className,
@@ -13,6 +16,16 @@ const DropdownItem = ({
   selected,
   ...other
 }) => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'The `DropdownItem` component has been deprecated and will be ' +
+        'removed in the next major release of `carbon-components-react`. ' +
+        'Please use `DropdownV2` instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
+
   const dropdownItemClasses = classNames({
     'bx--dropdown-item': true,
     [className]: className,

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -2,11 +2,14 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
+import warning from 'warning';
 import Icon from '../Icon';
 import Select from '../Select';
 import SelectItem from '../SelectItem';
 import TextInput from '../TextInput';
 import { equals } from '../../tools/array';
+
+let didWarnAboutDeprecation = false;
 
 export default class Pagination extends Component {
   static propTypes = {
@@ -53,6 +56,18 @@ export default class Pagination extends Component {
     defaultItemText: totalItems => `${totalItems} items`,
     onChangeInterval: 250,
   };
+
+  constructor(props) {
+    super(props);
+    if (__DEV__) {
+      warning(
+        didWarnAboutDeprecation,
+        'The `Pagination` component is being updated in the next release of ' +
+          '`carbon-components-react`. Please use `PaginationV2` instead.'
+      );
+      didWarnAboutDeprecation = true;
+    }
+  }
 
   state = {
     page: this.props.page,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,8 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import warning from 'warning';
+
+let didWarnAboutDeprecation = false;
 
 const Table = props => {
+  if (__DEV__) {
+    warning(
+      didWarnAboutDeprecation,
+      'The `Table` component is being updated in the next release of ' +
+        '`carbon-components-react`. Please use `DataTable.Table` instead.'
+    );
+    didWarnAboutDeprecation = true;
+  }
   const { children, className, containerClassName, ...other } = props;
 
   const tableClasses = classNames(className, 'bx--responsive-table');


### PR DESCRIPTION
Adds in deprecation notices for:

- `Dropdown` and `DropdownItem`
- `Pagination`
- `Table`
