### PR TITLE
 chore(release): v5.53.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-components-react",
-  "version": "5.52.5",
+  "version": "5.53.1",
   "description": "A React wrapper for carbon-components",
   "license": "Apache-2",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "sideEffects": false,
+  "publishConfig": {
+    "tag": "5.x"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
Turns out the latest version is actually [5.53.0](https://www.npmjs.com/package/carbon-components-react/v/5.53.0), so this is bumping on the latest version 👍 This also adds in a `publishConfig.tag` config to prevent accidentally publishing to latest.