### PR TITLE
fix(DataTable): add icon description to TableExpandRow in DataTable

### DIFF
--- a/src/components/DataTable/TableExpandRow.js
+++ b/src/components/DataTable/TableExpandRow.js
@@ -10,7 +10,7 @@ const TableExpandRow = ({
   children,
   isExpanded,
   onExpand,
-  iconDescription,
+  expandIconDescription,
   ...rest
 }) => {
   const className = cx(
@@ -34,7 +34,7 @@ const TableExpandRow = ({
           <Icon
             className="bx--table-expand-v2__svg"
             name="chevron--right"
-            description={iconDescription}
+            description={expandIconDescription}
           />
         </button>
       </TableCell>
@@ -65,7 +65,7 @@ TableExpandRow.propTypes = {
   /**
    * The description of the chevron right icon, to be put in its SVG `<title>` element.
    */
-  iconDescription: PropTypes.string,
+  expandIconDescription: PropTypes.string,
 };
 
 export default TableExpandRow;

--- a/src/components/DataTable/TableExpandRow.js
+++ b/src/components/DataTable/TableExpandRow.js
@@ -10,6 +10,7 @@ const TableExpandRow = ({
   children,
   isExpanded,
   onExpand,
+  iconDescription,
   ...rest
 }) => {
   const className = cx(
@@ -30,7 +31,11 @@ const TableExpandRow = ({
           className="bx--table-expand-v2__button"
           onClick={onExpand}
           aria-label={ariaLabel}>
-          <Icon className="bx--table-expand-v2__svg" name="chevron--right" />
+          <Icon
+            className="bx--table-expand-v2__svg"
+            name="chevron--right"
+            description={iconDescription}
+          />
         </button>
       </TableCell>
       {children}
@@ -56,6 +61,11 @@ TableExpandRow.propTypes = {
    * Hook for when a listener initiates a request to expand the given row
    */
   onExpand: PropTypes.func.isRequired,
+
+  /**
+   * The description of the chevron right icon, to be put in its SVG `<title>` element.
+   */
+  iconDescription: PropTypes.string,
 };
 
 export default TableExpandRow;


### PR DESCRIPTION
Closes #995

Add `iconDescription` props to `TableExpandRow` in `DataTable`

The `iconDescription` props that will be used as the Title

#### Changelog


