### PR TITLE
feat: add menuOptionsClass to overflowMenu

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu-test.js
+++ b/src/components/OverflowMenu/OverflowMenu-test.js
@@ -110,7 +110,7 @@ describe('OverflowMenu', () => {
 
     it('should render a ul with the appropriate class', () => {
       const rootWrapper = mount(
-        <OverflowMenu>
+        <OverflowMenu menuOptionsClass="extra-menu-class">
           <div className="test-child" />
           <div className="test-child" />
         </OverflowMenu>
@@ -124,6 +124,7 @@ describe('OverflowMenu', () => {
       const list = rootWrapper.find('ul');
       expect(list.length).toEqual(1);
       expect(list.hasClass('bx--overflow-menu-options')).toEqual(true);
+      expect(list.hasClass('extra-menu-class')).toEqual(true);
     });
 
     it('should render children as expected', () => {

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -210,6 +210,11 @@ class OverflowMenu extends Component {
     className: PropTypes.string,
 
     /**
+     * The class to apply to the menu options
+     */
+    menuOptionsClass: PropTypes.string,
+
+    /**
      * The `tabindex` attribute.
      */
     tabIndex: PropTypes.number,
@@ -577,6 +582,7 @@ class OverflowMenu extends Component {
       onOpen, // eslint-disable-line
       renderIcon: IconElement,
       innerRef: ref,
+      menuOptionsClass,
       ...other
     } = this.props;
     const floatingMenu = !!breakingChangesX || origFloatingMenu;
@@ -617,7 +623,8 @@ class OverflowMenu extends Component {
       {
         [`${prefix}--overflow-menu--flip`]: this.props.flipped,
         [`${prefix}--overflow-menu-options--open`]: open,
-      }
+      },
+      menuOptionsClass
     );
 
     const overflowMenuIconClasses = classNames(


### PR DESCRIPTION
<!--
Hi there! This project has been moved over to:
https://github.com/carbon-design-system/carbon

Any pull requests made in this project should be migrated over to that location.
-->

Added a new property, `menuOptionsClass`, to `<OverflowMenu>`. This allows a class to be specified on the `<OverflowMenu>` props. This is particularly useful when `floatingMenu` is set, as the menu is appended to `<body>` and has no obvious selector. Fixes https://github.com/carbon-design-system/carbon/issues/2876.

This is a backport of #2174 from `carbon-components-react@7` to `carbon-components-react@6`.

I apologise for ignoring the comment saying that this PR should be opened against [https://github.com/carbon-design-system/carbon](https://github.com/carbon-design-system/carbon), but since I wasn't able to find any React components in [the `v9` tree](https://github.com/carbon-design-system/carbon/tree/v9) over there, I believe the old versions have not been ported over there, and the comment only applies to `master`. Do correct me if I'm wrong.

**Changelog**

**Changed**

Changed `<OverflowMenu>` to accept a new property `menuOptionsClass` and pass it down to the menu body.