### PR TITLE
feat(FileUploader): Add optional `name` attribute for FileUploader

### DIFF
--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -16,6 +16,7 @@ storiesOf('FileUploader', module)
       <FileUploaderButton
         labelText="Add files"
         className="bob"
+        name="file"
         onChange={() => console.log('hi')}
         multiple
       />
@@ -34,6 +35,7 @@ storiesOf('FileUploader', module)
           buttonLabel="Add files"
           filenameStatus="edit"
           accept={['.jpg', '.png']}
+          name="file"
           multiple
           ref={fileUploader => (this.fileUploader = fileUploader)}
         />

--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -16,7 +16,7 @@ storiesOf('FileUploader', module)
       <FileUploaderButton
         labelText="Add files"
         className="bob"
-        name="file"
+        // name="file"
         onChange={() => console.log('hi')}
         multiple
       />

--- a/src/components/FileUploader/FileUploader-story.js
+++ b/src/components/FileUploader/FileUploader-story.js
@@ -16,7 +16,7 @@ storiesOf('FileUploader', module)
       <FileUploaderButton
         labelText="Add files"
         className="bob"
-        // name="file"
+        name="file"
         onChange={() => console.log('hi')}
         multiple
       />

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -13,6 +13,7 @@ export class FileUploaderButton extends Component {
     labelText: PropTypes.string,
     listFiles: PropTypes.bool,
     multiple: PropTypes.bool,
+    name: PropTypes.string,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
     role: PropTypes.string,
@@ -65,6 +66,7 @@ export class FileUploaderButton extends Component {
       tabIndex,
       buttonKind,
       accept,
+      name,
       ...other
     } = this.props;
     const classes = classNames({
@@ -96,6 +98,7 @@ export class FileUploaderButton extends Component {
           type="file"
           multiple={multiple}
           accept={accept}
+          name={name || ''}
           onChange={this.handleChange}
           onClick={evt => {
             evt.target.value = null;
@@ -171,6 +174,7 @@ export default class FileUploader extends Component {
     labelDescription: PropTypes.string,
     labelTitle: PropTypes.string,
     multiple: PropTypes.bool,
+    name: PropTypes.string,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
     className: PropTypes.string,
@@ -229,6 +233,7 @@ export default class FileUploader extends Component {
       className,
       multiple,
       accept,
+      name,
       ...other
     } = this.props;
 
@@ -248,6 +253,7 @@ export default class FileUploader extends Component {
           onChange={this.handleChange}
           disableLabelChanges
           accept={accept}
+          name={name || ''}
         />
         <div className="bx--file-container">
           {this.state.filenames.length === 0

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -98,7 +98,7 @@ export class FileUploaderButton extends Component {
           type="file"
           multiple={multiple}
           accept={accept}
-          name={name || ''}
+          name={name}
           onChange={this.handleChange}
           onClick={evt => {
             evt.target.value = null;
@@ -253,7 +253,7 @@ export default class FileUploader extends Component {
           onChange={this.handleChange}
           disableLabelChanges
           accept={accept}
-          name={name || ''}
+          name={name}
         />
         <div className="bx--file-container">
           {this.state.filenames.length === 0


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react #945 

This PR will add an optional `name` attribute to the FileUploader and FileUploaderButton so that the input element will receive its value. If no value is provided, then the attribute value defaults to an empty string.

#### Changelog

**New**

* add `name` attribute for `FileUploader` and `FileUploaderButton` components