### PR TITLE
fix(downshift): allow passing props to Downshift

### DIFF
--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -146,6 +146,11 @@ export default class ComboBox extends React.Component {
      * should use "light theme" (white background)?
      */
     light: PropTypes.bool,
+
+    /**
+     * Additional props passed to Downshift
+     */
+    downshiftProps: Downshift.propTypes,
   };
 
   static defaultProps = {
@@ -237,6 +242,7 @@ export default class ComboBox extends React.Component {
       shouldFilterItem, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
       onInputChange, // eslint-disable-line no-unused-vars
+      downshiftProps,
       ...rest
     } = this.props;
     const className = cx(`${prefix}--combo-box`, containerClassName);
@@ -257,6 +263,7 @@ export default class ComboBox extends React.Component {
     const wrapperClasses = cx(`${prefix}--list-box__wrapper`);
     const input = (
       <Downshift
+        {...downshiftProps}
         onChange={this.handleOnChange}
         onInputValueChange={this.handleOnInputValueChange}
         inputValue={this.state.inputValue || ''}

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -126,6 +126,11 @@ export default class Dropdown extends React.Component {
      * additional help
      */
     helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+    /**
+     * Additional props passed to Downshift
+     */
+    downshiftProps: Downshift.propTypes,
   };
 
   static defaultProps = {
@@ -163,6 +168,7 @@ export default class Dropdown extends React.Component {
       light,
       invalid,
       invalidText,
+      downshiftProps,
     } = this.props;
     const inline = type === 'inline';
     const className = ({ isOpen }) =>
@@ -205,6 +211,7 @@ export default class Dropdown extends React.Component {
         {title}
         {!inline && helper}
         <Downshift
+          {...downshiftProps}
           onChange={this.handleOnChange}
           itemToString={itemToString}
           defaultSelectedItem={initialSelectedItem}

--- a/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/src/components/MultiSelect/FilterableMultiSelect.js
@@ -114,6 +114,11 @@ export default class FilterableMultiSelect extends React.Component {
      * Callback function for translating ListBoxMenuIcon SVG title
      */
     translateWithId: PropTypes.func,
+
+    /**
+     * Additional props passed to Downshift
+     */
+    downshiftProps: Downshift.propTypes,
   };
 
   static getDerivedStateFromProps({ open }, state) {
@@ -262,6 +267,7 @@ export default class FilterableMultiSelect extends React.Component {
       invalidText,
       useTitleInItem,
       translateWithId,
+      downshiftProps,
     } = this.props;
     const inline = type === 'inline';
     const wrapperClasses = cx(
@@ -295,6 +301,7 @@ export default class FilterableMultiSelect extends React.Component {
         initialSelectedItems={initialSelectedItems}
         render={({ selectedItems, onItemChange, clearSelection }) => (
           <Downshift
+            {...downshiftProps}
             highlightedIndex={highlightedIndex}
             isOpen={isOpen}
             inputValue={inputValue}

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -115,6 +115,11 @@ export default class MultiSelect extends React.Component {
      * `top-after-reopen`: selected item jump to top after reopen dropdown
      */
     selectionFeedback: PropTypes.oneOf(['top', 'fixed', 'top-after-reopen']),
+
+    /**
+     * Additional props passed to Downshift
+     */
+    downshiftProps: Downshift.propTypes,
   };
 
   static getDerivedStateFromProps({ open }, state) {
@@ -226,6 +231,7 @@ export default class MultiSelect extends React.Component {
       invalidText,
       useTitleInItem,
       translateWithId,
+      downshiftProps,
     } = this.props;
     const inline = type === 'inline';
     const wrapperClasses = cx(
@@ -261,6 +267,7 @@ export default class MultiSelect extends React.Component {
         initialSelectedItems={initialSelectedItems}
         render={({ selectedItems, onItemChange, clearSelection }) => (
           <Downshift
+            {...downshiftProps}
             highlightedIndex={highlightedIndex}
             isOpen={isOpen}
             itemToString={itemToString}


### PR DESCRIPTION
This change will allow users to pass additional props to Downshift. This is useful for when for example the app is running in a shadowRoot and the user needs to pass an `environment` to Downshift (which is an issue I'm currently running into)

See downshift-js/downshift#536

#### Changelog

**New**

**Changed**

The following files have the same changes applied to them:
- Combobox.js
- Dropdown.js
- FilterableMultiselect.js
- Multiselect

Added optional prop `downshiftProps` which is merged with component's own Downshift props (component's props take precedence) and passed to Downshift.

**Removed**

