### PR TITLE
fix(Loading): use description prop as SVG title

### DIFF
--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -28,7 +28,7 @@ export default class InlineLoading extends React.Component {
     /**
      * Specify the description for the inline loading text
      */
-    description: PropTypes.string,
+    description: PropTypes.node,
 
     /**
      * Specify a description that would be used for the loading state SVG title
@@ -92,7 +92,7 @@ export default class InlineLoading extends React.Component {
     };
 
     const loadingText = (
-      <p className={`${prefix}--inline-loading__text`}>{description}</p>
+      <div className={`${prefix}--inline-loading__text`}>{description}</div>
     );
 
     return (

--- a/src/components/InlineLoading/InlineLoading.js
+++ b/src/components/InlineLoading/InlineLoading.js
@@ -31,6 +31,11 @@ export default class InlineLoading extends React.Component {
     description: PropTypes.string,
 
     /**
+     * Specify a description that would be used for the loading state SVG title
+     */
+    iconDescription: PropTypes.string,
+
+    /**
      * Provide an optional handler to be inovked when <InlineLoading> is
      * successful
      */
@@ -51,6 +56,7 @@ export default class InlineLoading extends React.Component {
     const {
       className,
       success,
+      iconDescription,
       description,
       onSuccess,
       successDelay,
@@ -80,7 +86,9 @@ export default class InlineLoading extends React.Component {
         );
       }
 
-      return <Loading small withOverlay={false} />;
+      return (
+        <Loading small description={iconDescription} withOverlay={false} />
+      );
     };
 
     const loadingText = (

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -34,16 +34,30 @@ export default class Loading extends React.Component {
      * Specify whether you would like the small variant of <Loading>
      */
     small: PropTypes.bool,
+
+    /**
+     * Specify a description that would be used to describe the loading state
+     * svg title
+     */
+    description: PropTypes.string,
   };
 
   static defaultProps = {
     active: true,
     withOverlay: true,
     small: false,
+    description: 'Active loading indicator',
   };
 
   render() {
-    const { active, className, withOverlay, small, ...other } = this.props;
+    const {
+      active,
+      className,
+      withOverlay,
+      small,
+      description,
+      ...other
+    } = this.props;
 
     const loadingClasses = classNames(`${prefix}--loading`, className, {
       [`${prefix}--loading--small`]: small,
@@ -60,7 +74,7 @@ export default class Loading extends React.Component {
         aria-live={active ? 'assertive' : 'off'}
         className={loadingClasses}>
         <svg className={`${prefix}--loading__svg`} viewBox="-75 -75 150 150">
-          <title>Loading</title>
+          <title>{description}</title>
           {componentsX && small ? (
             <circle
               className={`${prefix}--loading__background`}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/4194 (backport of https://github.com/carbon-design-system/carbon/pull/2955)

This PR passes the `description` prop to the `<Loading>` component SVG title

#### Testing / Reviewing

Ensure the SVG title reflects the `iconDescription` prop in `<InlineLoading>` and the `description` prop in `<Loading>`
