### PR TITLE
Add invalid prop to Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "es/**/*",
     "umd/**/*"
   ],
-  "contributors": [
-    {
+  "contributors": [{
       "name": "Brian Han",
       "email": "bthan@us.ibm.com"
     },
@@ -201,8 +200,7 @@
   "babel": {
     "presets": [
       "./scripts/env",
-      "@babel/preset-react",
-      [
+      "@babel/preset-react", [
         "@babel/preset-stage-1",
         {
           "decoratorsLegacy": true

--- a/src/components/Select/Select-story.js
+++ b/src/components/Select/Select-story.js
@@ -17,7 +17,7 @@ storiesOf('Select', module)
     `
       Select displays a list below its title when selected. They are used primarily in forms,
       where a user chooses one option from a list. Once the user selects an item, the dropdown will
-      dissapear and the field will reflect the user's choice. Create Select Item components for each
+      disappear and the field will reflect the user's choice. Create Select Item components for each
       option in the list. The example below shows an enabled Select component with three items.
     `,
     () => (
@@ -71,7 +71,7 @@ storiesOf('Select', module)
     `
       Select displays a list below its title when selected. They are used primarily in forms,
       where a user chooses one option from a list. Once the user selects an item, the dropdown will
-      dissapear and the field will reflect the user's choice. Create SelectItem components for each
+      disappear and the field will reflect the user's choice. Create SelectItem components for each
       option in the list. The example below shows an disabled Select component.
     `,
     () => (
@@ -97,7 +97,7 @@ storiesOf('Select', module)
     `
       Select displays a list below its title when selected. They are used primarily in forms,
       where a user chooses one option from a list. Once the user selects an item, the dropdown will
-      dissapear and the field will reflect the user's choice. Create SelectItem components for each
+      disappear and the field will reflect the user's choice. Create SelectItem components for each
       option in the list. The example below shows a Select component without a label.
     `,
     () => (
@@ -128,7 +128,7 @@ storiesOf('Select', module)
     `
       Select displays a list below its title when selected. They are used primarily in forms,
       where a user chooses one option from a list. Once the user selects an item, the dropdown will
-      dissapear and the field will reflect the user's choice. Create Select Item components for each
+      disappear and the field will reflect the user's choice. Create Select Item components for each
       option in the list. The example below shows an enabled Select component with three items.
     `,
     () => (

--- a/src/components/Select/Select-story.js
+++ b/src/components/Select/Select-story.js
@@ -93,6 +93,64 @@ storiesOf('Select', module)
     )
   )
   .addWithInfo(
+    'invalid',
+    `
+      Select displays a list below its title when selected. They are used primarily in forms,
+      where a user chooses one option from a list. Once the user selects an item, the dropdown will
+      disappear and the field will reflect the user's choice. Create Select Item components for each
+      option in the list. The example below shows an enabled Select component with three items. The example below shows a Select component after an invalid entry is chosen.
+    `,
+    () => (
+      <>
+        <Select
+          {...selectProps}
+          light
+          id="select-1"
+          defaultValue="placeholder-item"
+          invalid
+          invalidText="A valid value is required">
+          <SelectItem
+            disabled
+            hidden
+            value="placeholder-item"
+            text="Choose an option"
+          />
+          <SelectItemGroup label="Category 1">
+            <SelectItem value="option-1" text="Option 1" />
+            <SelectItem value="option-2" text="Option 2" />
+          </SelectItemGroup>
+          <SelectItemGroup label="Category 2">
+            <SelectItem value="option-3" text="Option 3" />
+            <SelectItem value="option-4" text="Option 4" />
+          </SelectItemGroup>
+        </Select>
+        <Select
+          {...selectProps}
+          inline
+          light
+          id="select-2"
+          defaultValue="placeholder-item"
+          invalid
+          invalidText="A valid value is required">
+          <SelectItem
+            disabled
+            hidden
+            value="placeholder-item"
+            text="Choose an option"
+          />
+          <SelectItemGroup label="Category 1">
+            <SelectItem value="option-1" text="Option 1" />
+            <SelectItem value="option-2" text="Option 2" />
+          </SelectItemGroup>
+          <SelectItemGroup label="Category 2">
+            <SelectItem value="option-3" text="Option 3" />
+            <SelectItem value="option-4" text="Option 4" />
+          </SelectItemGroup>
+        </Select>
+      </>
+    )
+  )
+  .addWithInfo(
     'no label',
     `
       Select displays a list below its title when selected. They are used primarily in forms,

--- a/src/components/Select/Select-test.js
+++ b/src/components/Select/Select-test.js
@@ -82,7 +82,7 @@ describe('Select', () => {
       });
 
       it('should set disabled as expected', () => {
-        expect(select.props().disabled).toEqual(false);
+        expect(select.props().disabled).toEqual(undefined);
         wrapper.setProps({ disabled: true });
         expect(wrapper.find('select').props().disabled).toEqual(true);
       });

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -12,6 +12,8 @@ const Select = ({
   children,
   iconDescription,
   hideLabel,
+  invalid,
+  invalidText,
   light,
   ...other
 }) => {
@@ -24,19 +26,23 @@ const Select = ({
   const labelClasses = classNames('bx--label', {
     'bx--visually-hidden': hideLabel,
   });
+  const errorId = `${id}-error-msg`;
+  const error = invalid ? (
+    <div className="bx--form-requirement" id={errorId}>
+      {invalidText}
+    </div>
+  ) : null;
   return (
     <div className="bx--form-item">
       <div className={selectClasses}>
-        {inline ? (
-          <label htmlFor={id} className={labelClasses}>
-            {labelText}
-          </label>
-        ) : null}
         <select
           {...other}
           id={id}
           className="bx--select-input"
-          disabled={disabled}>
+          disabled={disabled || undefined}
+          data-invalid={invalid || undefined}
+          aria-invalid={invalid || undefined}
+          aria-describedby={errorId}>
           {children}
         </select>
         <Icon
@@ -44,11 +50,10 @@ const Select = ({
           className="bx--select__arrow"
           description={iconDescription}
         />
-        {!inline ? (
-          <label htmlFor={id} className={labelClasses}>
-            {labelText}
-          </label>
-        ) : null}
+        <label htmlFor={id} className={labelClasses}>
+          {labelText}
+        </label>
+        {error}
       </div>
     </div>
   );
@@ -65,6 +70,8 @@ Select.propTypes = {
   defaultValue: PropTypes.any,
   iconDescription: PropTypes.string.isRequired,
   hideLabel: PropTypes.bool,
+  invalid: PropTypes.bool,
+  invalidText: PropTypes.string,
   light: PropTypes.bool,
 };
 
@@ -73,6 +80,8 @@ Select.defaultProps = {
   labelText: 'Select',
   inline: false,
   iconDescription: 'open list of options',
+  invalid: false,
+  invalidText: '',
   light: false,
 };
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#1017

This PR will add an `invalid` prop to `Select` to apply data validation styles to the component. Depends on https://github.com/carbon-design-system/carbon-components/pull/919

#### Changelog

**New**

* Add `invalid` prop to `Select` component

**Changed**

* If boolean values are falsy, set value to `undefined` so that they are not attached as string `"false"` to the rendered DOM elements
* Fix tests and typos

**Removed**

* Removed conditional logic for determining location of `Select` label. Reflects changes in https://github.com/carbon-design-system/carbon-components/pull/919
