### PR TITLE
TootlTip Fix

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -373,6 +373,7 @@ export default class DatePicker extends Component {
 
   render() {
     const {
+      appendTo, // eslint-disable-line
       children,
       className,
       short,
@@ -381,6 +382,8 @@ export default class DatePicker extends Component {
       maxDate, // eslint-disable-line
       dateFormat, // eslint-disable-line
       onChange, // eslint-disable-line
+      locale, // eslint-disable-line
+      value, // eslint-disable-line
       ...other
     } = this.props;
 


### PR DESCRIPTION


* fix(tooltip): assign all props types to node from string 

Closes carbon-design-system/carbon-components-react#

{{short description}}

**Changed**

* {{TextInput, TextArea, Select and NumberInput Lable or LableText prop changes from String to Node to accept Tooltip component}}


