### PR TITLE
fix(tag): update reduce method in story

### DIFF
--- a/src/components/Tag/Tag-story.js
+++ b/src/components/Tag/Tag-story.js
@@ -12,8 +12,8 @@ import Tag, { types as typesList } from '../Tag';
 import TagSkeleton from '../Tag/Tag.Skeleton';
 
 const types = typesList.reduce(
-  (o, type) => ({
-    ...o,
+  (accumulator, type) => ({
+    ...accumulator,
     [`${type} (${type})`]: type,
   }),
   {}

--- a/src/components/Tag/Tag-story.js
+++ b/src/components/Tag/Tag-story.js
@@ -12,7 +12,7 @@ import Tag, { types as typesList } from '../Tag';
 import TagSkeleton from '../Tag/Tag.Skeleton';
 
 const types = typesList.reduce(
-  (accumulator, type) => ({
+  (acc, type) => ({
     ...accumulator,
     [`${type} (${type})`]: type,
   }),


### PR DESCRIPTION
Small thing --

I wanted to suggest updating the first argument in the `reduce` method here from `o` to `accumulator`. I think that in a case where there's nothing relevant to name the accumulator, it would be best to just use a default / recognizable word to help with readability. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Syntax

#### Changelog

**Changed**

- change first argument of `reduce` method from `o` to `accumulator`
