### PR TITLE
remove requirements from aria label prop type

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -9,7 +9,7 @@ let didWarnAboutDeprecation = false;
 
 export default class Dropdown extends PureComponent {
   static propTypes = {
-    ariaLabel: PropTypes.string.isRequired,
+    ariaLabel: PropTypes.string,
     children: PropTypes.node,
     className: PropTypes.string,
     defaultText: PropTypes.string,


### PR DESCRIPTION
remove required prop type for ariaLabel or update documentation to reflect its requirement within the component

http://react.carbondesignsystem.com/?selectedKind=Dropdown&selectedStory=with%20default%20text&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

Closes carbon-design-system/carbon-components-react#

{{short description}}

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
