### PR TITLE
feat(TextInput): add password visibility toggle for text fields

### DIFF
--- a/src/components/TextInput/ControlledPasswordInput-test.js
+++ b/src/components/TextInput/ControlledPasswordInput-test.js
@@ -1,0 +1,197 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import TextInput from '../TextInput';
+import { mount, shallow } from 'enzyme';
+
+describe('TextInput', () => {
+  describe('renders as expected', () => {
+    const wrapper = mount(
+      <TextInput.ControlledPasswordInput
+        id="test"
+        className="extra-class"
+        labelText="testlabel"
+        helperText="testHelper"
+        light
+      />
+    );
+
+    const textInput = () => wrapper.find('input');
+
+    describe('input', () => {
+      it('renders as expected', () => {
+        expect(textInput().length).toBe(1);
+      });
+
+      it('should accept refs', () => {
+        class MyComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.textInput = React.createRef();
+            this.focus = this.focus.bind(this);
+          }
+          focus() {
+            this.textInput.current.focus();
+          }
+          render() {
+            return (
+              <TextInput id="test" labelText="testlabel" ref={this.textInput} />
+            );
+          }
+        }
+        const wrapper = mount(<MyComponent />);
+        expect(document.activeElement.type).toBeUndefined();
+        wrapper.instance().focus();
+        expect(document.activeElement.type).toEqual('text');
+      });
+
+      it('has the expected classes', () => {
+        expect(textInput().hasClass('bx--text-input')).toEqual(true);
+      });
+
+      it('should add extra classes that are passed via className', () => {
+        expect(textInput().hasClass('extra-class')).toEqual(true);
+      });
+
+      it('has the expected classes for light', () => {
+        wrapper.setProps({ light: true });
+        expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
+      });
+
+      it('should set type as expected', () => {
+        expect(textInput().props().type).toEqual('password');
+        wrapper.setProps({ type: 'text' });
+        expect(textInput().props().type).toEqual('text');
+      });
+
+      it('should set value as expected', () => {
+        expect(textInput().props().defaultValue).toEqual(undefined);
+        wrapper.setProps({ defaultValue: 'test' });
+        expect(textInput().props().defaultValue).toEqual('test');
+      });
+
+      it('should set disabled as expected', () => {
+        expect(textInput().props().disabled).toEqual(false);
+        wrapper.setProps({ disabled: true });
+        expect(textInput().props().disabled).toEqual(true);
+      });
+
+      it('should set placeholder as expected', () => {
+        expect(textInput().props().placeholder).not.toBeDefined();
+        wrapper.setProps({ placeholder: 'Enter text' });
+        expect(textInput().props().placeholder).toEqual('Enter text');
+      });
+    });
+
+    describe('label', () => {
+      wrapper.setProps({ labelText: 'Email Input' });
+      const renderedLabel = wrapper.find('label');
+
+      it('renders a label', () => {
+        expect(renderedLabel.length).toBe(1);
+      });
+
+      it('has the expected classes', () => {
+        expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+      });
+
+      it('should set label as expected', () => {
+        expect(renderedLabel.text()).toEqual('Email Input');
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="/">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="/">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.text()).toEqual('Helper text');
+      });
+    });
+  });
+
+  describe('events', () => {
+    describe('disabled textinput', () => {
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
+        <TextInput
+          id="test"
+          labelText="testlabel"
+          onClick={onClick}
+          onChange={onChange}
+          disabled
+        />
+      );
+
+      const input = wrapper.find('input');
+
+      it('should not invoke onClick', () => {
+        input.simulate('click');
+        expect(onClick).not.toBeCalled();
+      });
+
+      it('should not invoke onChange', () => {
+        input.simulate('change');
+        expect(onChange).not.toBeCalled();
+      });
+    });
+
+    describe('enabled textinput', () => {
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
+        <TextInput
+          labelText="testlabel"
+          id="test"
+          onClick={onClick}
+          onChange={onChange}
+        />
+      );
+
+      const input = wrapper.find('input');
+      const eventObject = {
+        target: {
+          defaultValue: 'test',
+        },
+      };
+
+      it('should invoke onClick when input is clicked', () => {
+        input.simulate('click');
+        expect(onClick).toBeCalled();
+      });
+
+      it('should invoke onChange when input value is changed', () => {
+        input.simulate('change', eventObject);
+        expect(onChange).toBeCalledWith(eventObject);
+      });
+    });
+  });
+});

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -20,6 +20,8 @@ export default function ControlledPasswordInput(props) {
     light,
     type = 'password',
     togglePasswordVisibility,
+    hidePasswordText = 'Hide',
+    showPasswordText = 'Show',
     ...other
   } = props;
   const errorId = id + '-error-msg';
