### PR TITLE
fix(Modal): accept nodes to heading

### DIFF
--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -257,12 +257,12 @@ export class ModalHeader extends Component {
     /**
      * Specify an optional label to be displayed
      */
-    label: PropTypes.string,
+    label: PropTypes.node,
 
     /**
      * Specify an optional title to be displayed
      */
-    title: PropTypes.string,
+    title: PropTypes.node,
 
     /**
      * Specify the content to be placed in the ModalHeader

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -46,7 +46,8 @@ export default class Modal extends Component {
     /**
      * Specify the content of the modal header title.
      */
-    modalHeading: PropTypes.string,
+    modalHeading: PropTypes.node,
+
     /**
      * Specify the content of the modal header label.
      */


### PR DESCRIPTION
Fixes carbon-design-system/carbon-components#629 - To see if the issue is merely requesting for changing prop types.

#### Changelog

**Changed**

- Prop types for modal heading/label to `PropTypes.node`.