### PR TITLE
Add stalebot. Update exemptions after it runs once

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 14
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3
+# Issues with these labels will never be considered stale
+exemptLabels:
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  We've marked this issue as stale because there hasn't been any activity for a couple of weeks.
+  If there's no further activity on this issue in the next three days then we'll close it.
+  Thanks for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  As there's been no activity since this issue was marked as stale, we are auto-closing it.


### PR DESCRIPTION
After this runs once (should be within 24 hours after merge), and in a few days when issues close, we can add exemption labels.