@@ -65,7 +67,10 @@ export default function ControlledPasswordInput(props) {
       />
       <button
         className="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom"
-        aria-label={alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`}
+        aria-label={
+          alt ||
+          `${passwordIsVisible ? hidePasswordText : showPasswordText} password`
+        }
         onClick={togglePasswordVisibility}>
         <Icon
           {...togglePasswordVisibilityIconProps({

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -1,99 +1,156 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { settings } from 'carbon-components';
+import View16 from '@carbon/icons-react/lib/view/16';
+import ViewOff16 from '@carbon/icons-react/lib/view--off/16';
+import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
 import Icon from '../Icon';
 import { textInputProps, togglePasswordVisibilityIconProps } from './util';
+import { componentsX } from '../../internal/FeatureFlags';
 
-export default function ControlledPasswordInput(props) {
-  const {
-    alt,
-    labelText,
-    className,
-    id,
-    placeholder,
-    onChange,
-    onClick,
-    hideLabel,
-    invalid,
-    invalidText,
-    helperText,
-    light,
-    type = 'password',
-    togglePasswordVisibility,
-    hidePasswordText = 'Hide',
-    showPasswordText = 'Show',
-    ...other
-  } = props;
-  const errorId = id + '-error-msg';
-  const textInputClasses = classNames('bx--text-input', className, {
-    'bx--text-input--light': light,
-  });
-  const labelClasses = classNames('bx--label', {
-    'bx--visually-hidden': hideLabel,
-  });
-  const label = labelText ? (
-    <label htmlFor={id} className={labelClasses}>
-      {labelText}
-    </label>
-  ) : null;
-  const sharedTextInputProps = {
-    id,
-    onChange: evt => {
-      if (!other.disabled) {
-        onChange(evt);
-      }
+const { prefix } = settings;
+
+const ControlledPasswordInput = React.forwardRef(
+  (
+    {
+      alt,
+      labelText,
+      className,
+      id,
+      placeholder,
+      onChange,
+      onClick,
+      hideLabel,
+      invalid,
+      invalidText,
+      helperText,
+      light,
+      type = 'password',
+      togglePasswordVisibility,
+      hidePasswordText = 'Hide',
+      showPasswordText = 'Show',
+      ...other
     },
-    onClick: evt => {
-      if (!other.disabled) {
-        onClick(evt);
+    ref
+  ) => {
+    const errorId = id + '-error-msg';
+    const textInputClasses = classNames(
+      `${prefix}--text-input`,
+      `${prefix}--password-input`,
+      className,
+      {
+        [`${prefix}--text-input--light`]: light,
+        [`${prefix}--text-input--invalid`]: invalid,
       }
-    },
-    placeholder,
-    type,
-    className: textInputClasses,
-    ...other,
-  };
-  const error = invalid ? (
-    <div className="bx--form-requirement" id={errorId}>
-      {invalidText}
-    </div>
-  ) : null;
-  const passwordIsVisible = type === 'text';
-  const input = (
-    <>
-      <input
-        {...textInputProps({ invalid, sharedTextInputProps, errorId })}
-        data-toggle-password-visibility={type === 'password'}
-      />
-      <button
-        className="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom"
-        aria-label={
-          alt ||
-          `${passwordIsVisible ? hidePasswordText : showPasswordText} password`
+    );
+    const sharedTextInputProps = {
+      id,
+      onChange: evt => {
+        if (!other.disabled) {
+          onChange(evt);
         }
-        onClick={togglePasswordVisibility}>
-        <Icon
-          {...togglePasswordVisibilityIconProps({
-            passwordIsVisible,
-            alt,
-          })}
+      },
+      onClick: evt => {
+        if (!other.disabled) {
+          onClick(evt);
+        }
+      },
+      placeholder,
+      type,
+      ref,
+      className: textInputClasses,
+      ...other,
+    };
+    const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLabel,
+      [`${prefix}--label--disabled`]: other.disabled,
+    });
+    const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
+      [`${prefix}--form__helper-text--disabled`]: other.disabled,
+    });
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
+    const error = invalid ? (
+      <div className={`${prefix}--form-requirement`} id={errorId}>
+        {invalidText}
+      </div>
+    ) : null;
+    const passwordIsVisible = type === 'text';
+    const passwordVisibilityToggleButtonClasses = classNames(
+      `${prefix}--text-input--password__visibility`,
+      `${prefix}--tooltip__trigger`,
+      `${prefix}--tooltip--icon__bottom`,
+      {}
+    );
+    const passwordVisibilityIcon = (() => {
+      if (!componentsX) {
+        return (
+          <Icon
+            {...togglePasswordVisibilityIconProps({
+              passwordIsVisible,
+              alt,
+            })}
+          />
+        );
+      }
+      return passwordIsVisible ? (
+        <ViewOff16 className={`${prefix}--icon-visibility-off`} />
+      ) : (
+        <View16 className={`${prefix}--icon-visibility-on`} />
+      );
+    })();
+    const input = (
+      <>
+        <input
+          {...textInputProps({ invalid, sharedTextInputProps, errorId })}
+          data-toggle-password-visibility={type === 'password'}
         />
-      </button>
-    </>
-  );
-  const helper = helperText ? (
-    <div className="bx--form__helper-text">{helperText}</div>
-  ) : null;
+        <button
+          className={passwordVisibilityToggleButtonClasses}
+          aria-label={
+            alt ||
+            `${
+              passwordIsVisible ? hidePasswordText : showPasswordText
+            } password`
+          }
+          onClick={togglePasswordVisibility}>
+          {passwordVisibilityIcon}
+        </button>
+      </>
+    );
+    const helper = helperText ? (
+      <div className={helperTextClasses}>{helperText}</div>
+    ) : null;
+    const textInputWrapperClasses = classNames(`${prefix}--form-item`, {
+      [`${prefix}--text-input-wrapper`]: componentsX,
+      [`${prefix}--password-input-wrapper`]: componentsX,
+    });
 
-  return (
-    <div className="bx--form-item bx--text-input-wrapper">
-      {label}
-      {input}
-      {helper}
-      {error}
-    </div>
-  );
-}
+    return (
+      <div className={textInputWrapperClasses}>
+        {label}
+        {helper}
+        {componentsX ? (
+          <div className={`${prefix}--text-input__field-wrapper`}>
+            {invalid && (
+              <WarningFilled16
+                className={`${prefix}--text-input__invalid-icon`}
+              />
+            )}
+            {input}
+          </div>
+        ) : (
+          input
+        )}
+        {error}
+      </div>
+    );
+  }
+);
 
 ControlledPasswordInput.propTypes = {
   /**
@@ -173,3 +230,5 @@ ControlledPasswordInput.defaultProps = {
   helperText: '',
   light: false,
 };
+
+export default ControlledPasswordInput;

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -138,62 +138,76 @@ ControlledPasswordInput.propTypes = {
    * Provide custom alt text for the password visibility toggle button
    */
   alt: PropTypes.string,
+
   /**
    * Provide a custom className that is applied directly to the underlying
    * <input> node
    */
   className: PropTypes.string,
+
   /**
    * Optionally provide the default value of the <input>
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
   /**
    * Specify whether the control is disabled
    */
   disabled: PropTypes.bool,
+
   /**
    * Provide a unique identifier for the input field
    */
   id: PropTypes.string.isRequired,
+
   /**
    * Provide the text that will be read by a screen reader when visiting this
    * control
    */
   labelText: PropTypes.node.isRequired,
+
   /**
    * Optionally provide an `onChange` handler that is called whenever <input>
    * is updated
    */
   onChange: PropTypes.func,
+
   /**
    * Optionally provide an `onClick` handler that is called whenever the
    * <input> is clicked
    */
   onClick: PropTypes.func,
+
   /**
    * Specify the placeholder attribute for the <input>
    */
   placeholder: PropTypes.string,
+
   /**
    * Provide the current value of the <input>
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
   /**
    * Specify whether or not the underlying label is visually hidden
    */
   hideLabel: PropTypes.bool,
+
   /**
    * Specify whether the control is currently invalid
    */
   invalid: PropTypes.bool,
+
   /**
    * Provide the text that is displayed when the control is in an invalid state
    */
   invalidText: PropTypes.string,
+
   /**
    * Provide text that is used alongside the control label for additional help
    */
   helperText: PropTypes.node,
+
   /**
    * Specify light version or default version of this control
    */

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -5,9 +5,7 @@ import { settings } from 'carbon-components';
 import View16 from '@carbon/icons-react/lib/view/16';
 import ViewOff16 from '@carbon/icons-react/lib/view--off/16';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
-import Icon from '../Icon';
-import { textInputProps, togglePasswordVisibilityIconProps } from './util';
-import { componentsX } from '../../internal/FeatureFlags';
+import { textInputProps } from './util';
 
 const { prefix } = settings;
 
@@ -86,23 +84,11 @@ const ControlledPasswordInput = React.forwardRef(
       `${prefix}--tooltip--icon__bottom`,
       {}
     );
-    const passwordVisibilityIcon = (() => {
-      if (!componentsX) {
-        return (
-          <Icon
-            {...togglePasswordVisibilityIconProps({
-              passwordIsVisible,
-              alt,
-            })}
-          />
-        );
-      }
-      return passwordIsVisible ? (
-        <ViewOff16 className={`${prefix}--icon-visibility-off`} />
-      ) : (
-        <View16 className={`${prefix}--icon-visibility-on`} />
-      );
-    })();
+    const passwordVisibilityIcon = passwordIsVisible ? (
+      <ViewOff16 className={`${prefix}--icon-visibility-off`} />
+    ) : (
+      <View16 className={`${prefix}--icon-visibility-on`} />
+    );
     const input = (
       <>
         <input
@@ -125,29 +111,22 @@ const ControlledPasswordInput = React.forwardRef(
     const helper = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
-    const textInputWrapperClasses = classNames(`${prefix}--form-item`, {
-      [`${prefix}--text-input-wrapper`]: componentsX,
-      [`${prefix}--password-input-wrapper`]: componentsX,
-    });
 
     return (
-      <div className={textInputWrapperClasses}>
+      <div
+        className={`${prefix}--form-item ${prefix}--text-input-wrapper ${prefix}--password-input-wrapper`}>
         {label}
         {helper}
-        {componentsX ? (
-          <div
-            className={`${prefix}--text-input__field-wrapper`}
-            data-invalid={invalid || null}>
-            {invalid && (
-              <WarningFilled16
-                className={`${prefix}--text-input__invalid-icon`}
-              />
-            )}
-            {input}
-          </div>
-        ) : (
-          input
-        )}
+        <div
+          className={`${prefix}--text-input__field-wrapper`}
+          data-invalid={invalid || null}>
+          {invalid && (
+            <WarningFilled16
+              className={`${prefix}--text-input__invalid-icon`}
+            />
+          )}
+          {input}
+        </div>
         {error}
       </div>
     );

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -135,7 +135,9 @@ const ControlledPasswordInput = React.forwardRef(
         {label}
         {helper}
         {componentsX ? (
-          <div className={`${prefix}--text-input__field-wrapper`}>
+          <div
+            className={`${prefix}--text-input__field-wrapper`}
+            data-invalid={invalid || null}>
             {invalid && (
               <WarningFilled16
                 className={`${prefix}--text-input__invalid-icon`}

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -18,7 +18,7 @@ export default function ControlledPasswordInput(props) {
     invalidText,
     helperText,
     light,
-    type,
+    type = 'password',
     togglePasswordVisibility,
     ...other
   } = props;

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -10,7 +10,7 @@ import { textInputProps } from './util';
 const { prefix } = settings;
 
 const ControlledPasswordInput = React.forwardRef(
-  (
+  function ControlledPasswordInput(
     {
       alt,
       labelText,
@@ -31,7 +31,7 @@ const ControlledPasswordInput = React.forwardRef(
       ...other
     },
     ref
-  ) => {
+  ) {
     const errorId = id + '-error-msg';
     const textInputClasses = classNames(
       `${prefix}--text-input`,

--- a/src/components/TextInput/ControlledPasswordInput.js
+++ b/src/components/TextInput/ControlledPasswordInput.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+import { textInputProps, togglePasswordVisibilityIconProps } from './util';
+
+export default function ControlledPasswordInput(props) {
+  const {
+    alt,
+    labelText,
+    className,
+    id,
+    placeholder,
+    onChange,
+    onClick,
+    hideLabel,
+    invalid,
+    invalidText,
+    helperText,
+    light,
+    type,
+    togglePasswordVisibility,
+    ...other
+  } = props;
+  const errorId = id + '-error-msg';
+  const textInputClasses = classNames('bx--text-input', className, {
+    'bx--text-input--light': light,
+  });
+  const labelClasses = classNames('bx--label', {
+    'bx--visually-hidden': hideLabel,
+  });
+  const label = labelText ? (
+    <label htmlFor={id} className={labelClasses}>
+      {labelText}
+    </label>
+  ) : null;
+  const sharedTextInputProps = {
+    id,
+    onChange: evt => {
+      if (!other.disabled) {
+        onChange(evt);
+      }
+    },
+    onClick: evt => {
+      if (!other.disabled) {
+        onClick(evt);
+      }
+    },
+    placeholder,
+    type,
+    className: textInputClasses,
+    ...other,
+  };
+  const error = invalid ? (
+    <div className="bx--form-requirement" id={errorId}>
+      {invalidText}
+    </div>
+  ) : null;
+  const passwordIsVisible = type === 'text';
+  const input = (
+    <>
+      <input
+        {...textInputProps({ invalid, sharedTextInputProps, errorId })}
+        data-toggle-password-visibility={type === 'password'}
+      />
+      <button
+        className="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom"
+        aria-label={alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`}
+        onClick={togglePasswordVisibility}>
+        <Icon
+          {...togglePasswordVisibilityIconProps({
+            passwordIsVisible,
+            alt,
+          })}
+        />
+      </button>
+    </>
+  );
+  const helper = helperText ? (
+    <div className="bx--form__helper-text">{helperText}</div>
+  ) : null;
+
+  return (
+    <div className="bx--form-item bx--text-input-wrapper">
+      {label}
+      {input}
+      {helper}
+      {error}
+    </div>
+  );
+}
+
+ControlledPasswordInput.propTypes = {
+  /**
+   * Provide custom alt text for the password visibility toggle button
+   */
+  alt: PropTypes.string,
+  /**
+   * Provide a custom className that is applied directly to the underlying
+   * <input> node
+   */
+  className: PropTypes.string,
+  /**
+   * Optionally provide the default value of the <input>
+   */
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Specify whether the control is disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Provide a unique identifier for the input field
+   */
+  id: PropTypes.string.isRequired,
+  /**
+   * Provide the text that will be read by a screen reader when visiting this
+   * control
+   */
+  labelText: PropTypes.node.isRequired,
+  /**
+   * Optionally provide an `onChange` handler that is called whenever <input>
+   * is updated
+   */
+  onChange: PropTypes.func,
+  /**
+   * Optionally provide an `onClick` handler that is called whenever the
+   * <input> is clicked
+   */
+  onClick: PropTypes.func,
+  /**
+   * Specify the placeholder attribute for the <input>
+   */
+  placeholder: PropTypes.string,
+  /**
+   * Provide the current value of the <input>
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Specify whether or not the underlying label is visually hidden
+   */
+  hideLabel: PropTypes.bool,
+  /**
+   * Specify whether the control is currently invalid
+   */
+  invalid: PropTypes.bool,
+  /**
+   * Provide the text that is displayed when the control is in an invalid state
+   */
+  invalidText: PropTypes.string,
+  /**
+   * Provide text that is used alongside the control label for additional help
+   */
+  helperText: PropTypes.node,
+  /**
+   * Specify light version or default version of this control
+   */
+  light: PropTypes.bool,
+};
+
+ControlledPasswordInput.defaultProps = {
+  alt: '',
+  className: 'bx--text__input',
+  disabled: false,
+  onChange: () => {},
+  onClick: () => {},
+  invalid: false,
+  invalidText: '',
+  helperText: '',
+  light: false,
+};

