### PR TITLE
fix(Tile): persist event object

### DIFF
--- a/src/components/Tile/Tile-test.js
+++ b/src/components/Tile/Tile-test.js
@@ -65,21 +65,21 @@ describe('Tile', () => {
 
     it('toggles the clickable class on click', () => {
       expect(wrapper.hasClass('bx--tile--is-clicked')).toEqual(false);
-      wrapper.simulate('click');
+      wrapper.simulate('click', { persist: () => {} });
       expect(wrapper.hasClass('bx--tile--is-clicked')).toEqual(true);
     });
 
     it('toggles the clickable state on click', () => {
       expect(wrapper.state().clicked).toEqual(false);
-      wrapper.simulate('click');
+      wrapper.simulate('click', { persist: () => {} });
       expect(wrapper.state().clicked).toEqual(true);
     });
 
     it('toggles the clicked state when using enter or space', () => {
       expect(wrapper.state().clicked).toEqual(false);
-      wrapper.simulate('keydown', { which: 32 });
+      wrapper.simulate('keydown', { which: 32, persist: () => {} });
       expect(wrapper.state().clicked).toEqual(true);
-      wrapper.simulate('keydown', { which: 13 });
+      wrapper.simulate('keydown', { which: 13, persist: () => {} });
       expect(wrapper.state().clicked).toEqual(false);
     });
 

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -75,6 +75,7 @@ export class ClickableTile extends Component {
   };
 
   handleClick = evt => {
+    evt.persist();
     this.setState(
       {
         clicked: !this.state.clicked,
@@ -86,6 +87,7 @@ export class ClickableTile extends Component {
   };
 
   handleKeyDown = evt => {
+    evt.persist();
     if (matches(evt, [keys.ENTER, keys.SPACE])) {
       this.setState(
         {
@@ -212,6 +214,7 @@ export class SelectableTile extends Component {
   };
 
   handleClick = evt => {
+    evt.persist();
     evt.preventDefault();
     const isInput = evt.target === this.input;
     if (!isInput) {
@@ -229,6 +232,7 @@ export class SelectableTile extends Component {
   };
 
   handleKeyDown = evt => {
+    evt.persist();
     if (matches(evt, [keys.ENTER, keys.SPACE])) {
       evt.preventDefault();
       this.setState(
@@ -416,6 +420,7 @@ export class ExpandableTile extends Component {
     });
 
   handleClick = evt => {
+    evt.persist();
     this.setState(
       {
         expanded: !this.state.expanded,


### PR DESCRIPTION
closes https://github.com/carbon-design-system/carbon/issues/3829

add `persist` to persist the event object so it can be used in async.

#### Changelog
#### Changed

- added `persist()` on event.

Testing / Reviewing
make sure we can see the event properties in the handlerKeyDown and handlerClick props on the component