### PR TITLE
fix(DropdownV2): v5 - passes through translation to menu icon

### DIFF
--- a/src/components/DropdownV2/DropdownV2.js
+++ b/src/components/DropdownV2/DropdownV2.js
@@ -58,6 +58,11 @@ export default class DropdownV2 extends React.Component {
      */
     label: PropTypes.node.isRequired,
 
+    /**
+     * Callback function for translating ListBoxMenuIcon SVG title
+     */
+    translateWithId: PropTypes.func,
+
     type: ListBoxPropTypes.ListBoxType,
 
     /**
@@ -88,6 +93,7 @@ export default class DropdownV2 extends React.Component {
       itemToString,
       itemToElement,
       type,
+      translateWithId,
       initialSelectedItem,
       selectedItem,
     } = this.props;
@@ -119,7 +125,10 @@ export default class DropdownV2 extends React.Component {
               <span className="bx--list-box__label" {...getLabelProps()}>
                 {selectedItem ? itemToString(selectedItem) : label}
               </span>
-              <ListBox.MenuIcon isOpen={isOpen} />
+              <ListBox.MenuIcon
+                isOpen={isOpen}
+                translateWithId={translateWithId}
+              />
             </ListBox.Field>
             {isOpen && (
               <ListBox.Menu>


### PR DESCRIPTION
related to https://github.com/carbon-design-system/carbon-components-react/issues/1952

copied from https://github.com/carbon-design-system/carbon-components-react/pull/2293