### PR TITLE
fix(loading): add a11y for JAWS

### DIFF
--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -29,7 +29,10 @@ export default class Loading extends React.Component {
     });
 
     const loading = (
-      <div {...other} className={loadingClasses}>
+      <div
+        {...other}
+        aria-live={active ? 'assertive' : 'off'}
+        className={loadingClasses}>
         <svg className="bx--loading__svg" viewBox="-75 -75 150 150">
           <circle cx="0" cy="0" r="37.5" />
         </svg>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-components-react/issues/700

Adds `aria-live` attribute for use with JAWS screen reader

#### Changelog

**New**

- `aria-live` is either `assertive` or `off` based on active prop

For reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
