### PR TITLE
fix(SelectableTile): remove console warnings

### DIFF
--- a/src/components/Tile/Tile-story.js
+++ b/src/components/Tile/Tile-story.js
@@ -131,25 +131,13 @@ storiesOf('Tile', module)
           defaultSelected="default-selected"
           legend="Selectable Tile Group"
           {...props.group()}>
-          <RadioTile
-            value="standard"
-            id="tile-1"
-            labelText="Selectable Tile"
-            {...radioProps}>
+          <RadioTile value="standard" id="tile-1" {...radioProps}>
             Selectable Tile
           </RadioTile>
-          <RadioTile
-            value="default-selected"
-            labelText="Default selected tile"
-            id="tile-2"
-            {...radioProps}>
+          <RadioTile value="default-selected" id="tile-2" {...radioProps}>
             Selectable Tile
           </RadioTile>
-          <RadioTile
-            value="selected"
-            labelText="Selectable Tile"
-            id="tile-3"
-            {...radioProps}>
+          <RadioTile value="selected" id="tile-3" {...radioProps}>
             Selectable Tile
           </RadioTile>
         </TileGroup>

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -185,6 +185,11 @@ export class SelectableTile extends Component {
     title: PropTypes.string,
 
     /**
+     * Provide an optional hook that is called each time the input is updated
+     */
+    onChange: PropTypes.func,
+
+    /**
      * The description of the checkmark icon.
      */
     iconDescription: PropTypes.string,
@@ -202,6 +207,7 @@ export class SelectableTile extends Component {
     selected: false,
     handleClick: () => {},
     handleKeyDown: () => {},
+    onChange: () => {},
     tabIndex: 0,
   };
 
@@ -260,6 +266,7 @@ export class SelectableTile extends Component {
       className,
       handleClick, // eslint-disable-line
       handleKeyDown, // eslint-disable-line
+      onChange,
       ...other
     } = this.props;
 
@@ -286,6 +293,7 @@ export class SelectableTile extends Component {
           name={name}
           title={title}
           checked={this.state.selected}
+          onChange={onChange}
         />
         <label
           htmlFor={id}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3537

ref: https://github.com/carbon-design-system/carbon/issues/2959 https://github.com/carbon-design-system/carbon/pull/3431

This PR removes console warnings created by invalid props and invalid prop types in the `<SelectableTile>`

#### Testing/Reviewing

Ensure no console errors are emitted when viewing the component