### PR TITLE
fix(TextInput): add invalid attr on wrapper div

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -101,7 +101,9 @@ const TextInput = React.forwardRef(
         {label}
         {helper}
         {componentsX ? (
-          <div className={`${prefix}--text-input__field-wrapper`}>
+          <div
+            className={`${prefix}--text-input__field-wrapper`}
+            data-invalid={invalid || null}>
             {invalid && (
               <WarningFilled16
                 className={`${prefix}--text-input__invalid-icon`}


### PR DESCRIPTION
Closes IBM/carbon-components-react#2133

This PR adds the invalid state outline to text inputs with a data attribute which was previously missing