--- a/src/components/TextInput/PasswordInput-test.js
+++ b/src/components/TextInput/PasswordInput-test.js
@@ -1,0 +1,168 @@
+import React from 'react';
+import PasswordInput from './PasswordInput';
+import { mount, shallow } from 'enzyme';
+
+describe('TextInput', () => {
+  describe('renders as expected', () => {
+    const wrapper = mount(
+      <PasswordInput
+        id="test"
+        className="extra-class"
+        labelText="testlabel"
+        helperText="testHelper"
+        light
+      />
+    );
+
+    const textInput = () => wrapper.find('input');
+
+    describe('input', () => {
+      it('renders as expected', () => {
+        expect(textInput().length).toBe(1);
+      });
+
+      it('has the expected classes', () => {
+        expect(textInput().hasClass('bx--text-input')).toEqual(true);
+      });
+
+      it('should add extra classes that are passed via className', () => {
+        expect(textInput().hasClass('extra-class')).toEqual(true);
+      });
+
+      it('has the expected classes for light', () => {
+        wrapper.setProps({ light: true });
+        expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
+      });
+
+      it('should set type as expected', () => {
+        expect(textInput().props().type).toEqual('password');
+        wrapper.find('button').simulate('click');
+        expect(textInput().props().type).toEqual('text');
+      });
+
+      it('should set value as expected', () => {
+        expect(textInput().props().defaultValue).toEqual(undefined);
+        wrapper.setProps({ defaultValue: 'test' });
+        expect(textInput().props().defaultValue).toEqual('test');
+      });
+
+      it('should set disabled as expected', () => {
+        expect(textInput().props().disabled).toEqual(false);
+        wrapper.setProps({ disabled: true });
+        expect(textInput().props().disabled).toEqual(true);
+      });
+
+      it('should set placeholder as expected', () => {
+        expect(textInput().props().placeholder).not.toBeDefined();
+        wrapper.setProps({ placeholder: 'Enter text' });
+        expect(textInput().props().placeholder).toEqual('Enter text');
+      });
+    });
+
+    describe('label', () => {
+      wrapper.setProps({ labelText: 'Password Input' });
+      const renderedLabel = wrapper.find('label');
+
+      it('renders a label', () => {
+        expect(renderedLabel.length).toBe(1);
+      });
+
+      it('has the expected classes', () => {
+        expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+      });
+
+      it('should set label as expected', () => {
+        expect(renderedLabel.text()).toEqual('Password Input');
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
+            <span>
+              This helper text has <a href="/">a link</a>.
+            </span>
+          ),
+        });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="/">a link</a>.
+          </span>
+        );
+      });
+
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.text()).toEqual('Helper text');
+      });
+    });
+  });
+
+  describe('events', () => {
+    describe('disabled textinput', () => {
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
+        <PasswordInput
+          id="test"
+          labelText="testlabel"
+          onClick={onClick}
+          onChange={onChange}
+          disabled
+        />
+      );
+
+      const input = wrapper.find('input');
+
+      it('should not invoke onClick', () => {
+        input.simulate('click');
+        expect(onClick).not.toBeCalled();
+      });
+
+      it('should not invoke onChange', () => {
+        input.simulate('change');
+        expect(onChange).not.toBeCalled();
+      });
+    });
+
+    describe('enabled textinput', () => {
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
+        <PasswordInput
+          labelText="testlabel"
+          id="test"
+          onClick={onClick}
+          onChange={onChange}
+        />
+      );
+
+      const input = wrapper.find('input');
+      const eventObject = {
+        target: {
+          defaultValue: 'test',
+        },
+      };
+
+      it('should invoke onClick when input is clicked', () => {
+        input.simulate('click');
+        expect(onClick).toBeCalled();
+      });
+
+      it('should invoke onChange when input value is changed', () => {
+        input.simulate('change', eventObject);
+        expect(onChange).toBeCalledWith(eventObject);
+      });
+    });
+  });
+});

--- a/src/components/TextInput/PasswordInput-test.js
+++ b/src/components/TextInput/PasswordInput-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PasswordInput from './PasswordInput';
 import { mount, shallow } from 'enzyme';
 
