### PR TITLE
fix(MultiSelect): SelectedItems should compare on an id to id basis

### DIFF
--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -188,11 +188,18 @@ export default class MultiSelect extends React.Component {
                     }).map((item, index) => {
                       const itemProps = getItemProps({ item });
                       const itemText = itemToString(item);
-                      const isChecked = selectedItem.indexOf(item) !== -1;
+                      const isChecked =
+                        selectedItem.findIndex(
+                          selected => item.id === selected.id
+                        ) !== -1;
                       return (
                         <ListBox.MenuItem
                           key={itemProps.id}
-                          isActive={selectedItem.indexOf(item) !== -1}
+                          isActive={
+                            selectedItem.findIndex(
+                              selected => item.id === selected.id
+                            ) !== -1
+                          }
                           isHighlighted={highlightedIndex === index}
                           {...itemProps}>
                           <Checkbox


### PR DESCRIPTION
Currently the selectedItems does an object to object in-memory comparison which limits it's usage and requires workarounds from the client.  Instead it should compare on an id to id basis.

Closes carbon-design-system/carbon-components-react#901

{{short description}}

#### Changelog

**New**

**Changed**

* MultiSelect Compare on ids when determining list item selection, not on object to object

**Removed**

