### PR TITLE
feat(FloatingMenu): support for specifying target container

### DIFF
--- a/.storybook/Container.js
+++ b/.storybook/Container.js
@@ -9,6 +9,7 @@ export default class Container extends Component {
     return (
       <React.StrictMode>
         <div
+          data-floating-menu-container
           role="main"
           style={{
             padding: '3em',
@@ -18,6 +19,11 @@ export default class Container extends Component {
           }}>
           {story()}
         </div>
+        <input
+          aria-label="inpute-text-offleft"
+          type="text"
+          class="bx--visually-hidden"
+        />
       </React.StrictMode>
     );
   }

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -33,6 +33,26 @@ const on = (element, ...args) => {
 };
 
 /**
+ * @param {Element} elem An element.
+ * @param {string} selector An query selector.
+ * @returns {Element} The ancestor of the given element matching the given selector.
+ * @private
+ */
+const closest = (elem, selector) => {
+  const doc = elem.ownerDocument;
+  for (
+    let traverse = elem;
+    traverse && traverse !== doc;
+    traverse = traverse.parentNode
+  ) {
+    if (traverse.matches(selector)) {
+      return traverse;
+    }
+  }
+  return null;
+};
+
+/**
  * @param {Element} menuBody The menu body with the menu arrow.
  * @returns {FloatingMenu~offset} The adjustment of the floating menu position, upon the position of the menu arrow.
  * @private
@@ -352,6 +372,13 @@ export default class OverflowMenu extends Component {
     }
   };
 
+  /**
+   * @returns {Element} The DOM element where the floating menu is placed in.
+   */
+  _getTarget = () =>
+    (this.menuEl && closest(this.menuEl, '[data-floating-menu-container]')) ||
+    document.body;
+
   render() {
     const {
       id,
@@ -415,6 +442,7 @@ export default class OverflowMenu extends Component {
           menuPosition={this.state.menuPosition}
           menuOffset={flipped ? menuOffsetFlip : menuOffset}
           menuRef={this._bindMenuBody}
+          target={this._getTarget}
           onPlace={this._handlePlace}>
           {menuBody}
         </FloatingMenu>

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -12,6 +12,26 @@ import FloatingMenu, {
 import ClickListener from '../../internal/ClickListener';
 
 /**
+ * @param {Element} elem An element.
+ * @param {string} selector An query selector.
+ * @returns {Element} The ancestor of the given element matching the given selector.
+ * @private
+ */
+const closest = (elem, selector) => {
+  const doc = elem.ownerDocument;
+  for (
+    let traverse = elem;
+    traverse && traverse !== doc;
+    traverse = traverse.parentNode
+  ) {
+    if (traverse.matches(selector)) {
+      return traverse;
+    }
+  }
+  return null;
+};
+
+/**
  * @param {Element} menuBody The menu body with the menu arrow.
  * @param {string} menuDirection Where the floating menu menu should be placed relative to the trigger button.
  * @returns {FloatingMenu~offset} The adjustment of the floating menu position, upon the position of the menu arrow.
@@ -214,6 +234,14 @@ export default class Tooltip extends Component {
    */
   _debouncedHandleHover = debounce(this._handleHover, 200);
 
+  /**
+   * @returns {Element} The DOM element where the floating menu is placed in.
+   */
+  _getTarget = () =>
+    (this.triggerEl &&
+      closest(this.triggerEl, '[data-floating-menu-container]')) ||
+    document.body;
+
   handleMouse = evt => {
     const state =
       typeof evt === 'string'
@@ -345,9 +373,13 @@ export default class Tooltip extends Component {
         </ClickListener>
         {open && (
           <FloatingMenu
+            target={this._getTarget}
             menuPosition={this.state.triggerPosition}
             menuDirection={direction}
-            menuOffset={menuOffset}>
+            menuOffset={menuOffset}
+            menuRef={node => {
+              this._tooltipEl = node;
+            }}>
             <div
               id={tooltipId}
               className={tooltipClasses}
@@ -358,10 +390,7 @@ export default class Tooltip extends Component {
               onMouseOut={evt => this.handleMouse(evt)}
               onFocus={evt => this.handleMouse(evt)}
               onBlur={evt => this.handleMouse(evt)}
-              onContextMenu={evt => this.handleMouse(evt)}
-              ref={node => {
-                this._tooltipEl = node;
-              }}>
+              onContextMenu={evt => this.handleMouse(evt)}>
               <span className="bx--tooltip__caret" />
               {children}
             </div>


### PR DESCRIPTION
This change makes `<FloatingMenu>` support an element to put the menu into,
which is, the ancestor of the trigger button with `data-floating-menu-container` attribute.

This change also removes code for React15-, which we dropped the support from 9.x codebase.

Refs carbon-design-system/carbon-components#910.
Refs carbon-design-system/carbon-components#911.

#### Changelog

**New**

* New prop in `<FloatingMenu>`, `target`, which takes a function that returns the container the menu should be placed into
* Code in `<OverflowMenu>` and `<Tooltip>` to pass along that new prop, both returning the ancestor of the trigger buttun with `data-floating-menu-container` attribute
* A hidden `<input>` in dev env, to trap keyboard focus. With it, tab navigation of overflow menu closes the menu once the focus goes out of the menu

**Removed**

* Code for React15- from `<FloatingMenu>`
* Temporary element for `createPortal()` (Now `createPortal()` runs with actual target of the floating menu)