### PR TITLE
fix(tooltip): Change the property from string to node for NumberInput…

### DIFF
--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -9,7 +9,7 @@ export default class NumberInput extends Component {
     disabled: PropTypes.bool,
     iconDescription: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    label: PropTypes.string,
+    label: PropTypes.node,
     max: PropTypes.number,
     min: PropTypes.number,
     /**

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -57,7 +57,7 @@ Select.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   inline: PropTypes.bool,
-  labelText: PropTypes.string,
+  labelText: PropTypes.node,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
   defaultValue: PropTypes.any,

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -68,7 +68,7 @@ TextArea.propTypes = {
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
   id: PropTypes.string,
-  labelText: PropTypes.string.isRequired,
+  labelText: PropTypes.node.isRequired,
   onChange: PropTypes.func,
   onClick: PropTypes.func,
   placeholder: PropTypes.string,

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -76,7 +76,7 @@ TextInput.propTypes = {
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  labelText: PropTypes.string.isRequired,
+  labelText: PropTypes.node.isRequired,
   onChange: PropTypes.func,
   onClick: PropTypes.func,
   placeholder: PropTypes.string,


### PR DESCRIPTION



Closes carbon-design-system/carbon-components-react#

Change the property from string to node to adopt tooltip component.

#### Changelog

**Changed**

Change the property from string to node to adopt tooltip component for 
Select, TextArea, TextInput and NumberInput

