### PR TITLE
fix(OverflowMenu): emulate vanilla component behavior

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -236,7 +236,7 @@ export default class OverflowMenu extends Component {
     if (this.state.open) {
       if (!floatingMenu) {
         (
-          this.menuEl.querySelector('[data-basic-menu-primary-focus]') ||
+          this.menuEl.querySelector('[data-overflow-menu-primary-focus]') ||
           this.menuEl
         ).focus();
         onOpen();
@@ -394,7 +394,7 @@ export default class OverflowMenu extends Component {
     const childrenWithProps = React.Children.toArray(children).map(child =>
       React.cloneElement(child, {
         closeMenu: this.closeMenu,
-        floating: floatingMenu || undefined,
+        floatingMenu: floatingMenu || undefined,
       })
     );
 

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -394,7 +394,7 @@ export default class OverflowMenu extends Component {
     const childrenWithProps = React.Children.toArray(children).map(child =>
       React.cloneElement(child, {
         closeMenu: this.closeMenu,
-        floating: this.props.floatingMenu,
+        floating: floatingMenu || undefined,
       })
     );
 

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -235,6 +235,10 @@ export default class OverflowMenu extends Component {
 
     if (this.state.open) {
       if (!floatingMenu) {
+        (
+          this.menuEl.querySelector('[data-floating-menu-primary-focus]') ||
+          this.menuEl
+        ).focus();
         onOpen();
       }
     } else {

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -236,7 +236,7 @@ export default class OverflowMenu extends Component {
     if (this.state.open) {
       if (!floatingMenu) {
         (
-          this.menuEl.querySelector('[data-floating-menu-primary-focus]') ||
+          this.menuEl.querySelector('[data-basic-menu-primary-focus]') ||
           this.menuEl
         ).focus();
         onOpen();
@@ -394,6 +394,7 @@ export default class OverflowMenu extends Component {
     const childrenWithProps = React.Children.toArray(children).map(child =>
       React.cloneElement(child, {
         closeMenu: this.closeMenu,
+        floating: this.props.floatingMenu,
       })
     );
 

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -110,6 +110,11 @@ OverflowMenuItem.propTypes = {
    * `true` if this menu item should get focus when the menu gets open.
    */
   primaryFocus: PropTypes.bool,
+
+  /**
+   * `true` if this menu item belongs to a floating OverflowMenu
+   */
+  floating: PropTypes.bool,
 };
 
 OverflowMenuItem.defaultProps = {

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -11,6 +11,7 @@ const OverflowMenuItem = ({
   closeMenu,
   onClick,
   primaryFocus,
+  floating,
   wrapperClassName,
   ...other
 }) => {
@@ -34,9 +35,15 @@ const OverflowMenuItem = ({
     closeMenu();
   };
 
-  const primaryFocusProp = !primaryFocus
-    ? {}
-    : { 'data-floating-menu-primary-focus': true };
+  const primaryFocusProp = (({ primaryFocus, floating }) => {
+    if (!primaryFocus) {
+      return {};
+    }
+    return floating
+      ? { 'data-floating-menu-primary-focus': true }
+      : { 'data-basic-menu-primary-focus': true };
+  })({ primaryFocus, floating });
+
   const item = (
     <li className={overflowMenuItemClasses} role="menuitem">
       <button

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -11,7 +11,7 @@ const OverflowMenuItem = ({
   closeMenu,
   onClick,
   primaryFocus,
-  floating,
+  floatingMenu,
   wrapperClassName,
   ...other
 }) => {
@@ -35,14 +35,14 @@ const OverflowMenuItem = ({
     closeMenu();
   };
 
-  const primaryFocusProp = (({ primaryFocus, floating }) => {
+  const primaryFocusProp = (({ primaryFocus, floatingMenu }) => {
     if (!primaryFocus) {
       return {};
     }
-    return floating
+    return floatingMenu
       ? { 'data-floating-menu-primary-focus': true }
-      : { 'data-basic-menu-primary-focus': true };
-  })({ primaryFocus, floating });
+      : { 'data-overflow-menu-primary-focus': true };
+  })({ primaryFocus, floatingMenu });
 
   const item = (
     <li className={overflowMenuItemClasses} role="menuitem">
@@ -114,7 +114,7 @@ OverflowMenuItem.propTypes = {
   /**
    * `true` if this menu item belongs to a floating OverflowMenu
    */
-  floating: PropTypes.bool,
+  floatingMenu: PropTypes.bool,
 };
 
 OverflowMenuItem.defaultProps = {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#991

Unlike its vanilla counterpart, the React basic OverflowMenu does not automatically focus the first menu item when the menu is opened. This PR will add a ref to the first menu item so that focus can be applied when the overflow menu is opened.

#### Changelog

**New**

* add `floatingMenu` prop to `OverflowMenuItem`s based on whether or not the `OverflowMenu` is a floating menu
* attach corresponding primary focus data attribute to menu item based on `primaryFocus` and `floatingMenu` props
* add conditional statement to focus primary element in basic `OverflowMenu` based on the new `data-overflow-menu-primary-focus ` prop