### PR TITLE
ModalWrapper `onKeyDown` default handler

### DIFF
--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -35,6 +35,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: 'Cancel',
     triggerButtonKind: 'primary',
     disabled: false,
+    onKeyDown: () => {},
   };
 
   state = {

--- a/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -9,6 +9,7 @@ exports[`ModalWrapper should render 1`] = `
   id="modal"
   modalHeading="Transactional Modal"
   modalLabel="Test Modal Label"
+  onKeyDown={[Function]}
   primaryButtonText="Save"
   secondaryButtonText="Cancel"
   shouldCloseAfterSubmit={true}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#989 

This PR will add a default onKeyDown handler to the ModalWrapper so that no errors are logged if the user does not provide an event handler function.

#### Changelog

**New**

* default `onKeyDown` prop for ModalWrapper