### PR TITLE
fix(DropdownV2): v6 - explicitly passes through translateWithId to menu icon

### DIFF
--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -113,6 +113,11 @@ export default class DropdownV2 extends React.Component {
     titleText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
     /**
+     * Callback function for translating ListBoxMenuIcon SVG title
+     */
+    translateWithId: PropTypes.func,
+
+    /**
      * Provide helper text that is used alongside the control label for
      * additional help
      */
@@ -150,6 +155,7 @@ export default class DropdownV2 extends React.Component {
       id,
       titleText,
       helperText,
+      translateWithId,
       light,
       invalid,
       invalidText,
@@ -230,7 +236,10 @@ export default class DropdownV2 extends React.Component {
                   {...getLabelProps()}>
                   {selectedItem ? itemToString(selectedItem) : label}
                 </span>
-                <ListBox.MenuIcon isOpen={isOpen} />
+                <ListBox.MenuIcon
+                  isOpen={isOpen}
+                  translateWithId={translateWithId}
+                />
               </ListBox.Field>
               {isOpen && (
                 <ListBox.Menu>


### PR DESCRIPTION
*against v6 branch

so consumers of dropdownv2 can specify translations for title text of the icon

Related to https://github.com/carbon-design-system/carbon-components-react/issues/1952

updated version of my previous pr, i noticed that FilterableMultiSelect has a directly analogous instance of this so I figured I would just copy that pattern instead of making a new one.