### PR TITLE
chore(components): complete removing icon prop

### DIFF
--- a/src/components/Button/Button-test.js
+++ b/src/components/Button/Button-test.js
@@ -132,7 +132,7 @@ describe('Button', () => {
       };
       // eslint-disable-next-line quotes
       const error = new Error(
-        'icon/renderIcon property specified without also providing an iconDescription property.'
+        'renderIcon property specified without also providing an iconDescription property.'
       );
       expect(Button.propTypes.iconDescription(props)).toEqual(error);
     });
@@ -160,7 +160,7 @@ describe('Button', () => {
       };
       // eslint-disable-next-line quotes
       const error = new Error(
-        'icon/renderIcon property specified without also providing an iconDescription property.'
+        'renderIcon property specified without also providing an iconDescription property.'
       );
       expect(Button.propTypes.iconDescription(props)).toEqual(error);
     });

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -146,28 +146,13 @@ Button.propTypes = {
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
-   * Specify an icon to include in the Button through a string or object
-   * representing the SVG data of the icon
-   */
-  icon: PropTypes.oneOfType([
-    PropTypes.shape({
-      width: PropTypes.string,
-      height: PropTypes.string,
-      viewBox: PropTypes.string.isRequired,
-      svgData: PropTypes.object.isRequired,
-    }),
-    PropTypes.string,
-    PropTypes.node,
-  ]),
-
-  /**
    * If specifying the `icon` prop, provide a description for that icon that can
    * be read by screen readers
    */
   iconDescription: props => {
-    if ((props.icon || props.renderIcon) && !props.iconDescription) {
+    if (props.renderIcon && !props.iconDescription) {
       return new Error(
-        'icon/renderIcon property specified without also providing an iconDescription property.'
+        'renderIcon property specified without also providing an iconDescription property.'
       );
     }
     return undefined;

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -143,16 +143,6 @@ class Tooltip extends Component {
     showIcon: PropTypes.bool,
 
     /**
-     * The tooltip icon element or `<Icon>` metadata.
-     */
-    icon: PropTypes.shape({
-      width: PropTypes.string,
-      height: PropTypes.string,
-      viewBox: PropTypes.string.isRequired,
-      svgData: PropTypes.object.isRequired,
-    }),
-
-    /**
      * The name of the default tooltip icon.
      */
     iconName: PropTypes.string,


### PR DESCRIPTION
Refs carbon-design-system/carbon-components#2308.

#### Changelog

**Removed**

- `icon` prop refs in `<Button>` and `<Tooltip>`.
