### PR TITLE
fix(Modal): Focus primary actionable button on modal opening

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -42,7 +42,7 @@ const Button = ({
       {...commonProps}
       disabled={disabled}
       type={type}
-      ref={other.inputRef}>
+      ref={other.inputref}>
       {children}
       {buttonImage}
     </button>
@@ -54,7 +54,7 @@ const Button = ({
       {...commonProps}
       href={href}
       role="button"
-      ref={other.inputRef}>
+      ref={other.inputref}>
       {children}
       {buttonImage}
     </a>

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,55 +3,81 @@ import React from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
-const Button = ({
-  children,
-  className,
-  disabled,
-  small,
-  kind,
-  href,
-  tabIndex,
-  type,
-  icon,
-  iconDescription,
-  ...other
-}) => {
-  const buttonClasses = classNames(className, {
-    'bx--btn': true,
-    'bx--btn--sm': small,
-    'bx--btn--primary': kind === 'primary',
-    'bx--btn--danger': kind === 'danger',
-    'bx--btn--secondary': kind === 'secondary',
-    'bx--btn--ghost': kind === 'ghost',
-    'bx--btn--danger--primary': kind === 'danger--primary',
-    'bx--btn--tertiary': kind === 'tertiary',
-  });
+export default class Button extends React.Component {
+  focus() {
+    this.el.focus();
+  }
 
-  const commonProps = {
-    tabIndex,
-    className: buttonClasses,
-  };
+  render() {
+    const {
+      children,
+      className,
+      disabled,
+      small,
+      kind,
+      href,
+      tabIndex,
+      type,
+      icon,
+      iconDescription,
+      ...other
+    } = this.props;
 
-  const buttonImage = icon ? (
-    <Icon name={icon} description={iconDescription} className="bx--btn__icon" />
-  ) : null;
+    const buttonClasses = classNames(className, {
+      'bx--btn': true,
+      'bx--btn--sm': small,
+      'bx--btn--primary': kind === 'primary',
+      'bx--btn--danger': kind === 'danger',
+      'bx--btn--secondary': kind === 'secondary',
+      'bx--btn--ghost': kind === 'ghost',
+      'bx--btn--danger--primary': kind === 'danger--primary',
+      'bx--btn--tertiary': kind === 'tertiary',
+    });
 
-  const button = (
-    <button {...other} {...commonProps} disabled={disabled} type={type}>
-      {children}
-      {buttonImage}
-    </button>
-  );
+    const commonProps = {
+      tabIndex,
+      className: buttonClasses,
+    };
 
-  const anchor = (
-    <a {...other} {...commonProps} href={href} role="button">
-      {children}
-      {buttonImage}
-    </a>
-  );
+    const buttonImage = icon ? (
+      <Icon
+        name={icon}
+        description={iconDescription}
+        className="bx--btn__icon"
+      />
+    ) : null;
 
-  return href ? anchor : button;
-};
+    const button = (
+      <button
+        {...other}
+        {...commonProps}
+        disabled={disabled}
+        type={type}
+        ref={el => {
+          this.el = el;
+        }}>
+        {children}
+        {buttonImage}
+      </button>
+    );
+
+    const anchor = (
+      <a
+        {...other}
+        {...commonProps}
+        href={href}
+        role="button"
+        ref={el => {
+          this.el = el;
+        }}>
+        {children}
+        {buttonImage}
+      </a>
+    );
+
+    return href ? anchor : button;
+  }
+}
 
 Button.propTypes = {
   children: PropTypes.node,
@@ -89,5 +115,3 @@ Button.defaultProps = {
   small: false,
   kind: 'primary',
 };
-
-export default Button;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,81 +3,65 @@ import React from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
 
-export default class Button extends React.Component {
-  focus() {
-    this.el.focus();
-  }
+const Button = ({
+  children,
+  className,
+  disabled,
+  small,
+  kind,
+  href,
+  tabIndex,
+  type,
+  icon,
+  iconDescription,
+  ...other
+}) => {
+  const buttonClasses = classNames(className, {
+    'bx--btn': true,
+    'bx--btn--sm': small,
+    'bx--btn--primary': kind === 'primary',
+    'bx--btn--danger': kind === 'danger',
+    'bx--btn--secondary': kind === 'secondary',
+    'bx--btn--ghost': kind === 'ghost',
+    'bx--btn--danger--primary': kind === 'danger--primary',
+    'bx--btn--tertiary': kind === 'tertiary',
+  });
 
-  render() {
-    const {
-      children,
-      className,
-      disabled,
-      small,
-      kind,
-      href,
-      tabIndex,
-      type,
-      icon,
-      iconDescription,
-      ...other
-    } = this.props;
+  const commonProps = {
+    tabIndex,
+    className: buttonClasses,
+  };
 
-    const buttonClasses = classNames(className, {
-      'bx--btn': true,
-      'bx--btn--sm': small,
-      'bx--btn--primary': kind === 'primary',
-      'bx--btn--danger': kind === 'danger',
-      'bx--btn--secondary': kind === 'secondary',
-      'bx--btn--ghost': kind === 'ghost',
-      'bx--btn--danger--primary': kind === 'danger--primary',
-      'bx--btn--tertiary': kind === 'tertiary',
-    });
+  const buttonImage = icon ? (
+    <Icon name={icon} description={iconDescription} className="bx--btn__icon" />
+  ) : null;
 
-    const commonProps = {
-      tabIndex,
-      className: buttonClasses,
-    };
+  const button = (
+    <button
+      {...other}
+      {...commonProps}
+      disabled={disabled}
+      type={type}
+      ref={other.inputRef}>
+      {children}
+      {buttonImage}
+    </button>
+  );
 
-    const buttonImage = icon ? (
-      <Icon
-        name={icon}
-        description={iconDescription}
-        className="bx--btn__icon"
-      />
-    ) : null;
+  const anchor = (
+    <a
+      {...other}
+      {...commonProps}
+      href={href}
+      role="button"
+      ref={other.inputRef}>
+      {children}
+      {buttonImage}
+    </a>
+  );
 
-    const button = (
-      <button
-        {...other}
-        {...commonProps}
-        disabled={disabled}
-        type={type}
-        ref={el => {
-          this.el = el;
-        }}>
-        {children}
-        {buttonImage}
-      </button>
-    );
-
-    const anchor = (
-      <a
-        {...other}
-        {...commonProps}
-        href={href}
-        role="button"
-        ref={el => {
-          this.el = el;
-        }}>
-        {children}
-        {buttonImage}
-      </a>
-    );
-
-    return href ? anchor : button;
-  }
-}
+  return href ? anchor : button;
+};
 
 Button.propTypes = {
   children: PropTypes.node,
@@ -115,3 +99,5 @@ Button.defaultProps = {
   small: false,
   kind: 'primary',
 };
+
+export default Button;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -54,22 +54,28 @@ export default class Modal extends Component {
     }
   };
 
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      this.buttonIsFocusable = true;
+    } else if (prevProps.open && !this.props.open) {
+      this.buttonIsFocusable = false;
+    }
+  }
+
   focusButton = () => {
     if (this.button) {
       this.button.current.focus();
     }
   };
 
-  handleTransitionEnd = evt => {
-    if (!evt.target.classList.contains('bx--modal')) {
-      return;
-    }
-    const modalIsVisible =
-      evt.target.offsetHeight &&
-      evt.target.offsetWidth &&
-      evt.propertyName === 'opacity';
-    if (this.props.open && modalIsVisible) {
+  handleTransitionEnd = () => {
+    if (
+      this.outerModal.offsetWidth &&
+      this.outerModal.offsetHeight &&
+      this.buttonIsFocusable
+    ) {
       this.focusButton();
+      this.buttonIsFocusable = false;
     }
   };
 
@@ -163,7 +169,10 @@ export default class Modal extends Component {
         className={modalClasses}
         role="presentation"
         tabIndex={-1}
-        onTransitionEnd={this.handleTransitionEnd}>
+        onTransitionEnd={this.props.open && this.handleTransitionEnd}
+        ref={outerModal => {
+          this.outerModal = outerModal;
+        }}>
         {modalBody}
       </div>
     );

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -53,12 +53,14 @@ export default class Modal extends Component {
   };
 
   focusButton() {
-    if (this.button) {
-      this.button.focus();
+    if (this.button && this.props.open) {
+      setTimeout(() => {
+        this.button.focus();
+      }, 200);
     }
   }
 
-  componentDidMount() {
+  componentDidUpdate() {
     this.focusButton();
   }
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -54,17 +54,14 @@ export default class Modal extends Component {
     }
   };
 
-  focusButton() {
-    if (this.button && this.props.open) {
-      setTimeout(() => {
-        this.button.current.focus();
-      }, 200);
+  focusButton = e => {
+    const modalIsVisible =
+      this.props.open &&
+      (e.propertyName === 'opacity' || e.propertyName === 'visibility');
+    if (this.button && modalIsVisible) {
+      this.button.current.focus();
     }
-  }
-
-  componentDidUpdate() {
-    this.focusButton();
-  }
+  };
 
   render() {
     const {
@@ -155,7 +152,8 @@ export default class Modal extends Component {
         onClick={this.handleClick}
         className={modalClasses}
         role="presentation"
-        tabIndex={-1}>
+        tabIndex={-1}
+        onTransitionEnd={this.focusButton}>
         {modalBody}
       </div>
     );

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -52,6 +52,16 @@ export default class Modal extends Component {
     }
   };
 
+  focusButton() {
+    if (this.button) {
+      this.button.focus();
+    }
+  }
+
+  componentDidMount() {
+    this.focusButton();
+  }
+
   render() {
     const {
       modalHeading,
@@ -86,7 +96,10 @@ export default class Modal extends Component {
       <button
         className="bx--modal-close"
         type="button"
-        onClick={onRequestClose}>
+        onClick={onRequestClose}
+        ref={closeButton => {
+          this.button = closeButton;
+        }}>
         <Icon
           name="close"
           className="bx--modal-close__icon"
@@ -123,7 +136,10 @@ export default class Modal extends Component {
               <Button
                 kind={danger ? 'danger--primary' : 'primary'}
                 disabled={primaryButtonDisabled}
-                onClick={onRequestSubmit}>
+                onClick={onRequestSubmit}
+                ref={primaryButton => {
+                  this.button = primaryButton;
+                }}>
                 {primaryButtonText}
               </Button>
             </div>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -56,9 +56,9 @@ export default class Modal extends Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.open && this.props.open) {
-      this.buttonIsFocusable = true;
+      this.beingOpen = true;
     } else if (prevProps.open && !this.props.open) {
-      this.buttonIsFocusable = false;
+      this.beingOpen = false;
     }
   }
 
@@ -72,10 +72,10 @@ export default class Modal extends Component {
     if (
       this.outerModal.offsetWidth &&
       this.outerModal.offsetHeight &&
-      this.buttonIsFocusable
+      this.beingOpen
     ) {
       this.focusButton();
-      this.buttonIsFocusable = false;
+      this.beingOpen = false;
     }
   };
 

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -37,6 +37,8 @@ export default class Modal extends Component {
     modalLabel: '',
   };
 
+  button = React.createRef();
+
   handleKeyDown = evt => {
     if (evt.which === 27) {
       this.props.onRequestClose();
@@ -55,7 +57,7 @@ export default class Modal extends Component {
   focusButton() {
     if (this.button && this.props.open) {
       setTimeout(() => {
-        this.button.focus();
+        this.button.current.focus();
       }, 200);
     }
   }
@@ -99,9 +101,7 @@ export default class Modal extends Component {
         className="bx--modal-close"
         type="button"
         onClick={onRequestClose}
-        ref={closeButton => {
-          this.button = closeButton;
-        }}>
+        ref={this.button}>
         <Icon
           name="close"
           className="bx--modal-close__icon"
@@ -139,9 +139,7 @@ export default class Modal extends Component {
                 kind={danger ? 'danger--primary' : 'primary'}
                 disabled={primaryButtonDisabled}
                 onClick={onRequestSubmit}
-                ref={primaryButton => {
-                  this.button = primaryButton;
-                }}>
+                inputRef={this.button}>
                 {primaryButtonText}
               </Button>
             </div>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -54,12 +54,22 @@ export default class Modal extends Component {
     }
   };
 
-  focusButton = e => {
-    const modalIsVisible =
-      this.props.open &&
-      (e.propertyName === 'opacity' || e.propertyName === 'visibility');
-    if (this.button && modalIsVisible) {
+  focusButton = () => {
+    if (this.button) {
       this.button.current.focus();
+    }
+  };
+
+  handleTransitionEnd = evt => {
+    if (!evt.target.classList.contains('bx--modal')) {
+      return;
+    }
+    const modalIsVisible =
+      evt.target.offsetHeight &&
+      evt.target.offsetWidth &&
+      evt.propertyName === 'opacity';
+    if (this.props.open && modalIsVisible) {
+      this.focusButton();
     }
   };
 
@@ -153,7 +163,7 @@ export default class Modal extends Component {
         className={modalClasses}
         role="presentation"
         tabIndex={-1}
-        onTransitionEnd={this.focusButton}>
+        onTransitionEnd={this.handleTransitionEnd}>
         {modalBody}
       </div>
     );

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -139,7 +139,7 @@ export default class Modal extends Component {
                 kind={danger ? 'danger--primary' : 'primary'}
                 disabled={primaryButtonDisabled}
                 onClick={onRequestSubmit}
-                inputRef={this.button}>
+                inputref={this.button}>
                 {primaryButtonText}
               </Button>
             </div>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -169,7 +169,7 @@ export default class Modal extends Component {
         className={modalClasses}
         role="presentation"
         tabIndex={-1}
-        onTransitionEnd={this.props.open && this.handleTransitionEnd}
+        onTransitionEnd={this.props.open ? this.handleTransitionEnd : undefined}
         ref={outerModal => {
           this.outerModal = outerModal;
         }}>

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -149,6 +149,18 @@ exports[`ModalWrapper should render 1`] = `
               <Button
                 disabled={false}
                 iconDescription="Provide icon description if icon is used"
+                inputref={
+                  Object {
+                    "current": <button
+                      class="bx--btn bx--btn--primary"
+                      inputref="[object Object]"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Save
+                    </button>,
+                  }
+                }
                 kind="primary"
                 onClick={[Function]}
                 small={false}
@@ -158,6 +170,18 @@ exports[`ModalWrapper should render 1`] = `
                 <button
                   className="bx--btn bx--btn--primary"
                   disabled={false}
+                  inputref={
+                    Object {
+                      "current": <button
+                        class="bx--btn bx--btn--primary"
+                        inputref="[object Object]"
+                        tabindex="0"
+                        type="button"
+                      >
+                        Save
+                      </button>,
+                    }
+                  }
                   onClick={[Function]}
                   tabIndex={0}
                   type="button"

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -58,7 +58,6 @@ exports[`ModalWrapper should render 1`] = `
         id="modal"
         onClick={[Function]}
         onKeyDown={[Function]}
-        onTransitionEnd={[Function]}
         role="presentation"
         tabIndex={-1}
       >

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -58,6 +58,7 @@ exports[`ModalWrapper should render 1`] = `
         id="modal"
         onClick={[Function]}
         onKeyDown={[Function]}
+        onTransitionEnd={[Function]}
         role="presentation"
         tabIndex={-1}
       >


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#827

This PR fixes the issue where the primary actionable element is not focused when a Modal component is opened. To accomplish this, `ref`s are attached to the Modal and Button components so that the primary actionable element can be programmatically referenced and focused.

#### Changelog

**Changed**

* Add support for `ref`s in both the Modal and Button components. This will allow for autofocusing of input elements on render.
* Convert `Button` from a stateless functional component to a class component in order to support `ref`s

There are 2 options to solve this issue, and I would like to gather some more opinions about this implementation:

One method would be to added the `autoFocus` attribute to the primary button or the `modalButton` in `Modal.js` depending on whether or not the modal is passive. This may be detrimental to a11y and usability though, since the linter will show a warning if `autoFocus` is used (as mentioned in the ticket).

Another method (currently implemented in this PR) is to convert the Button component from a stateless functional component to a class component, so that we can attach a ref and call the focus method when the Modal component is mounted.