### PR TITLE
fix(OverflowMenu): prevent unknown props being spread to `ClickListener`

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -366,6 +366,7 @@ export default class OverflowMenu extends Component {
       menuOffsetFlip,
       iconClass,
       onClick, // eslint-disable-line
+      onOpen, // eslint-disable-line
       renderIcon,
       ...other
     } = this.props;


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#1030

Removes unknown prop warning when `OverflowMenu` is rendered

#### Changelog

**Changed**

* destructure `onOpen` prop to prevent it from being spread into `<ClickListener>` ([more info on the issue](https://reactjs.org/warnings/unknown-prop.html))

This may be a target for refactoring since it seems that the `onClick` prop has previously been destructured but is unused and ignored by ESLint. Since `other` only contains 4 props (`className`, `onClose`, `onKeyDown`, and `open`), it might be better to explicitly pass along the necessary props to the `<div>` within `<ClickListener>`. Would like to hear some thoughts from the core team about this