### PR TITLE
docs(OverflowMenu): note on children

### DIFF
--- a/src/components/OverflowMenu/README.md
+++ b/src/components/OverflowMenu/README.md
@@ -49,3 +49,11 @@ There are two important React props:
 - `primaryFocus` in `OverflowMenuItem`: This is required for the menu item you put keyboard focus on when `OverflowMenu` gets open
 
 Please refer to [our Storybook](http://react.carbondesignsystem.com/?selectedKind=OverflowMenu&selectedStory=basic) for more details.
+
+## Note about `<OverflowMenu>` children
+
+Make sure children of `<OverflowMenu>` are React components that accepts `ref` as its children - Typically `<OverflowMenuItem>`. Otherwise, you'll get an error like:
+
+```
+Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+```

--- a/src/components/OverflowMenu/README.md
+++ b/src/components/OverflowMenu/README.md
@@ -52,7 +52,7 @@ Please refer to [our Storybook](http://react.carbondesignsystem.com/?selectedKin
 
 ## Note about `<OverflowMenu>` children
 
-Make sure children of `<OverflowMenu>` are React components that accepts `ref` as its children - Typically `<OverflowMenuItem>`. Otherwise, you'll get an error like:
+Make sure the children of `<OverflowMenu>` are React components that accept `ref` as their children - Typically `<OverflowMenuItem>`. Otherwise, you'll get an error like:
 
 ```
 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?


### PR DESCRIPTION
Closes #1924.

#### Changelog

**New**

- `README.md` content for `<OverflowMenu>` mentioning that the `children` has to accept `ref`.