### PR TITLE
chore(release): v6.115.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-components-react",
-  "version": "6.115.3",
+  "version": "6.115.4",
   "description": "A React wrapper for carbon-components",
   "license": "Apache-2",
   "main": "lib/index.js",


### PR DESCRIPTION
fix `npm publish` outdated module issues and release v6.115.4