### PR TITLE
feat(Notification): Add `timeout` prop to ToastNotification, closes #846

### DIFF
--- a/src/components/Notification/Notification-story.js
+++ b/src/components/Notification/Notification-story.js
@@ -17,6 +17,7 @@ const notificationProps = {
     captionNode: <Link href="#">The caption can be any node.</Link>,
     iconDescription: 'describes the close button',
     style: { minWidth: '30rem', marginBottom: '.5rem' },
+    timeout: 0,
   },
   inline: {
     onCloseButtonClick: action('onCloseButtonClick'),

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -121,7 +121,7 @@ export class ToastNotification extends Component {
     iconDescription: 'closes notification',
     onCloseButtonClick: () => {},
     hideCloseButton: false,
-    timeout: 3000,
+    timeout: 0,
   };
 
   state = {

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -108,6 +108,7 @@ export class ToastNotification extends Component {
     iconDescription: PropTypes.string.isRequired,
     notificationType: PropTypes.string,
     hideCloseButton: PropTypes.bool,
+    timeout: PropTypes.number,
   };
 
   static defaultProps = {
@@ -120,11 +121,20 @@ export class ToastNotification extends Component {
     iconDescription: 'closes notification',
     onCloseButtonClick: () => {},
     hideCloseButton: false,
+    timeout: 3000,
   };
 
   state = {
     open: true,
   };
+
+  componentDidMount() {
+    if (this.props.timeout) {
+      setTimeout(() => {
+        this.handleCloseButtonClick();
+      }, this.props.timeout);
+    }
+  }
 
   handleCloseButtonClick = evt => {
     this.setState({ open: false });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,8 +2761,9 @@ caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
-"carbon-components@file:../carbon-components":
-  version "7.2.1"
+carbon-components@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-9.0.2.tgz#7e959808974cc464fad6098e791230e1972162d8"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react #846 

This PR will support an optional `timeout` prop in the ToastNotification component. It makes use of the `componentDidMount` React lifecycle method to check if the `timeeout` prop (which is of type `Number`) is truthy. So if the value is `0`, then the toast will persist until the Notification close button is explicitly clicked. Otherwise, the `handleCloseButtonClick` method will be called after the number of milliseconds in the `timeout` prop has elapsed.

#### Changelog

**New**

* `timeout` prop on ToastNotification (default 3000ms).

A few things I would like some input on:

Currently, I am setting the default value of the timeout to 3000ms according to the discussion on the issue, but I'd like to know if we would want to keep a default timeout. I also want to make sure that the usage of `componentDidMount` would be the best place to add this functionality.