### PR TITLE
fix: added the legend to TileGroup, resolves #2358

### DIFF
--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -111,6 +111,12 @@ export default class TileGroup extends React.Component {
     }
   };
 
+  renderLegend = legend => {
+    if (legend) {
+      return <legend>{legend}</legend>;
+    }
+  };
+
   render() {
     const {
       disabled,
@@ -119,7 +125,8 @@ export default class TileGroup extends React.Component {
     } = this.props;
 
     return (
-      <fieldset className={className} disabled={disabled} legend={legend}>
+      <fieldset className={className} disabled={disabled}>
+        {this.renderLegend(legend)}
         {this.getRadioTiles()}
       </fieldset>
     );

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -107,10 +107,14 @@ export default class TileGroup extends React.Component {
   };
 
   render() {
-    const { disabled, className = `${prefix}--tile-group` } = this.props;
+    const {
+      disabled,
+      className = `${prefix}--tile-group`,
+      legend,
+    } = this.props;
 
     return (
-      <fieldset className={className} disabled={disabled}>
+      <fieldset className={className} disabled={disabled} legend={legend}>
         {this.getRadioTiles()}
       </fieldset>
     );

--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -52,6 +52,11 @@ export default class TileGroup extends React.Component {
     onChange: PropTypes.func,
 
     /**
+     * Provide an optional legend for this group
+     */
+    legend: PropTypes.string,
+
+    /**
      * Specify the value that is currently selected in the group
      */
     valueSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
Closes IBM/carbon-components-react#2358

Adds the legend attribute to the TileGroup if it was set by the calling code.