### PR TITLE
fix(FloatingMenu): fix with scrolling

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -225,7 +225,11 @@ export default class Tooltip extends Component {
     this._hasContextMenu = evt.type === 'contextmenu';
     if (this.props.clickToOpen) {
       if (state === 'click') {
-        this.setState({ open: !this.state.open });
+        const shouldOpen = !this.state.open;
+        if (shouldOpen) {
+          this.getTriggerPosition();
+        }
+        this.setState({ open: shouldOpen });
       }
     } else if (state && (state !== 'out' || !hadContextMenu)) {
       this._debouncedHandleHover(state, evt.relatedTarget);

--- a/src/internal/FloatingMenu.js
+++ b/src/internal/FloatingMenu.js
@@ -255,7 +255,7 @@ class FloatingMenu extends React.Component {
             refPosition,
             direction: menuDirection,
             offset,
-            scrollY: window.scrollY,
+            scrollY: window.pageYOffset,
           }),
         });
       }


### PR DESCRIPTION
Fixes #882.
Fixes #895.

#### Changelog

This change does two things, described below:

**New**

* Updates the position of trigger button in "click-to-open" scenario

**Changed**

* Uses cross-browser alternative to `scrollY` (`pageYOffset`)