### PR TITLE
fix(ListBox): remove default inner tab index

### DIFF
--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -74,7 +74,7 @@ exports[`DropdownV2 should render 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="listbox"
-        tabIndex={0}
+        tabIndex={null}
       >
         <ListBoxField
           aria-expanded={false}
@@ -248,7 +248,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="listbox"
-        tabIndex={0}
+        tabIndex={null}
       >
         <ListBoxField
           aria-expanded={true}
@@ -663,7 +663,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="listbox"
-        tabIndex={0}
+        tabIndex={null}
       >
         <ListBoxField
           aria-expanded={true}
@@ -970,7 +970,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
         onClick={[Function]}
         onKeyDown={[Function]}
         role="listbox"
-        tabIndex={0}
+        tabIndex={null}
       >
         <ListBoxField
           aria-expanded={true}

--- a/src/components/ListBox/ListBox.js
+++ b/src/components/ListBox/ListBox.js
@@ -60,7 +60,7 @@ const ListBox = ({
         {...rest}
         role="listbox"
         aria-label={ariaLabel}
-        tabIndex={innerTabIndex || 0}
+        tabIndex={innerTabIndex || null}
         className={className}
         ref={innerRef}
         onKeyDown={handleOnKeyDown}

--- a/src/components/ListBox/__tests__/ListBox-test.js
+++ b/src/components/ListBox/__tests__/ListBox-test.js
@@ -57,8 +57,8 @@ describe('ListBox', () => {
     const wrapper = mount(<ListBox {...mockProps} />);
     expect(wrapper.children().prop('tabIndex')).toBe(-1);
   });
-  it('should default the inner divs tabIndex to 0 if no innerTabIndex prop', () => {
+  it('should default the inner divs tabIndex to `null` if no innerTabIndex prop', () => {
     const wrapper = mount(<ListBox {...mockProps} />);
-    expect(wrapper.children().prop('tabIndex')).toBe(0);
+    expect(wrapper.children().prop('tabIndex')).toBe(null);
   });
 });

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -13,7 +13,6 @@ exports[`ListBox should render 1`] = `
             aria-label="Choose an item"
             class="bx--list-box__container bx--list-box"
             role="listbox"
-            tabindex="0"
           >
             <div
               class="bx--list-box__field"
@@ -39,7 +38,7 @@ exports[`ListBox should render 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     role="listbox"
-    tabIndex={0}
+    tabIndex={null}
   >
     <ListBoxField>
       <div

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -84,7 +84,7 @@ exports[`MultiSelect should render 1`] = `
           onClick={[Function]}
           onKeyDown={[Function]}
           role="listbox"
-          tabIndex={0}
+          tabIndex={null}
         >
           <ListBoxField
             aria-expanded={false}


### PR DESCRIPTION
Closes #2373 
Closes #2374 
Closes #2375 

This PR removes the default listbox inner tabindex value by default

For the testers:

ensure that no extra tab stops exist when navigating the list box components (multiselect, filterable multiselect, dropdownv2, combobox)