### PR TITLE
feat(FloatingMenu): support refs

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -22,6 +22,7 @@ import Icon from '../Icon';
 import OverflowMenuVertical16 from '@carbon/icons-react/lib/overflow-menu--vertical/16';
 import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
 import { keys, matches as keyCodeMatches } from '../../tools/key';
+import mergeRefs from '../../tools/mergeRefs';
 
 const { prefix } = settings;
 
@@ -162,7 +163,7 @@ export const getMenuOffset = (menuBody, direction, trigger, flip) => {
   }
 };
 
-export default class OverflowMenu extends Component {
+class OverflowMenu extends Component {
   state = {};
 
   static propTypes = {
@@ -564,6 +565,7 @@ export default class OverflowMenu extends Component {
       onClick, // eslint-disable-line
       onOpen, // eslint-disable-line
       renderIcon: IconElement,
+      innerRef: ref,
       ...other
     } = this.props;
     const floatingMenu = !!breakingChangesX || origFloatingMenu;
@@ -689,7 +691,7 @@ export default class OverflowMenu extends Component {
           aria-label={ariaLabel}
           id={id}
           tabIndex={tabIndex}
-          ref={this.bindMenuEl}>
+          ref={mergeRefs(ref, this.bindMenuEl)}>
           {overflowMenuIcon}
           {open && wrappedMenuBody}
         </div>
@@ -697,3 +699,13 @@ export default class OverflowMenu extends Component {
     );
   }
 }
+
+export default (!breakingChangesX
+  ? OverflowMenu
+  : (() => {
+      const forwardRef = (props, ref) => (
+        <OverflowMenu {...props} innerRef={ref} />
+      );
+      forwardRef.displayName = 'OverflowMenu';
+      return React.forwardRef(forwardRef);
+    })());

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -23,6 +23,7 @@ import FloatingMenu, {
 } from '../../internal/FloatingMenu';
 import ClickListener from '../../internal/ClickListener';
 import { breakingChangesX, componentsX } from '../../internal/FeatureFlags';
+import mergeRefs from '../../tools/mergeRefs';
 
 const { prefix } = settings;
 
@@ -112,7 +113,7 @@ const getMenuOffset = (menuBody, menuDirection) => {
 let didWarnAboutDeprecationClickToOpen = false;
 let didWarnAboutDeprecationIcon = false;
 
-export default class Tooltip extends Component {
+class Tooltip extends Component {
   state = {};
 
   static propTypes = {
@@ -397,6 +398,7 @@ export default class Tooltip extends Component {
       // Exclude `clickToOpen` from `other` to avoid passing it along to `<div>`
       clickToOpen,
       tabIndex = 0,
+      innerRef: ref,
       ...other
     } = this.props;
 
@@ -441,9 +443,9 @@ export default class Tooltip extends Component {
         name={iconName}
         aria-labelledby={triggerId}
         aria-label={iconDescription}
-        ref={node => {
+        ref={mergeRefs(ref, node => {
           this.triggerEl = node;
-        }}
+        })}
       />
     ) : (
       <Icon
@@ -451,9 +453,9 @@ export default class Tooltip extends Component {
         name={iconName}
         description={iconDescription}
         iconTitle={iconTitle}
-        iconRef={node => {
+        iconRef={mergeRefs(ref, node => {
           this.triggerEl = node;
-        }}
+        })}
       />
     );
 
@@ -487,9 +489,9 @@ export default class Tooltip extends Component {
               tabIndex={tabIndex}
               id={triggerId}
               className={triggerClasses}
-              ref={node => {
+              ref={mergeRefs(ref, node => {
                 this.triggerEl = node;
-              }}
+              })}
               onMouseOver={this.handleMouse}
               onMouseOut={this.handleMouse}
               onFocus={this.handleMouse}
@@ -531,3 +533,11 @@ export default class Tooltip extends Component {
     );
   }
 }
+
+export default (!breakingChangesX
+  ? Tooltip
+  : (() => {
+      const forwardRef = (props, ref) => <Tooltip {...props} innerRef={ref} />;
+      forwardRef.displayName = 'Tooltip';
+      return React.forwardRef(forwardRef);
+    })());


### PR DESCRIPTION
Fixes #1778.

#### Changelog

**New**

- Support `ref` property that redirects to the trigger button of:
  - `<OverflowMenu>`
  - `<Tooltip>`