### PR TITLE
fix(FileUploaderButton): allow more buttonKind options in propTypes

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
-import types from '../../prop-types/types';
+import { ButtonTypes } from '../../prop-types/types';
 
 const Button = ({
   children,
@@ -69,7 +69,7 @@ Button.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   small: PropTypes.bool,
-  kind: PropTypes.oneOf(types.Button.buttonKind).isRequired,
+  kind: ButtonTypes.buttonKind.isRequired,
   href: PropTypes.string,
   tabIndex: PropTypes.number,
   type: PropTypes.oneOf(['button', 'reset', 'submit']),

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../Icon';
 import classNames from 'classnames';
+import types from '../../prop-types/types';
 
 const Button = ({
   children,
@@ -68,14 +69,7 @@ Button.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   small: PropTypes.bool,
-  kind: PropTypes.oneOf([
-    'primary',
-    'secondary',
-    'danger',
-    'ghost',
-    'danger--primary',
-    'tertiary',
-  ]).isRequired,
+  kind: PropTypes.oneOf(types.Button.buttonKind).isRequired,
   href: PropTypes.string,
   tabIndex: PropTypes.number,
   type: PropTypes.oneOf(['button', 'reset', 'submit']),

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import uid from '../../tools/uniqueId';
-import types from '../../prop-types/types';
+import { ButtonTypes } from '../../prop-types/types';
 
 export class FileUploaderButton extends Component {
   static propTypes = {
@@ -19,7 +19,7 @@ export class FileUploaderButton extends Component {
     onClick: PropTypes.func,
     role: PropTypes.string,
     tabIndex: PropTypes.number,
-    buttonKind: PropTypes.oneOf(types.Button.buttonKind),
+    buttonKind: ButtonTypes.buttonKind,
     accept: PropTypes.arrayOf(PropTypes.string),
   };
   static defaultProps = {
@@ -169,7 +169,7 @@ export default class FileUploader extends Component {
   static propTypes = {
     iconDescription: PropTypes.string,
     buttonLabel: PropTypes.string,
-    buttonKind: PropTypes.oneOf(types.Button.buttonKind),
+    buttonKind: ButtonTypes.buttonKind,
     filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
       .isRequired,
     labelDescription: PropTypes.string,

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import uid from '../../tools/uniqueId';
+import types from '../../prop-types/types';
 
 export class FileUploaderButton extends Component {
   static propTypes = {
@@ -18,14 +19,7 @@ export class FileUploaderButton extends Component {
     onClick: PropTypes.func,
     role: PropTypes.string,
     tabIndex: PropTypes.number,
-    buttonKind: PropTypes.oneOf([
-      'primary',
-      'secondary',
-      'danger',
-      'ghost',
-      'danger--primary',
-      'tertiary',
-    ]),
+    buttonKind: PropTypes.oneOf(types.Button.buttonKind),
     accept: PropTypes.arrayOf(PropTypes.string),
   };
   static defaultProps = {
@@ -175,7 +169,7 @@ export default class FileUploader extends Component {
   static propTypes = {
     iconDescription: PropTypes.string,
     buttonLabel: PropTypes.string,
-    buttonKind: PropTypes.oneOf(['primary', 'secondary']),
+    buttonKind: PropTypes.oneOf(types.Button.buttonKind),
     filenameStatus: PropTypes.oneOf(['edit', 'complete', 'uploading'])
       .isRequired,
     labelDescription: PropTypes.string,

--- a/src/components/FileUploader/FileUploader.js
+++ b/src/components/FileUploader/FileUploader.js
@@ -18,7 +18,14 @@ export class FileUploaderButton extends Component {
     onClick: PropTypes.func,
     role: PropTypes.string,
     tabIndex: PropTypes.number,
-    buttonKind: PropTypes.oneOf(['primary', 'secondary']),
+    buttonKind: PropTypes.oneOf([
+      'primary',
+      'secondary',
+      'danger',
+      'ghost',
+      'danger--primary',
+      'tertiary',
+    ]),
     accept: PropTypes.arrayOf(PropTypes.string),
   };
   static defaultProps = {

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
+import types from '../../prop-types/types';
 
 export default class ModalWrapper extends React.Component {
   static propTypes = {
@@ -21,12 +22,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
     disabled: PropTypes.bool,
-    triggerButtonKind: PropTypes.oneOf([
-      'primary',
-      'secondary',
-      'danger',
-      'ghost',
-    ]),
+    triggerButtonKind: PropTypes.oneOf(types.Button.buttonKind),
     shouldCloseAfterSubmit: PropTypes.bool,
   };
 

--- a/src/components/ModalWrapper/ModalWrapper.js
+++ b/src/components/ModalWrapper/ModalWrapper.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import types from '../../prop-types/types';
+import { ButtonTypes } from '../../prop-types/types';
 
 export default class ModalWrapper extends React.Component {
   static propTypes = {
@@ -22,7 +22,7 @@ export default class ModalWrapper extends React.Component {
     secondaryButtonText: PropTypes.string,
     handleSubmit: PropTypes.func,
     disabled: PropTypes.bool,
-    triggerButtonKind: PropTypes.oneOf(types.Button.buttonKind),
+    triggerButtonKind: ButtonTypes.buttonKind,
     shouldCloseAfterSubmit: PropTypes.bool,
   };
 

--- a/src/prop-types/types.js
+++ b/src/prop-types/types.js
@@ -1,14 +1,12 @@
-const types = {
-  Button: {
-    buttonKind: [
-      'primary',
-      'secondary',
-      'danger',
-      'ghost',
-      'danger--primary',
-      'tertiary',
-    ],
-  },
-};
+import { oneOf } from 'prop-types';
 
-export default types;
+export const ButtonTypes = {
+  buttonKind: oneOf([
+    'primary',
+    'secondary',
+    'danger',
+    'ghost',
+    'danger--primary',
+    'tertiary',
+  ]),
+};

--- a/src/prop-types/types.js
+++ b/src/prop-types/types.js
@@ -1,0 +1,14 @@
+const types = {
+  Button: {
+    buttonKind: [
+      'primary',
+      'secondary',
+      'danger',
+      'ghost',
+      'danger--primary',
+      'tertiary',
+    ],
+  },
+};
+
+export default types;


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#1034

FileUploaderButton propTypes currently only expects `buttonKind` to either be `primary` or `secondary`, but the underlying `Button` component can accept additional `buttonKind` options

#### Changelog

**Changed**

* expected propTypes for `<FileUploaderButton>`'s `buttonKind` prop