### PR TITLE
chore(components): update required polyfills

### DIFF
--- a/.storybook/polyfills.js
+++ b/.storybook/polyfills.js
@@ -3,3 +3,6 @@ import 'core-js/modules/es6.array.fill';
 import 'core-js/modules/es6.string.includes';
 import 'core-js/modules/es6.string.trim';
 import 'core-js/modules/es7.object.values';
+
+import './polyfills/element-closest';
+import './polyfills/element-matches';

--- a/.storybook/polyfills/element-closest.js
+++ b/.storybook/polyfills/element-closest.js
@@ -1,0 +1,15 @@
+if (typeof Element.prototype.closest !== 'function') {
+  Element.prototype.closest = function closestElement(selector) {
+    const doc = this.ownerDocument;
+    for (
+      let traverse = this;
+      traverse && traverse !== doc;
+      traverse = traverse.parentNode
+    ) {
+      if (traverse.matches(selector)) {
+        return traverse;
+      }
+    }
+    return null;
+  };
+}

--- a/.storybook/polyfills/element-matches.js
+++ b/.storybook/polyfills/element-matches.js
@@ -1,0 +1,9 @@
+const matchesFuncName = [
+  'matches',
+  'webkitMatchesSelector',
+  'msMatchesSelector',
+].filter(name => typeof Element.prototype[name] === 'function')[0];
+
+if (matchesFuncName !== 'matches') {
+  Element.prototype.matches = Element.prototype[matchesFuncName];
+}

--- a/docs/migration/migrate-to-10.x.md
+++ b/docs/migration/migrate-to-10.x.md
@@ -129,3 +129,10 @@ can import icon components directly and use them in a variety of sizes (16x16,
 In addition, these components have minor accessibility and performance improvements, most notably
 around inlining the SVG data for an icon instead of deriving the markup at
 runtime.
+
+## Polyfills
+
+Required polyfills list has been updated, adding:
+
+- [`Element.prototype.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+- [`Element.prototype.matches()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)

--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -13,7 +13,7 @@ import Icon from '../Icon';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import Close20 from '@carbon/icons-react/lib/close/20';
-import { componentsX } from '../../internal/FeatureFlags';
+import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 const matchesFuncName =
@@ -89,22 +89,21 @@ export default class ComposedModal extends Component {
     } = this.props;
     if (target && typeof target.closest === 'function') {
       return selectorsFloatingMenus.some(selector => target.closest(selector));
-    }
-
-    // Alternative if closest does not exist.
-    while (target) {
-      if (typeof target[matchesFuncName] === 'function') {
-        if (
-          selectorsFloatingMenus.some(selector =>
-            target[matchesFuncName](selector)
-          )
-        ) {
-          return true;
+    } else if (!breakingChangesX) {
+      // Alternative if closest does not exist.
+      while (target) {
+        if (typeof target[matchesFuncName] === 'function') {
+          if (
+            selectorsFloatingMenus.some(selector =>
+              target[matchesFuncName](selector)
+            )
+          ) {
+            return true;
+          }
         }
+        target = target.parentNode;
       }
-      target = target.parentNode;
     }
-    return false;
   };
 
   handleKeyDown = evt => {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -13,7 +13,7 @@ import Icon from '../Icon';
 import Button from '../Button';
 import { settings } from 'carbon-components';
 import Close20 from '@carbon/icons-react/lib/close/20';
-import { componentsX } from '../../internal/FeatureFlags';
+import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
 
 const { prefix } = settings;
 
@@ -153,7 +153,7 @@ export default class Modal extends Component {
     } = this.props;
     if (target && typeof target.closest === 'function') {
       return selectorsFloatingMenus.some(selector => target.closest(selector));
-    } else {
+    } else if (!breakingChangesX) {
       // Alternative if closest does not exist.
       while (target) {
         if (typeof target[matchesFuncName] === 'function') {

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -40,9 +40,15 @@ const matchesFuncName =
  * @returns {boolean} `true` if the given DOM element is a element node and matches the given selector.
  * @private
  */
-const matches = (elem, selector) =>
-  typeof elem[matchesFuncName] === 'function' &&
-  elem[matchesFuncName](selector);
+const matches = (elem, selector) => {
+  if (breakingChangesX) {
+    return elem.matches(selector);
+  }
+  return (
+    typeof elem[matchesFuncName] === 'function' &&
+    elem[matchesFuncName](selector)
+  );
+};
 
 const on = (element, ...args) => {
   element.addEventListener(...args);
@@ -61,6 +67,9 @@ const on = (element, ...args) => {
  * @private
  */
 const closest = (elem, selector) => {
+  if (breakingChangesX) {
+    return elem.closest(selector);
+  }
   const doc = elem.ownerDocument;
   for (
     let traverse = elem;

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -39,9 +39,15 @@ const matchesFuncName =
  * @returns {boolean} `true` if the given DOM element is a element node and matches the given selector.
  * @private
  */
-const matches = (elem, selector) =>
-  typeof elem[matchesFuncName] === 'function' &&
-  elem[matchesFuncName](selector);
+const matches = (elem, selector) => {
+  if (breakingChangesX) {
+    return elem.matches(selector);
+  }
+  return (
+    typeof elem[matchesFuncName] === 'function' &&
+    elem[matchesFuncName](selector)
+  );
+};
 
 /**
  * @param {Element} elem An element.
@@ -50,6 +56,9 @@ const matches = (elem, selector) =>
  * @private
  */
 const closest = (elem, selector) => {
+  if (breakingChangesX) {
+    return elem.closest(selector);
+  }
   const doc = elem.ownerDocument;
   for (
     let traverse = elem;

--- a/src/components/migrate-to-10.x.md
+++ b/src/components/migrate-to-10.x.md
@@ -1,0 +1,6 @@
+### JavaScript
+
+Required polyfills list has been updated, adding:
+
+- [`Element.prototype.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
+- [`Element.prototype.matches()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)

--- a/src/components/migrate-to-10.x.md
+++ b/src/components/migrate-to-10.x.md
@@ -1,6 +1,0 @@
-### JavaScript
-
-Required polyfills list has been updated, adding:
-
-- [`Element.prototype.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)
-- [`Element.prototype.matches()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)


### PR DESCRIPTION
Fixes #1934.
Fixes #1517.

#### Changelog

**New**

- Polyfills for [`Element.prototype.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) and [`Element.prototype.matches()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches).

**Changed**

- Added above polyfills to the required polyfills list (`.storybook/polyfills.js`).
- `migrate-to-10.x.md` mentioning the additions.
- `<ComposedModal>`, `<Modal>`, `<OverflowMenu>` and `<Tooltip>` using above polyfills _only_ if `breakingChangesX` feature flag is `true`.