### PR TITLE
fix(FileUploader): `onChange` method called twice

### DIFF
--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -210,7 +210,6 @@ export default class FileUploader extends Component {
         [...evt.target.files].map(file => file.name)
       ),
     });
-    this.props.onChange(evt);
   };
 
   handleClick = (evt, index) => {

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -175,7 +175,6 @@ export default class FileUploader extends Component {
     labelTitle: PropTypes.string,
     multiple: PropTypes.bool,
     name: PropTypes.string,
-    onChange: PropTypes.func,
     onClick: PropTypes.func,
     className: PropTypes.string,
     accept: PropTypes.arrayOf(PropTypes.string),
@@ -187,7 +186,6 @@ export default class FileUploader extends Component {
     buttonLabel: '',
     buttonKind: 'primary',
     multiple: false,
-    onChange: () => {},
     onClick: () => {},
     accept: [],
   };
@@ -272,12 +270,6 @@ export default class FileUploader extends Component {
                     <Filename
                       iconDescription={iconDescription}
                       status={filenameStatus}
-                      onClick={evt => {
-                        if (filenameStatus === 'edit') {
-                          this.handleClick(evt, index);
-                        }
-                      }}
-                      iconDescription={iconDescription}
                       onKeyDown={evt => {
                         if (evt.which === 13 || evt.which === 32) {
                           this.handleClick(evt, index);

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -203,11 +203,13 @@ export default class FileUploader extends Component {
     }
   }
   handleChange = evt => {
+    evt.stopPropagation();
     this.setState({
       filenames: this.state.filenames.concat(
         [...evt.target.files].map(file => file.name)
       ),
     });
+    this.props.onChange(evt);
   };
 
   handleClick = (evt, index) => {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#998

The `onChange` method supplied to `FileUploader` is called twice by the component

#### Changelog

**Removed**

* Remove duplicate method call
* Remove redundant and unused props
