### PR TITLE
feat(MultiSelect): pass through  translations (cherry-pick from v7)

### DIFF
--- a/src/components/MultiSelect/MultiSelect-story.js
+++ b/src/components/MultiSelect/MultiSelect-story.js
@@ -58,6 +58,8 @@ const props = () => ({
     {
       'close.menu': 'Close menu',
       'open.menu': 'Open menu',
+      'clear.all': 'Clear all',
+      'clear.selection': 'Clear selection',
     }
   ),
 });

--- a/src/components/MultiSelect/MultiSelect.js
+++ b/src/components/MultiSelect/MultiSelect.js
@@ -240,6 +240,7 @@ export default class MultiSelect extends React.Component {
                     <ListBox.Selection
                       clearSelection={!disabled ? clearSelection : noop}
                       selectionCount={selectedItem.length}
+                      translateWithId={translateWithId}
                     />
                   )}
                   <span className={`${prefix}--list-box__label`}>{label}</span>


### PR DESCRIPTION
Porting over this change from v7.X over to 6.X [3395](https://github.com/carbon-design-system/carbon/pull/3395) which closed [#3393](https://github.com/carbon-design-system/carbon/issues/3393)

This **PR** passes ```translateWithId``` through to the nested ```<ListBox.Selection>``` in MultiSelect components

**Testing / Reviewing**

Ensure that translations are working correctly for the <ListBox.Selection> title