### PR TITLE
feat(tile-group): add legend to TileGroup, resolves #2358 (#2359)

### DIFF
--- a/src/components/TileGroup/TileGroup.js
+++ b/src/components/TileGroup/TileGroup.js
@@ -52,6 +52,11 @@ export default class TileGroup extends React.Component {
     onChange: PropTypes.func,
 
     /**
+     * Provide an optional legend for this group
+     */
+    legend: PropTypes.string,
+
+    /**
      * Specify the value that is currently selected in the group
      */
     valueSelected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -106,11 +111,22 @@ export default class TileGroup extends React.Component {
     }
   };
 
+  renderLegend = legend => {
+    if (legend) {
+      return <legend>{legend}</legend>;
+    }
+  };
+
   render() {
-    const { disabled, className = `${prefix}--tile-group` } = this.props;
+    const {
+      disabled,
+      className = `${prefix}--tile-group`,
+      legend,
+    } = this.props;
 
     return (
       <fieldset className={className} disabled={disabled}>
+        {this.renderLegend(legend)}
         {this.getRadioTiles()}
       </fieldset>
     );


### PR DESCRIPTION
Cherry picked the fix from https://github.com/carbon-design-system/carbon-components-react/pull/2359 to the `v6` branch