### PR TITLE
fix(OverflowMenu): assign refs only to class components

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -485,9 +485,12 @@ class OverflowMenu extends Component {
         React.cloneElement(child, {
           closeMenu: this.closeMenu,
           handleOverflowMenuItemFocus: this.handleOverflowMenuItemFocus,
-          ref: e => {
-            this[`overflowMenuItem${index}`] = e;
-          },
+          ref:
+            typeof child.type !== 'string' && child.type.prototype.render
+              ? e => {
+                  this[`overflowMenuItem${index}`] = e;
+                }
+              : null,
           index,
         })
     );


### PR DESCRIPTION
Closes IBM/carbon-components-react#1924

Function components cannot accept refs, but `<OverflowMenu>` is attempting to assign refs regardless of child type. This PR checks if the children of `<OverflowMenu>` can accept refs before assigning them