### PR TITLE
fix FileUploader to use it to upload multiple files

### DIFF
--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -205,7 +205,11 @@ export default class FileUploader extends Component {
     }
   }
   handleChange = evt => {
-    this.setState({ filenames: [...evt.target.files].map(file => file.name) });
+    this.setState({
+      filenames: this.state.filenames.concat(
+        [...evt.target.files].map(file => file.name)
+      ),
+    });
     this.props.onChange(evt);
   };
 


### PR DESCRIPTION
Closes  #845

Update `state.filenames` to concatenate the files and not overwrite the old state

#### Changelog

**New**

**Changed**


**Removed**

