### PR TITLE
fix(Tooltip): Prevent unnecessary setState calls

### DIFF
--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -366,7 +366,7 @@ class Tooltip extends Component {
       evt.target &&
       this._tooltipEl &&
       this._tooltipEl.contains(evt.target);
-    if (!shouldPreventClose) {
+    if (!shouldPreventClose && this.state.open) {
       this.setState({ open: false });
     }
   };


### PR DESCRIPTION
This PR prevents the `handleClickOutside` from calling `setState` if the ToolTip is already closed.

The reason for this check is that, at scale, these calls create _**real**_ performance issues. 

Our app has over 1,000 `<Tooltip>`s. Each of these `Tooltip`s calls `setState({open: false})`. These unnecessary calls to `setState` makes toggling radio buttons and opening Modals very, very slow. Up to two seconds in some cases in our UI. After adding this check the UI behaves normally.

Performance screenshot below.

<img width="623" alt="Screen Shot 2019-12-06 at 11 02 21 AM" src="https://user-images.githubusercontent.com/141877/70341230-193e0c80-1818-11ea-8219-658bfa606267.png">
