### PR TITLE
fix(DropdownV2): v6 - passes through props including translations to menu icon

### DIFF
--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -153,6 +153,7 @@ export default class DropdownV2 extends React.Component {
       light,
       invalid,
       invalidText,
+      ...rest
     } = this.props;
     const inline = type === 'inline';
     const className = ({ isOpen }) =>
@@ -230,7 +231,7 @@ export default class DropdownV2 extends React.Component {
                   {...getLabelProps()}>
                   {selectedItem ? itemToString(selectedItem) : label}
                 </span>
-                <ListBox.MenuIcon isOpen={isOpen} />
+                <ListBox.MenuIcon isOpen={isOpen} {...rest} />
               </ListBox.Field>
               {isOpen && (
                 <ListBox.Menu>

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -110,6 +110,8 @@ exports[`DropdownV2 should render 1`] = `
             </span>
             <ListBoxMenuIcon
               isOpen={false}
+              onChange={[MockFunction]}
+              placeholder="Filter..."
               translateWithId={[Function]}
             >
               <div
@@ -284,6 +286,8 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             </span>
             <ListBoxMenuIcon
               isOpen={true}
+              onChange={[MockFunction]}
+              placeholder="Filter..."
               translateWithId={[Function]}
             >
               <div
@@ -699,6 +703,8 @@ exports[`DropdownV2 should render custom item components 1`] = `
             </span>
             <ListBoxMenuIcon
               isOpen={true}
+              onChange={[MockFunction]}
+              placeholder="Filter..."
               translateWithId={[Function]}
             >
               <div
@@ -1006,6 +1012,8 @@ exports[`DropdownV2 should render with strings as items 1`] = `
             </span>
             <ListBoxMenuIcon
               isOpen={true}
+              onChange={[MockFunction]}
+              placeholder="Filter..."
               translateWithId={[Function]}
             >
               <div


### PR DESCRIPTION
for v6 branch: allow menu icon within dropdown to be i18n-ized using menu icons props

~Closes IBM/carbon-components-react#1952~ I suppose this doesn't technically close it since there's still master and v5 but i'll open prs against those once we iron out this one

it was a tossup between passing `rest` which includes potentially a lot of unnecessary props vs enumerating the properties of the child component, this way is more resilient to future changes while leaving the DropdownV2 as uncluttered as possible