### PR TITLE
Fix typo in selected example tabs component

### DIFF
--- a/src/components/Tabs/Tabs-story.js
+++ b/src/components/Tabs/Tabs-story.js
@@ -59,7 +59,7 @@ storiesOf('Tabs', module)
           <div className="some-content">Content for third tab goes here.</div>
         </Tab>
         <Tab {...props.tab} label="Tab label 4">
-          <div className="some-content">ontent for fourth tab goes here.</div>
+          <div className="some-content">Content for fourth tab goes here.</div>
         </Tab>
       </Tabs>
     )


### PR DESCRIPTION
#### Changelog

**Changed**

* Corrected typo: "ontent" -> "Content"