### PR TITLE
chore(SideNav): align icon API to other components

### DIFF
--- a/src/components/UIShell/SideNavHeader.js
+++ b/src/components/UIShell/SideNavHeader.js
@@ -13,11 +13,17 @@ import SideNavIcon from './SideNavIcon';
 
 const { prefix } = settings;
 
-const SideNavHeader = ({ className: customClassName, children, icon }) => {
+const SideNavHeader = ({
+  className: customClassName,
+  children,
+  renderIcon: IconElement,
+}) => {
   const className = cx(`${prefix}--side-nav__header`, customClassName);
   return (
     <header className={className}>
-      <SideNavIcon>{icon}</SideNavIcon>
+      <SideNavIcon>
+        <IconElement />
+      </SideNavIcon>
       {children}
     </header>
   );
@@ -31,9 +37,10 @@ SideNavHeader.propTypes = {
 
   /**
    * Provide an icon to render in the header of the side navigation. Should be
-   * an <svg> element.
+   * a React class.
    */
-  icon: PropTypes.node.isRequired,
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+    .isRequired,
 };
 
 export default SideNavHeader;

--- a/src/components/UIShell/SideNavLink.js
+++ b/src/components/UIShell/SideNavLink.js
@@ -19,7 +19,7 @@ const { prefix } = settings;
 const SideNavLink = ({
   className: customClassName,
   children,
-  icon,
+  renderIcon: IconElement,
   isActive,
   ...rest
 }) => {
@@ -32,7 +32,11 @@ const SideNavLink = ({
   return (
     <SideNavItem>
       <Link {...rest} className={className}>
-        <SideNavIcon small>{icon}</SideNavIcon>
+        {IconElement && (
+          <SideNavIcon small>
+            <IconElement />
+          </SideNavIcon>
+        )}
         <SideNavLinkText>{children}</SideNavLinkText>
       </Link>
     </SideNavItem>
@@ -46,6 +50,11 @@ SideNavLink.propTypes = {
    * Provide an optional class to be applied to the containing node
    */
   className: PropTypes.string,
+
+  /**
+   * Provide an icon to render in the side navigation link. Should be a React class.
+   */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
    * Specify the text content for the link

--- a/src/components/UIShell/SideNavMenu.js
+++ b/src/components/UIShell/SideNavMenu.js
@@ -29,7 +29,7 @@ export class SideNavMenu extends React.Component {
     /**
      * Pass in a custom icon to render next to the `SideNavMenu` title
      */
-    icon: PropTypes.node,
+    renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
     /**
      * Specify whether the `SideNavMenu` is "active". `SideNavMenu` should be
@@ -71,7 +71,7 @@ export class SideNavMenu extends React.Component {
       buttonRef,
       className: customClassName,
       children,
-      icon,
+      renderIcon: IconElement,
       isActive,
       title,
     } = this.props;
@@ -90,7 +90,11 @@ export class SideNavMenu extends React.Component {
           onClick={this.handleToggleExpand}
           ref={buttonRef}
           type="button">
-          {icon && <SideNavIcon>{icon}</SideNavIcon>}
+          {IconElement && (
+            <SideNavIcon>
+              <IconElement />
+            </SideNavIcon>
+          )}
           <span className={`${prefix}--side-nav__submenu-title`}>{title}</span>
           <SideNavIcon className={`${prefix}--side-nav__submenu-chevron`} small>
             <ChevronDown20 />

--- a/src/components/UIShell/UIShell-story.js
+++ b/src/components/UIShell/UIShell-story.js
@@ -144,7 +144,7 @@ storiesOf('[Experimental] UI Shell', module)
           </HeaderGlobalBar>
         </Header>
         <SideNav aria-label="Side navigation">
-          <SideNavHeader icon={<Fade16 />}>
+          <SideNavHeader renderIcon={Fade16}>
             <SideNavDetails title="Side navigation title">
               <SideNavSwitcher
                 labelText="Switcher"
@@ -154,12 +154,12 @@ storiesOf('[Experimental] UI Shell', module)
             </SideNavDetails>
           </SideNavHeader>
           <SideNavItems>
-            <SideNavLink icon={<Fade16 />} href="javascript:void(0)">
+            <SideNavLink renderIcon={Fade16} href="javascript:void(0)">
               Link
             </SideNavLink>
             <SideNavMenu
               defaultExpanded
-              icon={<Fade16 />}
+              renderIcon={Fade16}
               isActive
               title="Category title">
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>

--- a/src/components/UIShell/__tests__/SideNavHeader-test.js
+++ b/src/components/UIShell/__tests__/SideNavHeader-test.js
@@ -14,7 +14,7 @@ describe('SideNavHeader', () => {
 
   beforeEach(() => {
     mockProps = {
-      icon: <div>mock icon</div>,
+      renderIcon: () => <div>mock icon</div>,
       children: <span>foo</span>,
     };
   });

--- a/src/components/UIShell/__tests__/SideNavMenu-test.js
+++ b/src/components/UIShell/__tests__/SideNavMenu-test.js
@@ -17,7 +17,7 @@ describe('SideNavMenu', () => {
       buttonRef: jest.fn(),
       className: 'custom-classname',
       children: 'text',
-      icon: <div>icon</div>,
+      renderIcon: () => <div>icon</div>,
       isActive: false,
       title: 'title',
     };

--- a/src/components/UIShell/__tests__/__snapshots__/SideNavHeader-test.js.snap
+++ b/src/components/UIShell/__tests__/__snapshots__/SideNavHeader-test.js.snap
@@ -2,11 +2,7 @@
 
 exports[`SideNavHeader should render 1`] = `
 <SideNavHeader
-  icon={
-    <div>
-      mock icon
-    </div>
-  }
+  renderIcon={[Function]}
 >
   <header
     className="bx--side-nav__header"
@@ -17,9 +13,11 @@ exports[`SideNavHeader should render 1`] = `
       <div
         className="bx--side-nav__icon"
       >
-        <div>
-          mock icon
-        </div>
+        <renderIcon>
+          <div>
+            mock icon
+          </div>
+        </renderIcon>
       </div>
     </SideNavIcon>
     <span>

--- a/src/components/UIShell/__tests__/__snapshots__/SideNavLink-test.js.snap
+++ b/src/components/UIShell/__tests__/__snapshots__/SideNavLink-test.js.snap
@@ -18,21 +18,20 @@ exports[`SideNavLink should render 1`] = `
       <Link
         className="bx--side-nav__link custom-classname"
         element="a"
+        icon={
+          <div>
+            icon
+          </div>
+        }
       >
         <a
           className="bx--side-nav__link custom-classname"
-        >
-          <SideNavIcon
-            small={true}
-          >
-            <div
-              className="bx--side-nav__icon bx--side-nav__icon--small"
-            >
-              <div>
-                icon
-              </div>
+          icon={
+            <div>
+              icon
             </div>
-          </SideNavIcon>
+          }
+        >
           <SideNavLinkText>
             <span
               className="bx--side-nav__link-text"
@@ -65,21 +64,20 @@ exports[`SideNavLink should render 2`] = `
       <Link
         className="bx--side-nav__link bx--side-nav__link--current custom-classname"
         element="a"
+        icon={
+          <div>
+            icon
+          </div>
+        }
       >
         <a
           className="bx--side-nav__link bx--side-nav__link--current custom-classname"
-        >
-          <SideNavIcon
-            small={true}
-          >
-            <div
-              className="bx--side-nav__icon bx--side-nav__icon--small"
-            >
-              <div>
-                icon
-              </div>
+          icon={
+            <div>
+              icon
             </div>
-          </SideNavIcon>
+          }
+        >
           <SideNavLinkText>
             <span
               className="bx--side-nav__link-text"

--- a/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
+++ b/src/components/UIShell/__tests__/__snapshots__/SideNavMenu-test.js.snap
@@ -54,12 +54,8 @@ exports[`SideNavMenu should render 1`] = `
   }
   className="custom-classname"
   defaultExpanded={false}
-  icon={
-    <div>
-      icon
-    </div>
-  }
   isActive={false}
+  renderIcon={[Function]}
   title="title"
 >
   <li
@@ -78,9 +74,11 @@ exports[`SideNavMenu should render 1`] = `
         <div
           className="bx--side-nav__icon"
         >
-          <div>
-            icon
-          </div>
+          <renderIcon>
+            <div>
+              icon
+            </div>
+          </renderIcon>
         </div>
       </SideNavIcon>
       <span


### PR DESCRIPTION
Fixes #2008.

#### Changelog

**Changed**

- Changed `icon` API taking React node to `renderIcon` API taking React component class, for UI shell components. It aligns to other components in this library.