-describe('TextInput', () => {
+describe('PasswordInput', () => {
   describe('renders as expected', () => {
     const wrapper = mount(
       <PasswordInput
@@ -14,48 +14,48 @@ describe('TextInput', () => {
       />
     );
 
-    const textInput = () => wrapper.find('input');
+    const passwordInput = () => wrapper.find('input');
 
     describe('input', () => {
       it('renders as expected', () => {
-        expect(textInput().length).toBe(1);
+        expect(passwordInput().length).toBe(1);
       });
 
       it('has the expected classes', () => {
-        expect(textInput().hasClass('bx--text-input')).toEqual(true);
+        expect(passwordInput().hasClass('bx--text-input')).toEqual(true);
       });
 
       it('should add extra classes that are passed via className', () => {
-        expect(textInput().hasClass('extra-class')).toEqual(true);
+        expect(passwordInput().hasClass('extra-class')).toEqual(true);
       });
 
       it('has the expected classes for light', () => {
         wrapper.setProps({ light: true });
-        expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
+        expect(passwordInput().hasClass('bx--text-input--light')).toEqual(true);
       });
 
       it('should set type as expected', () => {
-        expect(textInput().props().type).toEqual('password');
+        expect(passwordInput().props().type).toEqual('password');
         wrapper.find('button').simulate('click');
-        expect(textInput().props().type).toEqual('text');
+        expect(passwordInput().props().type).toEqual('text');
       });
 
       it('should set value as expected', () => {
-        expect(textInput().props().defaultValue).toEqual(undefined);
+        expect(passwordInput().props().defaultValue).toEqual(undefined);
         wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput().props().defaultValue).toEqual('test');
+        expect(passwordInput().props().defaultValue).toEqual('test');
       });
 
       it('should set disabled as expected', () => {
-        expect(textInput().props().disabled).toEqual(false);
+        expect(passwordInput().props().disabled).toEqual(false);
         wrapper.setProps({ disabled: true });
-        expect(textInput().props().disabled).toEqual(true);
+        expect(passwordInput().props().disabled).toEqual(true);
       });
 
       it('should set placeholder as expected', () => {
-        expect(textInput().props().placeholder).not.toBeDefined();
+        expect(passwordInput().props().placeholder).not.toBeDefined();
         wrapper.setProps({ placeholder: 'Enter text' });
-        expect(textInput().props().placeholder).toEqual('Enter text');
+        expect(passwordInput().props().placeholder).toEqual('Enter text');
       });
     });
 

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -133,7 +133,9 @@ export default class PasswordInput extends React.Component {
         {label}
         {helper}
         {componentsX ? (
-          <div className={`${prefix}--text-input__field-wrapper`}>
+          <div
+            className={`${prefix}--text-input__field-wrapper`}
+            data-invalid={invalid || null}>
             {invalid && (
               <WarningFilled16
                 className={`${prefix}--text-input__invalid-icon`}

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -5,9 +5,7 @@ import { settings } from 'carbon-components';
 import View16 from '@carbon/icons-react/lib/view/16';
 import ViewOff16 from '@carbon/icons-react/lib/view--off/16';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
-import Icon from '../Icon';
-import { textInputProps, togglePasswordVisibilityIconProps } from './util';
-import { componentsX } from '../../internal/FeatureFlags';
+import { textInputProps } from './util';
 
 const { prefix } = settings;
 
@@ -89,23 +87,11 @@ export default class PasswordInput extends React.Component {
       `${prefix}--tooltip--icon__bottom`,
       {}
     );
-    const passwordVisibilityIcon = (() => {
-      if (!componentsX) {
-        return (
-          <Icon
-            {...togglePasswordVisibilityIconProps({
-              passwordIsVisible,
-              alt,
-            })}
-          />
-        );
-      }
-      return passwordIsVisible ? (
-        <ViewOff16 className={`${prefix}--icon-visibility-off`} />
-      ) : (
-        <View16 className={`${prefix}--icon-visibility-on`} />
-      );
-    })();
+    const passwordVisibilityIcon = passwordIsVisible ? (
+      <ViewOff16 className={`${prefix}--icon-visibility-off`} />
+    ) : (
+      <View16 className={`${prefix}--icon-visibility-on`} />
+    );
     const input = (
       <>
         <input
@@ -123,29 +109,22 @@ export default class PasswordInput extends React.Component {
     const helper = helperText ? (
       <div className={helperTextClasses}>{helperText}</div>
     ) : null;
-    const textInputWrapperClasses = classNames(`${prefix}--form-item`, {
-      [`${prefix}--text-input-wrapper`]: componentsX,
-      [`${prefix}--password-input-wrapper`]: componentsX,
-    });
 
     return (
-      <div className={textInputWrapperClasses}>
+      <div
+        className={`${prefix}--form-item ${prefix}--text-input-wrapper ${prefix}--password-input-wrapper`}>
         {label}
         {helper}
-        {componentsX ? (
-          <div
-            className={`${prefix}--text-input__field-wrapper`}
-            data-invalid={invalid || null}>
-            {invalid && (
-              <WarningFilled16
-                className={`${prefix}--text-input__invalid-icon`}
-              />
-            )}
-            {input}
-          </div>
-        ) : (
-          input
-        )}
+        <div
+          className={`${prefix}--text-input__field-wrapper`}
+          data-invalid={invalid || null}>
+          {invalid && (
+            <WarningFilled16
+              className={`${prefix}--text-input__invalid-icon`}
+            />
+          )}
+          {input}
+        </div>
         {error}
       </div>
     );

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -18,7 +18,7 @@ export default class PasswordInput extends React.Component {
   togglePasswordVisibilityIconProps = () => {
     const passwordIsVisible = this.state.type === 'text';
     return {
-      alt: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+      alt: this.props.alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`,
       name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
       description: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
     };
@@ -103,6 +103,10 @@ export default class PasswordInput extends React.Component {
 
 PasswordInput.propTypes = {
   /**
+   * Provide custom alt text for the password visibility toggle button
+   */
+  alt: PropTypes.string,
+  /**
    * Provide a custom className that is applied directly to the underlying
    * <input> node
    */
@@ -165,6 +169,7 @@ PasswordInput.propTypes = {
 };
 
 PasswordInput.defaultProps = {
+  alt: '',
   className: 'bx--text__input',
   disabled: false,
   onChange: () => {},

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -73,7 +73,8 @@ export default class PasswordInput extends React.Component {
           data-toggle-password-visibility={this.state.type === 'password'}
         />
         <button
-          className="bx--text-input--password__visibility"
+          className="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom"
+          aria-label={alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`}
           onClick={this.togglePasswordVisibility}>
           <Icon
             {...togglePasswordVisibilityIconProps({

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -101,9 +101,9 @@ export default class PasswordInput extends React.Component {
         );
       }
       return passwordIsVisible ? (
-        <ViewOff16 classname={`${prefix}--icon-visibility-off`} />
+        <ViewOff16 className={`${prefix}--icon-visibility-off`} />
       ) : (
-        <View16 classname={`${prefix}--icon-visibility-on`} />
+        <View16 className={`${prefix}--icon-visibility-on`} />
       );
     })();
     const input = (

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -1,0 +1,176 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import Icon from '../Icon';
+import { textInputProps } from './util';
+
+export default class PasswordInput extends React.Component {
+  state = {
+    type: 'password',
+  };
+
+  togglePasswordVisibility = () => {
+    this.setState({
+      type: this.state.type === 'password' ? 'text' : 'password',
+    });
+  };
+
+  togglePasswordVisibilityIconProps = () => {
+    const passwordIsVisible = this.state.type === 'text';
+    return {
+      alt: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+      name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
+      description: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+    };
+  };
+
+  render() {
+    const {
+      labelText,
+      className,
+      id,
+      placeholder,
+      onChange,
+      onClick,
+      hideLabel,
+      invalid,
+      invalidText,
+      helperText,
+      light,
+      ...other
+    } = this.props;
+    const errorId = id + '-error-msg';
+    const textInputClasses = classNames('bx--text-input', className, {
+      'bx--text-input--light': light,
+    });
+    const labelClasses = classNames('bx--label', {
+      'bx--visually-hidden': hideLabel,
+    });
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
+    const sharedTextInputProps = {
+      id,
+      onChange: evt => {
+        if (!other.disabled) {
+          onChange(evt);
+        }
+      },
+      onClick: evt => {
+        if (!other.disabled) {
+          onClick(evt);
+        }
+      },
+      placeholder,
+      type: this.state.type,
+      className: textInputClasses,
+      ...other,
+    };
+    const error = invalid ? (
+      <div className="bx--form-requirement" id={errorId}>
+        {invalidText}
+      </div>
+    ) : null;
+    const input = (
+      <>
+        <input
+          {...textInputProps({ invalid, sharedTextInputProps, errorId })}
+          data-toggle-password-visibility={this.state.type === 'password'}
+        />
+        <button
+          className="bx--text-input--password__visibility"
+          onClick={this.togglePasswordVisibility}>
+          <Icon {...this.togglePasswordVisibilityIconProps()} />
+        </button>
+      </>
+    );
+    const helper = helperText ? (
+      <div className="bx--form__helper-text">{helperText}</div>
+    ) : null;
+
+    return (
+      <div className="bx--form-item bx--text-input-wrapper">
+        {label}
+        {input}
+        {helper}
+        {error}
+      </div>
+    );
+  }
+}
+
+PasswordInput.propTypes = {
+  /**
+   * Provide a custom className that is applied directly to the underlying
+   * <input> node
+   */
+  className: PropTypes.string,
+  /**
+   * Optionally provide the default value of the <input>
+   */
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Specify whether the control is disabled
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Provide a unique identifier for the input field
+   */
+  id: PropTypes.string.isRequired,
+  /**
+   * Provide the text that will be read by a screen reader when visiting this
+   * control
+   */
+  labelText: PropTypes.node.isRequired,
+  /**
+   * Optionally provide an `onChange` handler that is called whenever <input>
+   * is updated
+   */
+  onChange: PropTypes.func,
+  /**
+   * Optionally provide an `onClick` handler that is called whenever the
+   * <input> is clicked
+   */
+  onClick: PropTypes.func,
+  /**
+   * Specify the placeholder attribute for the <input>
+   */
+  placeholder: PropTypes.string,
+  /**
+   * Provide the current value of the <input>
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /**
+   * Specify whether or not the underlying label is visually hidden
+   */
+  hideLabel: PropTypes.bool,
+  /**
+   * Specify whether the control is currently invalid
+   */
+  invalid: PropTypes.bool,
+  /**
+   * Provide the text that is displayed when the control is in an invalid state
+   */
+  invalidText: PropTypes.string,
+  /**
+   * Provide text that is used alongside the control label for additional help
+   */
+  helperText: PropTypes.node,
+  /**
+   * Specify light version or default version of this control
+   */
+  light: PropTypes.bool,
+};
+
+PasswordInput.defaultProps = {
+  className: 'bx--text__input',
+  disabled: false,
+  onChange: () => {},
+  onClick: () => {},
+  invalid: false,
+  invalidText: '',
+  helperText: '',
+  light: false,
+};

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
-import { textInputProps } from './util';
+import { textInputProps, togglePasswordVisibilityIconProps } from './util';
 
 export default class PasswordInput extends React.Component {
   state = {
@@ -15,17 +15,9 @@ export default class PasswordInput extends React.Component {
     });
   };
 
-  togglePasswordVisibilityIconProps = () => {
-    const passwordIsVisible = this.state.type === 'text';
-    return {
-      alt: this.props.alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`,
-      name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
-      description: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
-    };
-  };
-
   render() {
     const {
+      alt,
       labelText,
       className,
       id,
@@ -73,6 +65,7 @@ export default class PasswordInput extends React.Component {
         {invalidText}
       </div>
     ) : null;
+    const passwordIsVisible = this.state.type === 'text';
     const input = (
       <>
         <input
@@ -82,7 +75,12 @@ export default class PasswordInput extends React.Component {
         <button
           className="bx--text-input--password__visibility"
           onClick={this.togglePasswordVisibility}>
-          <Icon {...this.togglePasswordVisibilityIconProps()} />
+          <Icon
+            {...togglePasswordVisibilityIconProps({
+              passwordIsVisible,
+              alt,
+            })}
+          />
         </button>
       </>
     );

--- a/src/components/TextInput/PasswordInput.js
+++ b/src/components/TextInput/PasswordInput.js
@@ -1,8 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { settings } from 'carbon-components';
+import View16 from '@carbon/icons-react/lib/view/16';
+import ViewOff16 from '@carbon/icons-react/lib/view--off/16';
+import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
 import Icon from '../Icon';
 import { textInputProps, togglePasswordVisibilityIconProps } from './util';
+import { componentsX } from '../../internal/FeatureFlags';
+
+const { prefix } = settings;
 
 export default class PasswordInput extends React.Component {
   state = {
@@ -32,17 +39,15 @@ export default class PasswordInput extends React.Component {
       ...other
     } = this.props;
     const errorId = id + '-error-msg';
-    const textInputClasses = classNames('bx--text-input', className, {
-      'bx--text-input--light': light,
-    });
-    const labelClasses = classNames('bx--label', {
-      'bx--visually-hidden': hideLabel,
-    });
-    const label = labelText ? (
-      <label htmlFor={id} className={labelClasses}>
-        {labelText}
-      </label>
-    ) : null;
+    const textInputClasses = classNames(
+      `${prefix}--text-input`,
+      `${prefix}--password-input`,
+      className,
+      {
+        [`${prefix}--text-input--light`]: light,
+        [`${prefix}--text-input--invalid`]: invalid,
+      }
+    );
     const sharedTextInputProps = {
       id,
       onChange: evt => {
@@ -60,12 +65,47 @@ export default class PasswordInput extends React.Component {
       className: textInputClasses,
       ...other,
     };
+    const labelClasses = classNames(`${prefix}--label`, {
+      [`${prefix}--visually-hidden`]: hideLabel,
+      [`${prefix}--label--disabled`]: other.disabled,
+    });
+    const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
+      [`${prefix}--form__helper-text--disabled`]: other.disabled,
+    });
+    const label = labelText ? (
+      <label htmlFor={id} className={labelClasses}>
+        {labelText}
+      </label>
+    ) : null;
     const error = invalid ? (
-      <div className="bx--form-requirement" id={errorId}>
+      <div className={`${prefix}--form-requirement`} id={errorId}>
         {invalidText}
       </div>
     ) : null;
     const passwordIsVisible = this.state.type === 'text';
+    const passwordVisibilityToggleButtonClasses = classNames(
+      `${prefix}--text-input--password__visibility`,
+      `${prefix}--tooltip__trigger`,
+      `${prefix}--tooltip--icon__bottom`,
+      {}
+    );
+    const passwordVisibilityIcon = (() => {
+      if (!componentsX) {
+        return (
+          <Icon
+            {...togglePasswordVisibilityIconProps({
+              passwordIsVisible,
+              alt,
+            })}
+          />
+        );
+      }
+      return passwordIsVisible ? (
+        <ViewOff16 classname={`${prefix}--icon-visibility-off`} />
+      ) : (
+        <View16 classname={`${prefix}--icon-visibility-on`} />
+      );
+    })();
     const input = (
       <>
         <input
@@ -73,27 +113,37 @@ export default class PasswordInput extends React.Component {
           data-toggle-password-visibility={this.state.type === 'password'}
         />
         <button
-          className="bx--text-input--password__visibility bx--tooltip__trigger bx--tooltip--icon__bottom"
+          className={passwordVisibilityToggleButtonClasses}
           aria-label={alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`}
           onClick={this.togglePasswordVisibility}>
-          <Icon
-            {...togglePasswordVisibilityIconProps({
-              passwordIsVisible,
-              alt,
-            })}
-          />
+          {passwordVisibilityIcon}
         </button>
       </>
     );
     const helper = helperText ? (
-      <div className="bx--form__helper-text">{helperText}</div>
+      <div className={helperTextClasses}>{helperText}</div>
     ) : null;
+    const textInputWrapperClasses = classNames(`${prefix}--form-item`, {
+      [`${prefix}--text-input-wrapper`]: componentsX,
+      [`${prefix}--password-input-wrapper`]: componentsX,
+    });
 
     return (
-      <div className="bx--form-item bx--text-input-wrapper">
+      <div className={textInputWrapperClasses}>
         {label}
-        {input}
         {helper}
+        {componentsX ? (
+          <div className={`${prefix}--text-input__field-wrapper`}>
+            {invalid && (
+              <WarningFilled16
+                className={`${prefix}--text-input__invalid-icon`}
+              />
+            )}
+            {input}
+          </div>
+        ) : (
+          input
+        )}
         {error}
       </div>
     );

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -97,11 +97,14 @@ storiesOf('TextInput', module)
   )
   .add(
     'Fully controlled toggle password visibility',
-    withInfo({
-      text: `
+    () => <ControlledPasswordInputApp />,
+    {
+      info: {
+        text: `
         Fully controlled text field with password visibility toggle.
       `,
-    })(() => <ControlledPasswordInputApp />)
+      },
+    }
   )
   .add(
     'skeleton',

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -14,6 +14,7 @@ import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
 
 const types = {
   None: '',
+  'Text (text)': 'text',
   'For email (email)': 'email',
   'For password (password)': 'password',
 };

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -19,6 +19,28 @@ const types = {
   'For password (password)': 'password',
 };
 
+class ControlledPasswordInputApp extends React.Component {
+  state = {
+    type: 'password',
+  };
+
+  togglePasswordVisibility = () => {
+    this.setState({
+      type: this.state.type === 'password' ? 'text' : 'password',
+    });
+  };
+
+  render() {
+    return (
+      <TextInput.ControlledPasswordInput
+        type={this.state.type}
+        togglePasswordVisibility={this.togglePasswordVisibility}
+        {...TextInputProps()}
+      />
+    );
+  }
+}
+
 const TextInputProps = () => ({
   className: 'some-class',
   id: 'test2',
@@ -72,6 +94,14 @@ storiesOf('TextInput', module)
         `,
       },
     }
+  )
+  .add(
+    'Fully controlled toggle password visibility',
+    withInfo({
+      text: `
+        Fully controlled text field with password visibility toggle.
+      `,
+    })(() => <ControlledPasswordInputApp />)
   )
   .add(
     'skeleton',

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -62,6 +62,20 @@ storiesOf('TextInput', module)
     }
   )
   .add(
+    'Toggle password visibility',
+    withInfo({
+      text: `
+        Text field with password visibility toggle.
+      `,
+    })(() => (
+      <TextInput
+        {...TextInputProps()}
+        type="password"
+        passwordVisibilityToggle
+      />
+    ))
+  )
+  .add(
     'skeleton',
     () => (
       <div>

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -64,17 +64,14 @@ storiesOf('TextInput', module)
   )
   .add(
     'Toggle password visibility',
-    withInfo({
-      text: `
-        Text field with password visibility toggle.
-      `,
-    })(() => (
-      <TextInput
-        {...TextInputProps()}
-        type="password"
-        passwordVisibilityToggle
-      />
-    ))
+    () => <TextInput.PasswordInput {...TextInputProps()} />,
+    {
+      info: {
+        text: `
+          Text field with password visibility toggle.
+        `,
+      },
+    }
   )
   .add(
     'skeleton',

--- a/src/components/TextInput/TextInput-story.js
+++ b/src/components/TextInput/TextInput-story.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import TextInput from '../TextInput';
 import TextInputSkeleton from '../TextInput/TextInput.Skeleton';
@@ -27,7 +26,6 @@ const TextInputProps = () => ({
     'This is not a default value'
   ),
   labelText: text('Label text (labelText)', 'Text Input label'),
-  type: select('Form control type (type)', types, ''),
   placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
   light: boolean('Light variant (light)', false),
   disabled: boolean('Disabled (disabled)', false),
@@ -44,16 +42,25 @@ const TextInputProps = () => ({
 
 storiesOf('TextInput', module)
   .addDecorator(withKnobs)
-  .add('Default', () => <TextInput {...TextInputProps()} />, {
-    info: {
-      text: `
+  .add(
+    'Default',
+    () => (
+      <TextInput
+        type={select('Form control type (type)', types, 'text')}
+        {...TextInputProps()}
+      />
+    ),
+    {
+      info: {
+        text: `
             Text fields enable the user to interact with and input data. A single line
             field is used when the input anticipated by the user is a single line of
             text as opposed to a paragraph.
             The default type is 'text' and its value can be either 'string' or 'number'.
           `,
-    },
-  })
+      },
+    }
+  )
   .add(
     'skeleton',
     () => (

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -115,14 +115,14 @@ describe('TextInput', () => {
         wrapper.setProps({
           helperText: (
             <span>
-              This helper text has <a href="#">a link</a>.
+              This helper text has <a href="/">a link</a>.
             </span>
           ),
         });
         const renderedHelper = wrapper.find('.bx--form__helper-text');
         expect(renderedHelper.props().children).toEqual(
           <span>
-            This helper text has <a href="#">a link</a>.
+            This helper text has <a href="/">a link</a>.
           </span>
         );
       });

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -11,186 +11,250 @@ import { mount, shallow } from 'enzyme';
 
 describe('TextInput', () => {
   describe('renders as expected', () => {
-    const wrapper = mount(
+    const variations = [
       <TextInput
         id="test"
         className="extra-class"
         labelText="testlabel"
         helperText="testHelper"
         light
-      />
-    );
+      />,
+      <TextInput.PasswordInput
+        id="test"
+        className="extra-class"
+        labelText="testlabel"
+        helperText="testHelper"
+        light
+      />,
+      <TextInput.ControlledPasswordInput
+        id="test"
+        className="extra-class"
+        labelText="testlabel"
+        helperText="testHelper"
+        light
+      />,
+    ];
+    variations.forEach(variation => {
+      const wrapper = mount(variation);
+      const textInput = () => wrapper.find('input');
 
-    const textInput = () => wrapper.find('input');
+      describe('input', () => {
+        it('renders as expected', () => {
+          expect(textInput().length).toBe(1);
+        });
 
-    describe('input', () => {
-      it('renders as expected', () => {
-        expect(textInput().length).toBe(1);
-      });
-
-      it('should accept refs', () => {
-        class MyComponent extends React.Component {
-          constructor(props) {
-            super(props);
-            this.textInput = React.createRef();
-            this.focus = this.focus.bind(this);
+        it('should accept refs', () => {
+          class MyComponent extends React.Component {
+            constructor(props) {
+              super(props);
+              this.textInput = React.createRef();
+              this.focus = this.focus.bind(this);
+            }
+            focus() {
+              this.textInput.current.focus();
+            }
+            render() {
+              return (
+                <TextInput
+                  id="test"
+                  labelText="testlabel"
+                  ref={this.textInput}
+                />
+              );
+            }
           }
-          focus() {
-            this.textInput.current.focus();
-          }
-          render() {
-            return (
-              <TextInput id="test" labelText="testlabel" ref={this.textInput} />
-            );
-          }
-        }
-        const wrapper = mount(<MyComponent />);
-        expect(document.activeElement.type).toBeUndefined();
-        wrapper.instance().focus();
-        expect(document.activeElement.type).toEqual('text');
+          const wrapper = mount(<MyComponent />);
+          expect(document.activeElement.type).toBeUndefined();
+          wrapper.instance().focus();
+          expect(document.activeElement.type).toEqual('text');
+        });
+
+        it('has the expected classes', () => {
+          expect(textInput().hasClass('bx--text-input')).toEqual(true);
+        });
+
+        it('should add extra classes that are passed via className', () => {
+          expect(textInput().hasClass('extra-class')).toEqual(true);
+        });
+
+        it('has the expected classes for light', () => {
+          wrapper.setProps({ light: true });
+          expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
+        });
+
+        it('should set type as expected', () => {
+          expect(['text', 'password']).toContain(textInput().props().type);
+          wrapper.setProps({ type: 'email' });
+          expect(textInput().props().type).toEqual('email');
+        });
+
+        it('should set value as expected', () => {
+          expect(textInput().props().defaultValue).toEqual(undefined);
+          wrapper.setProps({ defaultValue: 'test' });
+          expect(textInput().props().defaultValue).toEqual('test');
+        });
+
+        it('should set disabled as expected', () => {
+          expect(textInput().props().disabled).toEqual(false);
+          wrapper.setProps({ disabled: true });
+          expect(textInput().props().disabled).toEqual(true);
+        });
+
+        it('should set placeholder as expected', () => {
+          expect(textInput().props().placeholder).not.toBeDefined();
+          wrapper.setProps({ placeholder: 'Enter text' });
+          expect(textInput().props().placeholder).toEqual('Enter text');
+        });
       });
 
-      it('has the expected classes', () => {
-        expect(textInput().hasClass('bx--text-input')).toEqual(true);
+      describe('label', () => {
+        wrapper.setProps({ labelText: 'Email Input' });
+        const renderedLabel = wrapper.find('label');
+
+        it('renders a label', () => {
+          expect(renderedLabel.length).toBe(1);
+        });
+
+        it('has the expected classes', () => {
+          expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+        });
+
+        it('should set label as expected', () => {
+          expect(renderedLabel.text()).toEqual('Email Input');
+        });
       });
 
-      it('should add extra classes that are passed via className', () => {
-        expect(textInput().hasClass('extra-class')).toEqual(true);
-      });
+      describe('helper', () => {
+        it('renders a helper', () => {
+          const renderedHelper = wrapper.find('.bx--form__helper-text');
+          expect(renderedHelper.length).toEqual(1);
+        });
 
-      it('has the expected classes for light', () => {
-        wrapper.setProps({ light: true });
-        expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
-      });
-
-      it('should set type as expected', () => {
-        expect(textInput().props().type).toEqual('text');
-        wrapper.setProps({ type: 'email' });
-        expect(textInput().props().type).toEqual('email');
-      });
-
-      it('should set value as expected', () => {
-        expect(textInput().props().defaultValue).toEqual(undefined);
-        wrapper.setProps({ defaultValue: 'test' });
-        expect(textInput().props().defaultValue).toEqual('test');
-      });
-
-      it('should set disabled as expected', () => {
-        expect(textInput().props().disabled).toEqual(false);
-        wrapper.setProps({ disabled: true });
-        expect(textInput().props().disabled).toEqual(true);
-      });
-
-      it('should set placeholder as expected', () => {
-        expect(textInput().props().placeholder).not.toBeDefined();
-        wrapper.setProps({ placeholder: 'Enter text' });
-        expect(textInput().props().placeholder).toEqual('Enter text');
-      });
-    });
-
-    describe('label', () => {
-      wrapper.setProps({ labelText: 'Email Input' });
-      const renderedLabel = wrapper.find('label');
-
-      it('renders a label', () => {
-        expect(renderedLabel.length).toBe(1);
-      });
-
-      it('has the expected classes', () => {
-        expect(renderedLabel.hasClass('bx--label')).toEqual(true);
-      });
-
-      it('should set label as expected', () => {
-        expect(renderedLabel.text()).toEqual('Email Input');
-      });
-    });
-
-    describe('helper', () => {
-      it('renders a helper', () => {
-        const renderedHelper = wrapper.find('.bx--form__helper-text');
-        expect(renderedHelper.length).toEqual(1);
-      });
-
-      it('renders children as expected', () => {
-        wrapper.setProps({
-          helperText: (
+        it('renders children as expected', () => {
+          wrapper.setProps({
+            helperText: (
+              <span>
+                This helper text has <a href="/">a link</a>.
+              </span>
+            ),
+          });
+          const renderedHelper = wrapper.find('.bx--form__helper-text');
+          expect(renderedHelper.props().children).toEqual(
             <span>
               This helper text has <a href="/">a link</a>.
             </span>
-          ),
+          );
         });
-        const renderedHelper = wrapper.find('.bx--form__helper-text');
-        expect(renderedHelper.props().children).toEqual(
-          <span>
-            This helper text has <a href="/">a link</a>.
-          </span>
-        );
-      });
 
-      it('should set helper text as expected', () => {
-        wrapper.setProps({ helperText: 'Helper text' });
-        const renderedHelper = wrapper.find('.bx--form__helper-text');
-        expect(renderedHelper.text()).toEqual('Helper text');
+        it('should set helper text as expected', () => {
+          wrapper.setProps({ helperText: 'Helper text' });
+          const renderedHelper = wrapper.find('.bx--form__helper-text');
+          expect(renderedHelper.text()).toEqual('Helper text');
+        });
       });
     });
   });
 
   describe('events', () => {
+    const onClick = jest.fn();
+    const onChange = jest.fn();
     describe('disabled textinput', () => {
-      const onClick = jest.fn();
-      const onChange = jest.fn();
-
-      const wrapper = shallow(
+      const variations = [
         <TextInput
           id="test"
+          className="extra-class"
           labelText="testlabel"
+          helperText="testHelper"
           onClick={onClick}
           onChange={onChange}
           disabled
-        />
-      );
+          light
+        />,
+        <TextInput.PasswordInput
+          id="test"
+          className="extra-class"
+          labelText="testlabel"
+          helperText="testHelper"
+          onClick={onClick}
+          onChange={onChange}
+          disabled
+          light
+        />,
+        <TextInput.ControlledPasswordInput
+          id="test"
+          className="extra-class"
+          labelText="testlabel"
+          helperText="testHelper"
+          onClick={onClick}
+          onChange={onChange}
+          disabled
+          light
+        />,
+      ];
+      variations.forEach(variation => {
+        const wrapper = shallow(variation);
+        const input = wrapper.find('input');
 
-      const input = wrapper.find('input');
+        it('should not invoke onClick', () => {
+          input.simulate('click');
+          expect(onClick).not.toBeCalled();
+        });
 
-      it('should not invoke onClick', () => {
-        input.simulate('click');
-        expect(onClick).not.toBeCalled();
-      });
-
-      it('should not invoke onChange', () => {
-        input.simulate('change');
-        expect(onChange).not.toBeCalled();
+        it('should not invoke onChange', () => {
+          input.simulate('change');
+          expect(onChange).not.toBeCalled();
+        });
       });
     });
 
     describe('enabled textinput', () => {
-      const onClick = jest.fn();
-      const onChange = jest.fn();
-
-      const wrapper = shallow(
+      const variations = [
         <TextInput
-          labelText="testlabel"
           id="test"
+          className="extra-class"
+          labelText="testlabel"
+          helperText="testHelper"
           onClick={onClick}
           onChange={onChange}
-        />
-      );
+          light
+        />,
+        <TextInput.PasswordInput
+          id="test"
+          className="extra-class"
+          labelText="testlabel"
+          helperText="testHelper"
+          onClick={onClick}
+          onChange={onChange}
+          light
+        />,
+        <TextInput.ControlledPasswordInput
+          id="test"
+          className="extra-class"
+          labelText="testlabel"
+          helperText="testHelper"
+          onClick={onClick}
+          onChange={onChange}
+          light
+        />,
+      ];
+      variations.forEach(variation => {
+        const wrapper = shallow(variation);
+        const input = wrapper.find('input');
+        const eventObject = {
+          target: {
+            defaultValue: 'test',
+          },
+        };
 
-      const input = wrapper.find('input');
-      const eventObject = {
-        target: {
-          defaultValue: 'test',
-        },
-      };
+        it('should invoke onClick when input is clicked', () => {
+          input.simulate('click');
+          expect(onClick).toBeCalled();
+        });
 
-      it('should invoke onClick when input is clicked', () => {
-        input.simulate('click');
-        expect(onClick).toBeCalled();
-      });
-
-      it('should invoke onChange when input value is changed', () => {
-        input.simulate('change', eventObject);
-        expect(onChange).toBeCalledWith(eventObject);
+        it('should invoke onChange when input value is changed', () => {
+          input.simulate('change', eventObject);
+          expect(onChange).toBeCalledWith(eventObject);
+        });
       });
     });
   });

--- a/src/components/TextInput/TextInput-test.js
+++ b/src/components/TextInput/TextInput-test.js
@@ -11,250 +11,186 @@ import { mount, shallow } from 'enzyme';
 
 describe('TextInput', () => {
   describe('renders as expected', () => {
-    const variations = [
+    const wrapper = mount(
       <TextInput
         id="test"
         className="extra-class"
         labelText="testlabel"
         helperText="testHelper"
         light
-      />,
-      <TextInput.PasswordInput
-        id="test"
-        className="extra-class"
-        labelText="testlabel"
-        helperText="testHelper"
-        light
-      />,
-      <TextInput.ControlledPasswordInput
-        id="test"
-        className="extra-class"
-        labelText="testlabel"
-        helperText="testHelper"
-        light
-      />,
-    ];
-    variations.forEach(variation => {
-      const wrapper = mount(variation);
-      const textInput = () => wrapper.find('input');
+      />
+    );
 
-      describe('input', () => {
-        it('renders as expected', () => {
-          expect(textInput().length).toBe(1);
-        });
+    const textInput = () => wrapper.find('input');
 
-        it('should accept refs', () => {
-          class MyComponent extends React.Component {
-            constructor(props) {
-              super(props);
-              this.textInput = React.createRef();
-              this.focus = this.focus.bind(this);
-            }
-            focus() {
-              this.textInput.current.focus();
-            }
-            render() {
-              return (
-                <TextInput
-                  id="test"
-                  labelText="testlabel"
-                  ref={this.textInput}
-                />
-              );
-            }
+    describe('input', () => {
+      it('renders as expected', () => {
+        expect(textInput().length).toBe(1);
+      });
+
+      it('should accept refs', () => {
+        class MyComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.textInput = React.createRef();
+            this.focus = this.focus.bind(this);
           }
-          const wrapper = mount(<MyComponent />);
-          expect(document.activeElement.type).toBeUndefined();
-          wrapper.instance().focus();
-          expect(document.activeElement.type).toEqual('text');
-        });
-
-        it('has the expected classes', () => {
-          expect(textInput().hasClass('bx--text-input')).toEqual(true);
-        });
-
-        it('should add extra classes that are passed via className', () => {
-          expect(textInput().hasClass('extra-class')).toEqual(true);
-        });
-
-        it('has the expected classes for light', () => {
-          wrapper.setProps({ light: true });
-          expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
-        });
-
-        it('should set type as expected', () => {
-          expect(['text', 'password']).toContain(textInput().props().type);
-          wrapper.setProps({ type: 'email' });
-          expect(textInput().props().type).toEqual('email');
-        });
-
-        it('should set value as expected', () => {
-          expect(textInput().props().defaultValue).toEqual(undefined);
-          wrapper.setProps({ defaultValue: 'test' });
-          expect(textInput().props().defaultValue).toEqual('test');
-        });
-
-        it('should set disabled as expected', () => {
-          expect(textInput().props().disabled).toEqual(false);
-          wrapper.setProps({ disabled: true });
-          expect(textInput().props().disabled).toEqual(true);
-        });
-
-        it('should set placeholder as expected', () => {
-          expect(textInput().props().placeholder).not.toBeDefined();
-          wrapper.setProps({ placeholder: 'Enter text' });
-          expect(textInput().props().placeholder).toEqual('Enter text');
-        });
+          focus() {
+            this.textInput.current.focus();
+          }
+          render() {
+            return (
+              <TextInput id="test" labelText="testlabel" ref={this.textInput} />
+            );
+          }
+        }
+        const wrapper = mount(<MyComponent />);
+        expect(document.activeElement.type).toBeUndefined();
+        wrapper.instance().focus();
+        expect(document.activeElement.type).toEqual('text');
       });
 
-      describe('label', () => {
-        wrapper.setProps({ labelText: 'Email Input' });
-        const renderedLabel = wrapper.find('label');
-
-        it('renders a label', () => {
-          expect(renderedLabel.length).toBe(1);
-        });
-
-        it('has the expected classes', () => {
-          expect(renderedLabel.hasClass('bx--label')).toEqual(true);
-        });
-
-        it('should set label as expected', () => {
-          expect(renderedLabel.text()).toEqual('Email Input');
-        });
+      it('has the expected classes', () => {
+        expect(textInput().hasClass('bx--text-input')).toEqual(true);
       });
 
-      describe('helper', () => {
-        it('renders a helper', () => {
-          const renderedHelper = wrapper.find('.bx--form__helper-text');
-          expect(renderedHelper.length).toEqual(1);
-        });
+      it('should add extra classes that are passed via className', () => {
+        expect(textInput().hasClass('extra-class')).toEqual(true);
+      });
 
-        it('renders children as expected', () => {
-          wrapper.setProps({
-            helperText: (
-              <span>
-                This helper text has <a href="/">a link</a>.
-              </span>
-            ),
-          });
-          const renderedHelper = wrapper.find('.bx--form__helper-text');
-          expect(renderedHelper.props().children).toEqual(
+      it('has the expected classes for light', () => {
+        wrapper.setProps({ light: true });
+        expect(textInput().hasClass('bx--text-input--light')).toEqual(true);
+      });
+
+      it('should set type as expected', () => {
+        expect(textInput().props().type).toEqual('text');
+        wrapper.setProps({ type: 'email' });
+        expect(textInput().props().type).toEqual('email');
+      });
+
+      it('should set value as expected', () => {
+        expect(textInput().props().defaultValue).toEqual(undefined);
+        wrapper.setProps({ defaultValue: 'test' });
+        expect(textInput().props().defaultValue).toEqual('test');
+      });
+
+      it('should set disabled as expected', () => {
+        expect(textInput().props().disabled).toEqual(false);
+        wrapper.setProps({ disabled: true });
+        expect(textInput().props().disabled).toEqual(true);
+      });
+
+      it('should set placeholder as expected', () => {
+        expect(textInput().props().placeholder).not.toBeDefined();
+        wrapper.setProps({ placeholder: 'Enter text' });
+        expect(textInput().props().placeholder).toEqual('Enter text');
+      });
+    });
+
+    describe('label', () => {
+      wrapper.setProps({ labelText: 'Email Input' });
+      const renderedLabel = wrapper.find('label');
+
+      it('renders a label', () => {
+        expect(renderedLabel.length).toBe(1);
+      });
+
+      it('has the expected classes', () => {
+        expect(renderedLabel.hasClass('bx--label')).toEqual(true);
+      });
+
+      it('should set label as expected', () => {
+        expect(renderedLabel.text()).toEqual('Email Input');
+      });
+    });
+
+    describe('helper', () => {
+      it('renders a helper', () => {
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.length).toEqual(1);
+      });
+
+      it('renders children as expected', () => {
+        wrapper.setProps({
+          helperText: (
             <span>
-              This helper text has <a href="/">a link</a>.
+              This helper text has <a href="#">a link</a>.
             </span>
-          );
+          ),
         });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.props().children).toEqual(
+          <span>
+            This helper text has <a href="#">a link</a>.
+          </span>
+        );
+      });
 
-        it('should set helper text as expected', () => {
-          wrapper.setProps({ helperText: 'Helper text' });
-          const renderedHelper = wrapper.find('.bx--form__helper-text');
-          expect(renderedHelper.text()).toEqual('Helper text');
-        });
+      it('should set helper text as expected', () => {
+        wrapper.setProps({ helperText: 'Helper text' });
+        const renderedHelper = wrapper.find('.bx--form__helper-text');
+        expect(renderedHelper.text()).toEqual('Helper text');
       });
     });
   });
 
   describe('events', () => {
-    const onClick = jest.fn();
-    const onChange = jest.fn();
     describe('disabled textinput', () => {
-      const variations = [
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
         <TextInput
           id="test"
-          className="extra-class"
           labelText="testlabel"
-          helperText="testHelper"
           onClick={onClick}
           onChange={onChange}
           disabled
-          light
-        />,
-        <TextInput.PasswordInput
-          id="test"
-          className="extra-class"
-          labelText="testlabel"
-          helperText="testHelper"
-          onClick={onClick}
-          onChange={onChange}
-          disabled
-          light
-        />,
-        <TextInput.ControlledPasswordInput
-          id="test"
-          className="extra-class"
-          labelText="testlabel"
-          helperText="testHelper"
-          onClick={onClick}
-          onChange={onChange}
-          disabled
-          light
-        />,
-      ];
-      variations.forEach(variation => {
-        const wrapper = shallow(variation);
-        const input = wrapper.find('input');
+        />
+      );
 
-        it('should not invoke onClick', () => {
-          input.simulate('click');
-          expect(onClick).not.toBeCalled();
-        });
+      const input = wrapper.find('input');
 
-        it('should not invoke onChange', () => {
-          input.simulate('change');
-          expect(onChange).not.toBeCalled();
-        });
+      it('should not invoke onClick', () => {
+        input.simulate('click');
+        expect(onClick).not.toBeCalled();
+      });
+
+      it('should not invoke onChange', () => {
+        input.simulate('change');
+        expect(onChange).not.toBeCalled();
       });
     });
 
     describe('enabled textinput', () => {
-      const variations = [
+      const onClick = jest.fn();
+      const onChange = jest.fn();
+
+      const wrapper = shallow(
         <TextInput
-          id="test"
-          className="extra-class"
           labelText="testlabel"
-          helperText="testHelper"
+          id="test"
           onClick={onClick}
           onChange={onChange}
-          light
-        />,
-        <TextInput.PasswordInput
-          id="test"
-          className="extra-class"
-          labelText="testlabel"
-          helperText="testHelper"
-          onClick={onClick}
-          onChange={onChange}
-          light
-        />,
-        <TextInput.ControlledPasswordInput
-          id="test"
-          className="extra-class"
-          labelText="testlabel"
-          helperText="testHelper"
-          onClick={onClick}
-          onChange={onChange}
-          light
-        />,
-      ];
-      variations.forEach(variation => {
-        const wrapper = shallow(variation);
-        const input = wrapper.find('input');
-        const eventObject = {
-          target: {
-            defaultValue: 'test',
-          },
-        };
+        />
+      );
 
-        it('should invoke onClick when input is clicked', () => {
-          input.simulate('click');
-          expect(onClick).toBeCalled();
-        });
+      const input = wrapper.find('input');
+      const eventObject = {
+        target: {
+          defaultValue: 'test',
+        },
+      };
 
-        it('should invoke onChange when input value is changed', () => {
-          input.simulate('change', eventObject);
-          expect(onChange).toBeCalledWith(eventObject);
-        });
+      it('should invoke onClick when input is clicked', () => {
+        input.simulate('click');
+        expect(onClick).toBeCalled();
+      });
+
+      it('should invoke onChange when input value is changed', () => {
+        input.simulate('change', eventObject);
+        expect(onChange).toBeCalledWith(eventObject);
       });
     });
   });

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -172,10 +172,6 @@ TextInput.propTypes = {
    * Specify light version or default version of this control
    */
   light: PropTypes.bool,
-  /**
-   * Specify whether or not password visibility toggle is added
-   */
-  passwordVisibilityToggle: PropTypes.bool,
 };
 
 TextInput.defaultProps = {
@@ -187,5 +183,4 @@ TextInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
-  passwordVisibilityToggle: false,
 };

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -109,80 +109,67 @@ const TextInput = React.forwardRef(function TextInput(
 
 TextInput.propTypes = {
   /**
-   * Specify an optional className to be applied to the <input> node
+   * Provide a custom className that is applied directly to the underlying
+   * <input> node
    */
   className: PropTypes.string,
-
   /**
    * Optionally provide the default value of the <input>
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
   /**
-   * Specify whether the <input> should be disabled
+   * Specify whether the control is disabled
    */
   disabled: PropTypes.bool,
-
   /**
-   * Specify a custom `id` for the <input>
+   * Provide a unique identifier for the input field
    */
   id: PropTypes.string.isRequired,
-
   /**
    * Provide the text that will be read by a screen reader when visiting this
    * control
    */
   labelText: PropTypes.node.isRequired,
-
   /**
    * Optionally provide an `onChange` handler that is called whenever <input>
    * is updated
    */
   onChange: PropTypes.func,
-
   /**
    * Optionally provide an `onClick` handler that is called whenever the
    * <input> is clicked
    */
   onClick: PropTypes.func,
-
   /**
    * Specify the placeholder attribute for the <input>
    */
   placeholder: PropTypes.string,
-
   /**
-   * Specify the type of the <input>
+   * Specify the type attribute for the <input>
    */
   type: PropTypes.string,
-
   /**
-   * Specify the value of the <input>
+   * Provide the current value of the <input>
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
   /**
-   * Specify whether you want the underlying label to be visually hidden
+   * Specify whether or not the underlying label is visually hidden
    */
   hideLabel: PropTypes.bool,
-
   /**
    * Specify whether the control is currently invalid
    */
   invalid: PropTypes.bool,
-
   /**
    * Provide the text that is displayed when the control is in an invalid state
    */
   invalidText: PropTypes.string,
-
   /**
    * Provide text that is used alongside the control label for additional help
    */
   helperText: PropTypes.node,
-
   /**
-   * `true` to use the light version.
+   * Specify light version or default version of this control
    */
   light: PropTypes.bool,
 };

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -172,6 +172,10 @@ TextInput.propTypes = {
    * Specify light version or default version of this control
    */
   light: PropTypes.bool,
+  /**
+   * Specify whether or not password visibility toggle is added
+   */
+  passwordVisibilityToggle: PropTypes.bool,
 };
 
 TextInput.defaultProps = {
@@ -183,6 +187,5 @@ TextInput.defaultProps = {
   invalidText: '',
   helperText: '',
   light: false,
+  passwordVisibilityToggle: false,
 };
-
-export default TextInput;

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -101,67 +101,80 @@ TextInput.PasswordInput = PasswordInput;
 TextInput.ControlledPasswordInput = ControlledPasswordInput;
 TextInput.propTypes = {
   /**
-   * Provide a custom className that is applied directly to the underlying
-   * <input> node
+   * Specify an optional className to be applied to the <input> node
    */
   className: PropTypes.string,
+
   /**
    * Optionally provide the default value of the <input>
    */
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
   /**
-   * Specify whether the control is disabled
+   * Specify whether the <input> should be disabled
    */
   disabled: PropTypes.bool,
+
   /**
-   * Provide a unique identifier for the input field
+   * Specify a custom `id` for the <input>
    */
   id: PropTypes.string.isRequired,
+
   /**
    * Provide the text that will be read by a screen reader when visiting this
    * control
    */
   labelText: PropTypes.node.isRequired,
+
   /**
    * Optionally provide an `onChange` handler that is called whenever <input>
    * is updated
    */
   onChange: PropTypes.func,
+
   /**
    * Optionally provide an `onClick` handler that is called whenever the
    * <input> is clicked
    */
   onClick: PropTypes.func,
+
   /**
    * Specify the placeholder attribute for the <input>
    */
   placeholder: PropTypes.string,
+
   /**
-   * Specify the type attribute for the <input>
+   * Specify the type of the <input>
    */
   type: PropTypes.string,
+
   /**
-   * Provide the current value of the <input>
+   * Specify the value of the <input>
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
   /**
-   * Specify whether or not the underlying label is visually hidden
+   * Specify whether you want the underlying label to be visually hidden
    */
   hideLabel: PropTypes.bool,
+
   /**
    * Specify whether the control is currently invalid
    */
   invalid: PropTypes.bool,
+
   /**
    * Provide the text that is displayed when the control is in an invalid state
    */
   invalidText: PropTypes.string,
+
   /**
    * Provide text that is used alongside the control label for additional help
    */
   helperText: PropTypes.node,
+
   /**
-   * Specify light version or default version of this control
+   * `true` to use the light version.
    */
   light: PropTypes.bool,
 };

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -10,9 +10,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { settings } from 'carbon-components';
 import WarningFilled16 from '@carbon/icons-react/lib/warning--filled/16';
+import PasswordInput from './PasswordInput';
+import ControlledPasswordInput from './ControlledPasswordInput';
+import { textInputProps } from './util';
 
 const { prefix } = settings;
-
 const TextInput = React.forwardRef(function TextInput(
   {
     labelText,
@@ -31,7 +33,12 @@ const TextInput = React.forwardRef(function TextInput(
   },
   ref
 ) {
-  const textInputProps = {
+  const errorId = id + '-error-msg';
+  const textInputClasses = classNames(`${prefix}--text-input`, className, {
+    [`${prefix}--text-input--light`]: light,
+    [`${prefix}--text-input--invalid`]: invalid,
+  });
+  const sharedTextInputProps = {
     id,
     onChange: evt => {
       if (!other.disabled) {
@@ -46,13 +53,9 @@ const TextInput = React.forwardRef(function TextInput(
     placeholder,
     type,
     ref,
+    className: textInputClasses,
+    ...other,
   };
-
-  const errorId = id + '-error-msg';
-  const textInputClasses = classNames(`${prefix}--text-input`, className, {
-    [`${prefix}--text-input--light`]: light,
-    [`${prefix}--text-input--invalid`]: invalid,
-  });
   const labelClasses = classNames(`${prefix}--label`, {
     [`${prefix}--visually-hidden`]: hideLabel,
     [`${prefix}--label--disabled`]: other.disabled,
@@ -60,38 +63,25 @@ const TextInput = React.forwardRef(function TextInput(
   const helperTextClasses = classNames(`${prefix}--form__helper-text`, {
     [`${prefix}--form__helper-text--disabled`]: other.disabled,
   });
-
   const label = labelText ? (
     <label htmlFor={id} className={labelClasses}>
       {labelText}
     </label>
   ) : null;
-
   const error = invalid ? (
     <div className={`${prefix}--form-requirement`} id={errorId}>
       {invalidText}
     </div>
   ) : null;
-
-  const input = invalid ? (
-    <input
-      {...other}
-      {...textInputProps}
-      data-invalid
-      aria-invalid
-      aria-describedby={errorId}
-      className={textInputClasses}
-    />
-  ) : (
-    <input {...other} {...textInputProps} className={textInputClasses} />
+  const input = (
+    <input {...textInputProps({ invalid, sharedTextInputProps, errorId })} />
   );
-
   const helper = helperText ? (
     <div className={helperTextClasses}>{helperText}</div>
   ) : null;
 
   return (
-    <div className={(`${prefix}--form-item`, `${prefix}--text-input-wrapper`)}>
+    <div className={`${prefix}--form-item ${prefix}--text-input-wrapper`}>
       {label}
       {helper}
       <div
@@ -107,6 +97,8 @@ const TextInput = React.forwardRef(function TextInput(
   );
 });
 
+TextInput.PasswordInput = PasswordInput;
+TextInput.ControlledPasswordInput = ControlledPasswordInput;
 TextInput.propTypes = {
   /**
    * Provide a custom className that is applied directly to the underlying
@@ -184,3 +176,5 @@ TextInput.defaultProps = {
   helperText: '',
   light: false,
 };
+
+export default TextInput;

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -6,4 +6,6 @@
  */
 
 export * from './TextInput.Skeleton';
+export ControlledPasswordInput from './ControlledPasswordInput';
+export PasswordInput from './PasswordInput';
 export default from './TextInput';

--- a/src/components/TextInput/util.js
+++ b/src/components/TextInput/util.js
@@ -1,0 +1,10 @@
+const invalidProps = ({ invalid, errorId }) => ({
+  'data-invalid': invalid,
+  'aria-invalid': invalid,
+  'aria-describedby': errorId,
+});
+
+export const textInputProps = ({ invalid, sharedTextInputProps, errorId }) => ({
+  ...sharedTextInputProps,
+  ...(invalid ? invalidProps({ invalid, errorId }) : {}),
+});

--- a/src/components/TextInput/util.js
+++ b/src/components/TextInput/util.js
@@ -12,8 +12,14 @@ export const textInputProps = ({ invalid, sharedTextInputProps, errorId }) => ({
 export const togglePasswordVisibilityIconProps = ({
   passwordIsVisible,
   alt,
+  hidePasswordText = 'Hide',
+  showPasswordText = 'Show',
 }) => ({
-  alt: alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+  alt:
+    alt ||
+    `${passwordIsVisible ? hidePasswordText : showPasswordText} password`,
   name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
-  description: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+  description: `${
+    passwordIsVisible ? hidePasswordText : showPasswordText
+  } password`,
 });

--- a/src/components/TextInput/util.js
+++ b/src/components/TextInput/util.js
@@ -8,18 +8,3 @@ export const textInputProps = ({ invalid, sharedTextInputProps, errorId }) => ({
   ...sharedTextInputProps,
   ...(invalid ? invalidProps({ invalid, errorId }) : {}),
 });
-
-export const togglePasswordVisibilityIconProps = ({
-  passwordIsVisible,
-  alt,
-  hidePasswordText = 'Hide',
-  showPasswordText = 'Show',
-}) => ({
-  alt:
-    alt ||
-    `${passwordIsVisible ? hidePasswordText : showPasswordText} password`,
-  name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
-  description: `${
-    passwordIsVisible ? hidePasswordText : showPasswordText
-  } password`,
-});

--- a/src/components/TextInput/util.js
+++ b/src/components/TextInput/util.js
@@ -8,3 +8,12 @@ export const textInputProps = ({ invalid, sharedTextInputProps, errorId }) => ({
   ...sharedTextInputProps,
   ...(invalid ? invalidProps({ invalid, errorId }) : {}),
 });
+
+export const togglePasswordVisibilityIconProps = ({
+  passwordIsVisible,
+  alt,
+}) => ({
+  alt: alt || `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+  name: `visibility-${passwordIsVisible ? 'off' : 'on'}`,
+  description: `${passwordIsVisible ? 'Hide' : 'Show'} password`,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,7 +3671,7 @@ carbon-components@^10.2.0:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-icons@^7.0.5, carbon-icons@^7.0.7:
+carbon-icons@^7.0.7:
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/carbon-icons/-/carbon-icons-7.0.7.tgz#ebafe3e9fa25df973796a8eca06d8a7c501cc610"
   integrity sha512-3vgkdXJRgCViCrH3fLUdyAXo0I8wmohO6QETv7vWFx6yc7s+SirWFBSFL38zUx4MHtR8iTxIlLEzkeU6FlFtXg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,7 +3671,7 @@ carbon-components@^10.2.0:
     lodash.debounce "^4.0.8"
     warning "^3.0.0"
 
-carbon-icons@^7.0.7:
+carbon-icons@^7.0.5, carbon-icons@^7.0.7:
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/carbon-icons/-/carbon-icons-7.0.7.tgz#ebafe3e9fa25df973796a8eca06d8a7c501cc610"
   integrity sha512-3vgkdXJRgCViCrH3fLUdyAXo0I8wmohO6QETv7vWFx6yc7s+SirWFBSFL38zUx4MHtR8iTxIlLEzkeU6FlFtXg==


### PR DESCRIPTION
Closes IBM/carbon-components-react#1033

This PR will add the password visibility toggle button to `<TextInput>`

Related: IBM/carbon-components#1058 and IBM/carbon-components#1060

#### Changelog

**New**

* controlled and uncontrolled text inputs with password visibility toggles
* helper functions for text input and password input components
* storybook examples
* tests for password visibility toggle `<TextInput>`