### PR TITLE
Add support for useTitleInItem (tooltip on hover) for carbon 9 (v6)

### DIFF
--- a/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/src/components/MultiSelect/FilterableMultiSelect.js
@@ -68,6 +68,11 @@ export default class FilterableMultiSelect extends React.Component {
     placeholder: PropTypes.string.isRequired,
 
     /**
+     *  Specify title to show title on hover
+     */
+    useTitleInItem: PropTypes.bool,
+
+    /**
      * `true` to use the light version.
      */
     light: PropTypes.bool,
@@ -219,6 +224,7 @@ export default class FilterableMultiSelect extends React.Component {
       sortItems,
       compareItems,
       light,
+      useTitleInItem,
       invalid,
       invalidText,
     } = this.props;
@@ -302,6 +308,7 @@ export default class FilterableMultiSelect extends React.Component {
                                 {...itemProps}>
                                 <Checkbox
                                   id={itemProps.id}
+                                  title={useTitleInItem ? itemText : null}
                                   name={itemText}
                                   checked={isChecked}
                                   readOnly={true}
@@ -335,6 +342,7 @@ export default class FilterableMultiSelect extends React.Component {
                               {...itemProps}>
                               <Checkbox
                                 id={itemProps.id}
+                                title={useTitleInItem ? itemText : null}
                                 name={itemText}
                                 checked={isChecked}
                                 readOnly={true}


### PR DESCRIPTION
- MultiSelect.Filterable doesn’t support `useTitleInItem` (tooltip on hover) #2328
- https://github.com/carbon-design-system/carbon-components-react/issues/2328

Ref: https://github.com/carbon-design-system/carbon-components-react/pull/2330
