### PR TITLE
fix(datepicker): unknown prop on div tag

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -373,6 +373,7 @@ export default class DatePicker extends Component {
 
   render() {
     const {
+      appendTo, // eslint-disable-line
       children,
       className,
       short,
@@ -381,6 +382,9 @@ export default class DatePicker extends Component {
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
+      locale, // eslint-disable-line
+      value, // eslint-disable-line
+      ...other
     } = this.props;
 
     const datePickerClasses = classNames('bx--date-picker', className, {
@@ -430,7 +434,7 @@ export default class DatePicker extends Component {
     });
     return (
       <div className="bx--form-item">
-        <div className={datePickerClasses}>
+        <div className={datePickerClasses} {...other}>
           {childrenWithProps}
           {datePickerIcon}
         </div>

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -381,7 +381,6 @@ export default class DatePicker extends Component {
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
-      ...other
     } = this.props;
 
     const datePickerClasses = classNames('bx--date-picker', className, {
@@ -431,7 +430,7 @@ export default class DatePicker extends Component {
     });
     return (
       <div className="bx--form-item">
-        <div className={datePickerClasses} {...other}>
+        <div className={datePickerClasses}>
           {childrenWithProps}
           {datePickerIcon}
         </div>


### PR DESCRIPTION
Fixes [Issue 997](https://github.com/carbon-design-system/carbon-components-react/issues/997) and [Issue 998](https://github.com/carbon-design-system/carbon-components-react/issues/988).

## This is a Fix for v5
My project has not migrated to React 16.4 so we cannot use your v6. Please merge to v5.

## To reproduce with v5 and React 15.x:
- The console error does not occur in Storybook (maybe because that uses React 16) but you can still observe the props added to the `<div>` tag with the React dev-tools.
- Start with an app that is successfully using DatePicker component with version "^5.44.0",`
- Add a `locale` prop to DatePicker such as `locale: {'fr'}` *OR* a `minDate` or `maxDate` prop. All break v5 withe React 15.4.
- See error in console
- DatePicker will not initialize and will not respond to input.
- Console error will appear as in first screenshot
- Using React dev-tools to inspect the children of DatePicker will reveal that there is a plain `<div>` element that is being passed a `locale` prop, just as the error states.