### PR TITLE
fix(MultiSelect):  close MultiSelect after any option is selected/unselected

### DIFF
--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -119,7 +119,19 @@ export default class MultiSelect extends React.Component {
       // Reference: https://github.com/paypal/downshift/issues/206
       case Downshift.stateChangeTypes.clickButton:
       case Downshift.stateChangeTypes.keyDownSpaceButton:
-        this.handleOnToggleMenu();
+        this.setState(() => {
+          let nextIsOpen = changes.isOpen;
+          if (changes.isOpen === false) {
+            // If Downshift is trying to close the menu, but we know the input
+            // is the active element in the document, then keep the menu open
+            if (this.inputNode === document.activeElement) {
+              nextIsOpen = true;
+            }
+          }
+          return {
+            isOpen: nextIsOpen,
+          };
+        });
         break;
     }
   };

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -90,12 +90,6 @@ export default class MultiSelect extends React.Component {
     }
   };
 
-  handleOnToggleMenu = () => {
-    this.setState(state => ({
-      isOpen: !state.isOpen,
-    }));
-  };
-
   handleOnOuterClick = () => {
     this.setState({
       isOpen: false,

--- a/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -31,9 +31,9 @@ describe('MultiSelect', () => {
       const items = generateItems(5, generateGenericItem);
       const wrapper = mount(<MultiSelect label="Field" items={items} />);
       expect(wrapper.state('isOpen')).toBe(false);
-      wrapper.instance().handleOnToggleMenu();
+      wrapper.find('.bx--list-box__field').simulate('click');
       expect(wrapper.state('isOpen')).toBe(true);
-      wrapper.instance().handleOnToggleMenu();
+      wrapper.find('.bx--list-box__field').simulate('click');
       expect(wrapper.state('isOpen')).toBe(false);
     });
   });


### PR DESCRIPTION
Closes  #1009

The Downshift does not close the menu as long as it contains active elements that have not lost the fucus.

Using the code  useed for the `FilterableMultiSelect` component to resolves this problem

#### Changelog

**New**

**Changed**


**Removed**

