### PR TITLE
fix(tabs): add a11y fixes to tabs

### DIFF
--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -74,6 +74,7 @@ export default class Tab extends React.Component {
       href,
       role: 'tab',
       tabIndex,
+      ['aria-selected']: selected,
       ref: e => {
         this.tabAnchor = e;
       },

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -148,6 +148,7 @@ export default class Tabs extends React.Component {
       return (
         <TabContent
           className="tab-content"
+          aria-hidden={!selected}
           hidden={!selected}
           selected={selected}>
           {children}


### PR DESCRIPTION
Adds some more a11y fixes to `Tab` and `Tabs` to more closely mimic the vanilla component

#### Changelog

**New**

- adds `aria-selected` to `Tab` component
- adds `aria-hidden` to `TabContent`