### PR TITLE
fix(datepicker): unknown prop on div tag

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -380,6 +380,7 @@ export default class DatePicker extends Component {
 
   render() {
     const {
+      appendTo, // eslint-disable-line
       children,
       className,
       short,
@@ -389,6 +390,8 @@ export default class DatePicker extends Component {
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
+      locale, // eslint-disable-line
+      value, // eslint-disable-line
       ...other
     } = this.props;
 


### PR DESCRIPTION
Fixes [Issue 997](https://github.com/carbon-design-system/carbon-components-react/issues/997) and [Issue 998](https://github.com/carbon-design-system/carbon-components-react/issues/988).

## This is a Fix for v6
This does the same work as [PR-1000](https://github.com/carbon-design-system/carbon-components-react/pull/1000/files) which is for v5.

## To reproduce with v6 in Storybook
- The console error does not occur in Storybook (maybe because that uses React 16) but you can still observe the props added to the `<div>` tag with the React dev-tools.
- Run Storybook and go to the [DatePicker](http://localhost:9000/?selectedKind=DatePicker&selectedStory=range%20with%20calendar%20and%20min%2Fmax%20dates&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel).
- Using React dev-tools to inspect the children of DatePicker will reveal that there is a plain `<div>` element that is being passed a `locale` prop.
- This caused a fatal error in v5 with React 15 which freezes DatePicker. It may do the same in an actual app and is bad practice. This PR keeps v6 in line with v5.

![screen shot 2018-06-15 at 3 08 30 pm](https://user-images.githubusercontent.com/1697656/41487407-300d3368-70ae-11e8-8964-32eb703b4426.png)
