### PR TITLE
fix(MultiSelect): close MultiSelect after any option is selected/unselected

### DIFF
--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -84,10 +84,21 @@ export default class MultiSelect extends React.Component {
     }
   };
 
-  handleOnToggleMenu = () => {
-    this.setState(state => ({
-      isOpen: !state.isOpen,
-    }));
+  handleOnToggleMenu = changes => {
+    this.setState(() => {
+      let nextIsOpen = changes.isOpen;
+      // If Downshift is trying to close the menu, but we know the input
+      // is the active element in the document, then keep the menu open
+      if (
+        changes.isOpen === false &&
+        this.inputNode === document.activeElement
+      ) {
+        nextIsOpen = true;
+      }
+      return {
+        isOpen: nextIsOpen,
+      };
+    });
   };
 
   handleOnOuterClick = () => {
@@ -113,7 +124,7 @@ export default class MultiSelect extends React.Component {
       // Reference: https://github.com/paypal/downshift/issues/206
       case Downshift.stateChangeTypes.clickButton:
       case Downshift.stateChangeTypes.keyDownSpaceButton:
-        this.handleOnToggleMenu();
+        this.handleOnToggleMenu(changes);
         break;
     }
   };

--- a/src/components/MultiSelect/__tests__/MultiSelect-test.js
+++ b/src/components/MultiSelect/__tests__/MultiSelect-test.js
@@ -31,9 +31,9 @@ describe('MultiSelect', () => {
       const items = generateItems(5, generateGenericItem);
       const wrapper = mount(<MultiSelect label="Field" items={items} />);
       expect(wrapper.state('isOpen')).toBe(false);
-      wrapper.instance().handleOnToggleMenu();
+      wrapper.find('.bx--list-box__field').simulate('click');
       expect(wrapper.state('isOpen')).toBe(true);
-      wrapper.instance().handleOnToggleMenu();
+      wrapper.find('.bx--list-box__field').simulate('click');
       expect(wrapper.state('isOpen')).toBe(false);
     });
   });


### PR DESCRIPTION
This is integrating work in a fix on v6 to v5. Same bugfix was released in v6 as the following issue https://github.com/carbon-design-system/carbon-components-react/pull/1021/files#diff-d5a233582a5bb13fa38d69fe8692b324. The one discrepency between that fix and this is I combined the if conditions.

@marijohannessen noticed you merged the v6 fix for this issue, if you could give this a review would appreciate

Closes IBM/carbon-components-react#

{{short description}}

#### Changelog

**Changed**

- {{MultiSelect handleOnToggleMenu method and related tests}}
