### PR TITLE
feat(Checkbox): add `title` attribute to checkbox label

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -10,6 +10,7 @@ const Checkbox = ({
   indeterminate,
   hideLabel,
   wrapperClassName,
+  title = '',
   ...other
 }) => {
   let input;
@@ -40,7 +41,7 @@ const Checkbox = ({
           }
         }}
       />
-      <label htmlFor={id} className={labelClasses}>
+      <label htmlFor={id} className={labelClasses} title={title}>
         <span className={innerLabelClasses}>{labelText}</span>
       </label>
     </div>
@@ -60,6 +61,7 @@ Checkbox.propTypes = {
   labelText: PropTypes.node.isRequired,
   hideLabel: PropTypes.bool,
   onChange: PropTypes.func,
+  title: PropTypes.string,
   /**
    * The CSS class name to be placed on the wrapping element
    */

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -41,7 +41,7 @@ const Checkbox = ({
           }
         }}
       />
-      <label htmlFor={id} className={labelClasses} title={title}>
+      <label htmlFor={id} className={labelClasses} title={title || null}>
         <span className={innerLabelClasses}>{labelText}</span>
       </label>
     </div>


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#1059

This PR adds a `title` attribute to the Checkbox component so that users can add alt text to their checkbox labels.

#### Changelog

**New**

* `title` attribute on `<Checkbox>`