### PR TITLE
fix(ListBox.Field): set aria-owns and aria-controls

### DIFF
--- a/src/components/DropdownV2/DropdownV2-test.js
+++ b/src/components/DropdownV2/DropdownV2-test.js
@@ -23,6 +23,7 @@ describe('DropdownV2', () => {
   let mockProps;
   beforeEach(() => {
     mockProps = {
+      id: 'test-dropdown',
       items: generateItems(5, generateGenericItem),
       onChange: jest.fn(),
       label: 'input',

--- a/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
+++ b/src/components/DropdownV2/__snapshots__/DropdownV2-test.js.snap
@@ -4,6 +4,7 @@ exports[`DropdownV2 should render 1`] = `
 <DropdownV2
   disabled={false}
   helperText=""
+  id="test-dropdown"
   itemToElement={null}
   itemToString={[Function]}
   items={
@@ -50,6 +51,7 @@ exports[`DropdownV2 should render 1`] = `
     defaultSelectedItem={null}
     environment={[Window]}
     getA11yStatusMessage={[Function]}
+    id="test-dropdown"
     itemToString={[Function]}
     onChange={[Function]}
     onInputValueChange={[Function]}
@@ -89,9 +91,11 @@ exports[`DropdownV2 should render 1`] = `
           type="button"
         >
           <div
+            aria-controls={null}
             aria-expanded={false}
             aria-haspopup={true}
             aria-label="open menu"
+            aria-owns={null}
             className="bx--list-box__field"
             data-toggle={true}
             disabled={false}
@@ -104,7 +108,7 @@ exports[`DropdownV2 should render 1`] = `
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-1-input"
+              htmlFor="test-dropdown-input"
             >
               input
             </span>
@@ -178,6 +182,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
 <DropdownV2
   disabled={false}
   helperText=""
+  id="test-dropdown"
   itemToElement={[Function]}
   itemToString={[Function]}
   items={
@@ -224,6 +229,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
     defaultSelectedItem={null}
     environment={[Window]}
     getA11yStatusMessage={[Function]}
+    id="test-dropdown"
     itemToString={[Function]}
     onChange={[Function]}
     onInputValueChange={[Function]}
@@ -263,9 +269,11 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
           type="button"
         >
           <div
+            aria-controls="undefined__menu"
             aria-expanded={true}
             aria-haspopup={true}
             aria-label="close menu"
+            aria-owns="undefined__menu"
             className="bx--list-box__field"
             data-toggle={true}
             disabled={false}
@@ -278,7 +286,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-6-input"
+              htmlFor="test-dropdown-input"
             >
               input
             </span>
@@ -347,7 +355,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             className="bx--list-box__menu"
           >
             <ListBoxMenuItem
-              id="downshift-6-item-0"
+              id="test-dropdown-item-0"
               isActive={false}
               isHighlighted={false}
               key="Item 0"
@@ -357,7 +365,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-6-item-0"
+                id="test-dropdown-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -394,7 +402,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-6-item-1"
+              id="test-dropdown-item-1"
               isActive={false}
               isHighlighted={false}
               key="Item 1"
@@ -404,7 +412,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-6-item-1"
+                id="test-dropdown-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -441,7 +449,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-6-item-2"
+              id="test-dropdown-item-2"
               isActive={false}
               isHighlighted={false}
               key="Item 2"
@@ -451,7 +459,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-6-item-2"
+                id="test-dropdown-item-2"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -488,7 +496,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-6-item-3"
+              id="test-dropdown-item-3"
               isActive={false}
               isHighlighted={false}
               key="Item 3"
@@ -498,7 +506,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-6-item-3"
+                id="test-dropdown-item-3"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -535,7 +543,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-6-item-4"
+              id="test-dropdown-item-4"
               isActive={false}
               isHighlighted={false}
               key="Item 4"
@@ -545,7 +553,7 @@ exports[`DropdownV2 should render DropdownItem components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-6-item-4"
+                id="test-dropdown-item-4"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -593,6 +601,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
 <DropdownV2
   disabled={false}
   helperText=""
+  id="test-dropdown"
   itemToElement={[Function]}
   itemToString={[Function]}
   items={
@@ -639,6 +648,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
     defaultSelectedItem={null}
     environment={[Window]}
     getA11yStatusMessage={[Function]}
+    id="test-dropdown"
     itemToString={[Function]}
     onChange={[Function]}
     onInputValueChange={[Function]}
@@ -678,9 +688,11 @@ exports[`DropdownV2 should render custom item components 1`] = `
           type="button"
         >
           <div
+            aria-controls="undefined__menu"
             aria-expanded={true}
             aria-haspopup={true}
             aria-label="close menu"
+            aria-owns="undefined__menu"
             className="bx--list-box__field"
             data-toggle={true}
             disabled={false}
@@ -693,7 +705,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-5-input"
+              htmlFor="test-dropdown-input"
             >
               input
             </span>
@@ -762,7 +774,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             className="bx--list-box__menu"
           >
             <ListBoxMenuItem
-              id="downshift-5-item-0"
+              id="test-dropdown-item-0"
               isActive={false}
               isHighlighted={false}
               key="Item 0"
@@ -772,7 +784,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-5-item-0"
+                id="test-dropdown-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -792,7 +804,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-5-item-1"
+              id="test-dropdown-item-1"
               isActive={false}
               isHighlighted={false}
               key="Item 1"
@@ -802,7 +814,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-5-item-1"
+                id="test-dropdown-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -822,7 +834,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-5-item-2"
+              id="test-dropdown-item-2"
               isActive={false}
               isHighlighted={false}
               key="Item 2"
@@ -832,7 +844,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-5-item-2"
+                id="test-dropdown-item-2"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -852,7 +864,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-5-item-3"
+              id="test-dropdown-item-3"
               isActive={false}
               isHighlighted={false}
               key="Item 3"
@@ -862,7 +874,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-5-item-3"
+                id="test-dropdown-item-3"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -882,7 +894,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-5-item-4"
+              id="test-dropdown-item-4"
               isActive={false}
               isHighlighted={false}
               key="Item 4"
@@ -892,7 +904,7 @@ exports[`DropdownV2 should render custom item components 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-5-item-4"
+                id="test-dropdown-item-4"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -923,6 +935,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
 <DropdownV2
   disabled={false}
   helperText=""
+  id="test-dropdown"
   itemToElement={null}
   itemToString={[Function]}
   items={
@@ -946,6 +959,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
     defaultSelectedItem={null}
     environment={[Window]}
     getA11yStatusMessage={[Function]}
+    id="test-dropdown"
     itemToString={[Function]}
     onChange={[Function]}
     onInputValueChange={[Function]}
@@ -985,9 +999,11 @@ exports[`DropdownV2 should render with strings as items 1`] = `
           type="button"
         >
           <div
+            aria-controls="undefined__menu"
             aria-expanded={true}
             aria-haspopup={true}
             aria-label="close menu"
+            aria-owns="undefined__menu"
             className="bx--list-box__field"
             data-toggle={true}
             disabled={false}
@@ -1000,7 +1016,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-4-input"
+              htmlFor="test-dropdown-input"
             >
               input
             </span>
@@ -1069,7 +1085,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
             className="bx--list-box__menu"
           >
             <ListBoxMenuItem
-              id="downshift-4-item-0"
+              id="test-dropdown-item-0"
               isActive={false}
               isHighlighted={false}
               key="zar"
@@ -1079,7 +1095,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-4-item-0"
+                id="test-dropdown-item-0"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}
@@ -1088,7 +1104,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
               </div>
             </ListBoxMenuItem>
             <ListBoxMenuItem
-              id="downshift-4-item-1"
+              id="test-dropdown-item-1"
               isActive={false}
               isHighlighted={false}
               key="doz"
@@ -1098,7 +1114,7 @@ exports[`DropdownV2 should render with strings as items 1`] = `
             >
               <div
                 className="bx--list-box__menu-item"
-                id="downshift-4-item-1"
+                id="test-dropdown-item-1"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseMove={[Function]}

--- a/src/components/ListBox/ListBoxField.js
+++ b/src/components/ListBox/ListBoxField.js
@@ -18,12 +18,15 @@ const { prefix } = settings;
  * elements inside of a field. It also provides a11y-related attributes like
  * `role` to make sure a user can focus the given field.
  */
-const ListBoxField = ({ children, ...rest }) => (
+const ListBoxField = ({ children, id, ...rest }) => (
   <div
     role="button"
     className={`${prefix}--list-box__field`}
     tabIndex="0"
-    {...rest}>
+    {...rest}
+    aria-expanded={rest['aria-expanded']}
+    aria-owns={(rest['aria-expanded'] && `${id}__menu`) || null}
+    aria-controls={(rest['aria-expanded'] && `${id}__menu`) || null}>
     {children}
   </div>
 );

--- a/src/components/ListBox/__tests__/ListBoxField-test.js
+++ b/src/components/ListBox/__tests__/ListBoxField-test.js
@@ -27,4 +27,19 @@ describe('ListBoxField', () => {
     );
     expect(wrapper.children().prop('tabIndex')).toBe('0');
   });
+
+  it('should set `aria-owns` based when expanded', () => {
+    const wrapper = mount(
+      <ListBox.Field id="test-listbox" aria-expanded>
+        <ListBox.Selection clearSelection={jest.fn()} />
+      </ListBox.Field>
+    );
+    expect(wrapper.find('div[aria-expanded]').props()['aria-owns']).toBe(
+      'test-listbox__menu'
+    );
+    expect(wrapper.find('div[aria-expanded]').props()['aria-controls']).toBe(
+      'test-listbox__menu'
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -42,6 +42,8 @@ exports[`ListBox should render 1`] = `
   >
     <ListBoxField>
       <div
+        aria-controls={null}
+        aria-owns={null}
         className="bx--list-box__field"
         role="button"
         tabIndex="0"

--- a/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
+++ b/src/components/ListBox/__tests__/__snapshots__/ListBoxField-test.js.snap
@@ -3,6 +3,88 @@
 exports[`ListBoxField should render 1`] = `
 <ListBoxField>
   <div
+    aria-controls={null}
+    aria-owns={null}
+    className="bx--list-box__field"
+    role="button"
+    tabIndex="0"
+  >
+    <ListBoxSelection
+      clearSelection={[MockFunction]}
+      translateWithId={[Function]}
+    >
+      <div
+        className="bx--list-box__selection"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex="0"
+        title="Clear selected item"
+      >
+        <Icon
+          description="Clear selected item"
+          fillRule="evenodd"
+          focusable="false"
+          icon={
+            Object {
+              "height": "10",
+              "id": "icon--close",
+              "name": "icon--close",
+              "styles": "",
+              "svgData": Object {
+                "circles": "",
+                "ellipses": "",
+                "paths": Array [
+                  Object {
+                    "d": "M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z",
+                    "fill-rule": "nonzero",
+                  },
+                ],
+                "polygons": "",
+                "polylines": "",
+                "rects": "",
+              },
+              "tags": "icon--close",
+              "viewBox": "0 0 10 10",
+              "width": "10",
+            }
+          }
+          role="img"
+        >
+          <svg
+            alt="Clear selected item"
+            aria-label="Clear selected item"
+            fillRule="evenodd"
+            focusable="false"
+            height="10"
+            role="img"
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <title>
+              Clear selected item
+            </title>
+            <path
+              d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+              key="key0"
+            />
+          </svg>
+        </Icon>
+      </div>
+    </ListBoxSelection>
+  </div>
+</ListBoxField>
+`;
+
+exports[`ListBoxField should set \`aria-owns\` based when expanded 1`] = `
+<ListBoxField
+  aria-expanded={true}
+  id="test-listbox"
+>
+  <div
+    aria-controls="test-listbox__menu"
+    aria-expanded={true}
+    aria-owns="test-listbox__menu"
     className="bx--list-box__field"
     role="button"
     tabIndex="0"

--- a/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -100,9 +100,11 @@ exports[`MultiSelect.Filterable should render 1`] = `
             type="button"
           >
             <div
+              aria-controls={null}
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="open menu"
+              aria-owns={null}
               className="bx--list-box__field"
               data-toggle={true}
               disabled={false}

--- a/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -99,9 +99,11 @@ exports[`MultiSelect should render 1`] = `
             type="button"
           >
             <div
+              aria-controls={null}
               aria-expanded={false}
               aria-haspopup={true}
               aria-label="open menu"
+              aria-owns={null}
               className="bx--list-box__field"
               data-toggle={true}
               disabled={false}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3481

This PR addresses a couple of DAP violations in the listbox components

#### Changelog

**Changed**

- add `aria-owns` and `aria-controls` attributes only when the referenced element is rendered

#### Testing / Reviewing

Ensure the listbox components pass a11y testing
