### PR TITLE
fix(AccordionItem): fix NPE thrown by key.match

### DIFF
--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -96,7 +96,7 @@ export default class AccordionItem extends Component {
 
   handleKeyDown = evt => {
     if (
-      match(evt.which, keys.ESC) &&
+      match(evt, keys.ESC) &&
       this.state.open &&
       evt.target.classList.contains(`${prefix}--accordion__heading`)
     ) {

--- a/src/components/AccordionItem/AccordionItem.js
+++ b/src/components/AccordionItem/AccordionItem.js
@@ -96,7 +96,7 @@ export default class AccordionItem extends Component {
 
   handleKeyDown = evt => {
     if (
-      match(evt, keys.ESC) &&
+      match(evt.which, keys.ESC) &&
       this.state.open &&
       evt.target.classList.contains(`${prefix}--accordion__heading`)
     ) {

--- a/src/tools/key.js
+++ b/src/tools/key.js
@@ -60,7 +60,7 @@ export function matches(event, keysToMatch) {
  * @returns {boolean}
  */
 export function match(eventOrCode, key) {
-  return eventOrCode.which === key || eventOrCode === key;
+  return (eventOrCode && eventOrCode.which === key) || eventOrCode === key;
 }
 
 /**


### PR DESCRIPTION
In `AccordionItem`, it is calling the `key.match` utility with wrong parameters. Based on the example given in https://github.com/carbon-design-system/carbon-components-react/blob/master/src/tools/key.js#L72, it should pass the entire `evt` object instead. This is now causing an NPE thrown.

```
Uncaught TypeError: Cannot read property 'which' of undefined
    at match (key.js?13e0:63)
    at eval (AccordionItem.js?33e3:86)
    at HTMLUnknownElement.callCallback (react-dom.development.js?61bb:347)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?61bb:397)
    at invokeGuardedCallback (react-dom.development.js?61bb:454)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js?61bb:468)
    at executeDispatch (react-dom.development.js?61bb:600)
    at executeDispatchesInOrder (react-dom.development.js?61bb:619)
    at executeDispatchesAndRelease (react-dom.development.js?61bb:725)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js?61bb:733)
    at forEachAccumulated (react-dom.development.js?61bb:707)
    at runEventsInBatch (react-dom.development.js?61bb:750)
    at runExtractedPluginEventsInBatch (react-dom.development.js?61bb:881)
    at handleTopLevel (react-dom.development.js?61bb:5901)
    at batchedEventUpdates (react-dom.development.js?61bb:2344)
    at dispatchEventForPluginEventSystem (react-dom.development.js?61bb:5996)
```