### PR TITLE
feat(overflow-menu): add requireTitle prop for text that is truncated

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     }
   },
   "peerDependencies": {
-    "carbon-components": "^9.1.6",
+    "carbon-components": "^9.1.13",
     "carbon-icons": "^7.0.5",
     "react": "^16.4.0",
     "react-dom": "^16.4.0"
@@ -152,7 +152,7 @@
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "bowser": "^1.6.1",
-    "carbon-components": "^9.1.6",
+    "carbon-components": "^9.1.13",
     "carbon-icons": "^7.0.5",
     "chalk": "^2.3.0",
     "cli-table": "^0.3.0",

--- a/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/src/components/OverflowMenu/OverflowMenu-story.js
@@ -29,7 +29,11 @@ storiesOf('OverflowMenu', module)
           itemText="Option 1"
           primaryFocus={true}
         />
-        <OverflowMenuItem {...overflowMenuItemEvents} itemText="Option 2" />
+        <OverflowMenuItem
+          {...overflowMenuItemEvents}
+          itemText="Option 2 is an example of a really long string and how we recommend handling this"
+          requireTitle
+        />
         <OverflowMenuItem {...overflowMenuItemEvents} itemText="Option 3" />
         <OverflowMenuItem {...overflowMenuItemEvents} itemText="Option 4" />
         <OverflowMenuItem

--- a/src/components/OverflowMenuItem/OverflowMenuItem.js
+++ b/src/components/OverflowMenuItem/OverflowMenuItem.js
@@ -13,6 +13,7 @@ const OverflowMenuItem = ({
   primaryFocus,
   floatingMenu,
   wrapperClassName,
+  requireTitle,
   ...other
 }) => {
   const overflowMenuBtnClasses = classNames(
@@ -52,6 +53,7 @@ const OverflowMenuItem = ({
         className={overflowMenuBtnClasses}
         disabled={disabled}
         onClick={handleClick}
+        title={requireTitle ? itemText : null}
         tabIndex={disabled ? -1 : 0}>
         {itemText}
       </button>
@@ -115,6 +117,10 @@ OverflowMenuItem.propTypes = {
    * `true` if this menu item belongs to a floating OverflowMenu
    */
   floatingMenu: PropTypes.bool,
+  /**
+   * `true` if this menu item has long text and requires a browser tooltip
+   */
+  requireTitle: PropTypes.bool,
 };
 
 OverflowMenuItem.defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,9 +2761,9 @@ caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
-carbon-components@^9.1.6:
-  version "9.1.7"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-9.1.7.tgz#a0e194925f858bb7936bd5f3eb15bbb2aeb37dc5"
+carbon-components@^9.1.13:
+  version "9.1.16"
+  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-9.1.16.tgz#96a84def7b4d647f8ccecd090735bce74c8a0ff7"
   dependencies:
     carbon-icons "^6.0.4"
     flatpickr "2.6.3"


### PR DESCRIPTION
Adds in a `title` prop to `OverflowMenuItem` that will add the browser default tooltip on text that is expected to be truncated. I felt this was less intrusive than adding `title` on all `OverflowMenuItem` and can be added on a case by case basis. 

Requires https://github.com/carbon-design-system/carbon-components/pull/947 to be merged first

#### Changelog

**New**

- `title` prop that will add the browser default tooltip on the text that is expected to be truncated

**Testing**

- Check option 2 of the first `OverflowMenu` example once the PR is the main repo has been merged and pulled in