### PR TITLE
fix(Modal): allow differnt roles for modal

### DIFF
--- a/src/components/ComposedModal/ComposedModal.js
+++ b/src/components/ComposedModal/ComposedModal.js
@@ -28,6 +28,7 @@ export default class ComposedModal extends Component {
   static defaultProps = {
     onKeyDown: () => {},
     selectorPrimaryFocus: '[data-modal-primary-focus]',
+    role: 'region',
   };
 
   outerModal = React.createRef();
@@ -67,6 +68,11 @@ export default class ComposedModal extends Component {
      * focused when the Modal opens
      */
     selectorPrimaryFocus: PropTypes.string,
+
+    /**
+     * Specify a role that best describe the purpose of the modal. Role should be one of the WAI-ARIA roles.
+     */
+    role: PropTypes.string,
   };
 
   static getDerivedStateFromProps({ open }, state) {
@@ -199,6 +205,7 @@ export default class ComposedModal extends Component {
       children,
       danger,
       selectorPrimaryFocus, // eslint-disable-line
+      role,
       ...other
     } = this.props;
 
@@ -241,7 +248,7 @@ export default class ComposedModal extends Component {
         onTransitionEnd={open ? this.handleTransitionEnd : undefined}
         className={modalClass}
         tabIndex={-1}>
-        <div ref={this.innerModal} className={containerClass}>
+        <div ref={this.innerModal} className={containerClass} role={role}>
           {childrenWithProps}
         </div>
       </div>

--- a/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal-test.js.snap
@@ -4,6 +4,7 @@ exports[`<ComposedModal /> renders 1`] = `
 <ComposedModal
   onKeyDown={[Function]}
   open={true}
+  role="region"
   selectorPrimaryFocus="[data-modal-primary-focus]"
 >
   <div
@@ -18,6 +19,7 @@ exports[`<ComposedModal /> renders 1`] = `
   >
     <div
       className="bx--modal-container"
+      role="region"
     />
   </div>
 </ComposedModal>


### PR DESCRIPTION
Issue:
- Current modal component has a accessibility checkpoint violation. `All content must reside within a WAI-ARIA landmark or labelled region role`
- The role "presentation" in the modal is not a WAI-ARIA role.

Details in: https://aat.w3ibm.mybluemix.net/token/98e2765a-de76-49d2-9f5c-605778089422/b7118222-21ab-441d-9037-25deacdefdf0/archives/2018AugustDeploy/doc/w3/help/en-US/idhi_accessibility_check_g1157.html

Solution:
- adding prop that allow modification of the role of the container so no more violation in the content of the modal